### PR TITLE
feat: add support for yaml fragment templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,42 @@ include:
 
 ---
 
+## 📝 Template Header Spec (Optional Context)
+
+To provide consistent context in the Component Browser, you can add **spec-compliant header comments** at the top of a template file. Only these keys are displayed; all other comments are ignored.
+
+**Supported keys (must be at top of file):**
+- `summary`
+- `usage`
+- `note`
+
+**Full format:**
+```yaml
+# @gitlab-component-helper: summary: Push a Helm chart to Sonic
+# @gitlab-component-helper: usage: include + set SONIC_TARGET_* variables
+# @gitlab-component-helper: note: Requires a protected ref for publish
+```
+
+**Short format:**
+```yaml
+# @gch: summary: Push a Helm chart to Sonic
+# @gch: usage: include + set SONIC_TARGET_* variables
+# @gch: note: Requires a protected ref for publish
+```
+
+Notes:
+- Header comments must appear **before any non-comment content**.
+- Multiple `note` entries are supported.
+- If no header is present, the Context section stays hidden.
+
+---
+
+## 📄 Raw YAML Toggle
+
+Component details include a **Raw YAML** toggle so you can inspect the original template when needed. This is available regardless of whether header comments are present.
+
+---
+
 ## ⚙️ Configuration
 
 Add your favorite sources in VS Code settings:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1673,7 +1673,6 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -1990,7 +1989,6 @@
       "integrity": "sha512-DZ8VwRFUNzuqJ5khrvwMXHmvPe+zGayJhr2CDNiKB1WBE1ST8Djl00D0IC4vvNmHMdj6DlbYRIaFE7WHjlDl5w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2051,7 +2049,6 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -2273,7 +2270,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3541,7 +3537,6 @@
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -4343,7 +4338,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8689,7 +8683,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nodeutils/defaults-deep": "1.1.0",
         "@octokit/rest": "22.0.1",
@@ -9797,7 +9790,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9968,7 +9960,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/providers/componentBrowserProvider.ts
+++ b/src/providers/componentBrowserProvider.ts
@@ -428,7 +428,7 @@ export class ComponentBrowserProvider {
     return this.insertComponent(component, includeInputs, selectedInputs);
   }
 
-  private async showComponentDetails(component: any) {
+  public async showComponentDetails(component: any) {
     // Create a new webview panel for component details
     const detailsPanel = vscode.window.createWebviewPanel(
       'gitlabComponentDetails',
@@ -458,12 +458,32 @@ export class ComponentBrowserProvider {
               version
             );
             if (updatedComponent) {
-              await this.insertComponent(updatedComponent, includeInputs, selectedInputs);
+              if (component._hoverContext) {
+                await this.editExistingComponentFromDetached(
+                  updatedComponent,
+                  component._hoverContext.documentUri,
+                  component._hoverContext.position,
+                  includeInputs || false,
+                  selectedInputs || []
+                );
+              } else {
+                await this.insertComponent(updatedComponent, includeInputs, selectedInputs);
+              }
             } else {
               vscode.window.showErrorMessage(`Failed to fetch version ${version} of component ${component.name}`);
             }
           } else {
-            await this.insertComponent(component, includeInputs, selectedInputs);
+            if (component._hoverContext) {
+              await this.editExistingComponentFromDetached(
+                component,
+                component._hoverContext.documentUri,
+                component._hoverContext.position,
+                includeInputs || false,
+                selectedInputs || []
+              );
+            } else {
+              await this.insertComponent(component, includeInputs, selectedInputs);
+            }
           }
         } else if (message.command === 'fetchVersions') {
           // Fetch available versions for the component
@@ -1289,7 +1309,7 @@ export class ComponentBrowserProvider {
     `;
   }
 
-  private getComponentDetailsHtml(component: any): string {
+  public getComponentDetailsHtml(component: any): string {
     const parameters = component.parameters || [];
     const availableVersions = component.availableVersions || [component.version || 'main'];
     const headerSummary = component.summary;

--- a/src/providers/componentBrowserProvider.ts
+++ b/src/providers/componentBrowserProvider.ts
@@ -202,6 +202,10 @@ export class ComponentBrowserProvider {
               const components = catalogData.components.map((c: GitLabCatalogComponent) => ({
                 name: c.name,
                 description: c.description || `Component from ${contextPath}`,
+                summary: c.summary,
+                usage: c.usage,
+                notes: c.notes,
+                rawYaml: c.rawYaml,
                 parameters: (c.variables || []).map((v: GitLabCatalogVariable) => ({
                   name: v.name,
                   description: v.description || `Parameter: ${v.name}`,
@@ -1093,7 +1097,8 @@ export class ComponentBrowserProvider {
               const component = {
                 ...componentData[version],
                 name: componentName,
-                version: version
+                version: version,
+                templateFileUrl: buildTemplateFileUrl(componentData[version], componentName, version)
               };
               vscode.postMessage({ command: 'viewComponentDetails', component });
             }
@@ -1111,6 +1116,14 @@ export class ComponentBrowserProvider {
               };
               vscode.postMessage({ command: 'insertComponent', component });
             }
+          }
+
+          function buildTemplateFileUrl(versionData, componentName, version) {
+            if (!versionData || !versionData.sourcePath || !versionData.gitlabInstance) {
+              return '';
+            }
+            const ref = version || 'main';
+            return 'https://' + versionData.gitlabInstance + '/' + versionData.sourcePath + '/-/blob/' + ref + '/templates/' + componentName + '.yml';
           }
 
           function filterComponents() {
@@ -1279,6 +1292,13 @@ export class ComponentBrowserProvider {
   private getComponentDetailsHtml(component: any): string {
     const parameters = component.parameters || [];
     const availableVersions = component.availableVersions || [component.version || 'main'];
+    const headerSummary = component.summary;
+    const headerUsage = component.usage;
+    const headerNotes = Array.isArray(component.notes) ? component.notes : [];
+    const hasContext = Boolean(headerSummary || headerUsage || headerNotes.length > 0);
+    const rawYaml = component.rawYaml || '';
+    const hasRawYaml = Boolean(rawYaml);
+    const templateFileUrl = this.buildTemplateFileUrl(component);
 
     return `
       <!DOCTYPE html>
@@ -1421,6 +1441,14 @@ export class ComponentBrowserProvider {
           button.secondary:hover {
             background-color: var(--vscode-button-secondaryHoverBackground);
           }
+          #rawYamlContent {
+            white-space: pre;
+            overflow-x: auto;
+            background-color: var(--vscode-textCodeBlock-background);
+            padding: 10px;
+            border-radius: 5px;
+            border: 1px solid var(--vscode-panel-border);
+          }
         </style>
       </head>
       <body>
@@ -1428,6 +1456,30 @@ export class ComponentBrowserProvider {
 
         <div class="description" id="componentDescription">
           ${component.description}
+        </div>
+
+        <div class="metadata" id="componentContext" style="display: ${hasContext ? 'block' : 'none'};">
+          <div><strong>Context</strong></div>
+          <div id="componentSummaryRow" style="display: ${headerSummary ? 'block' : 'none'};">
+            <strong>Summary:</strong> <span id="componentSummary">${headerSummary || ''}</span>
+          </div>
+          <div id="componentUsageRow" style="display: ${headerUsage ? 'block' : 'none'};">
+            <strong>Usage:</strong> <span id="componentUsage">${headerUsage || ''}</span>
+          </div>
+          <div id="componentNotesRow" style="display: ${headerNotes.length > 0 ? 'block' : 'none'};">
+            <strong>Notes:</strong>
+            <ul id="componentNotes">
+              ${headerNotes.map((note: string) => '<li>' + note + '</li>').join('')}
+            </ul>
+          </div>
+        </div>
+
+        <div class="metadata" id="rawYamlSection" style="display: ${hasRawYaml ? 'block' : 'none'};">
+          <div class="parameters-header" style="margin-bottom: 5px;">
+            <h2 style="margin: 0;">Raw YAML</h2>
+            <button class="secondary" id="toggleRawYaml" onclick="toggleRawYaml()">Show</button>
+          </div>
+          <pre id="rawYamlContent" style="display: none;">${this.escapeHtml(rawYaml)}</pre>
         </div>
 
         <div class="metadata">
@@ -1446,6 +1498,8 @@ export class ComponentBrowserProvider {
             `<div><strong>Project URL:</strong> <a href="${component.documentationUrl}" target="_blank" id="componentDocUrl">${component.documentationUrl}</a></div>` : ''}
           ${component.url ?
             `<div><strong>Component URL:</strong> <a href="${component.url}" target="_blank" id="componentUrl">${component.url}</a></div>` : ''}
+          ${templateFileUrl ?
+            `<div><strong>Template File:</strong> <a href="${templateFileUrl}" target="_blank" id="templateFileUrl">${templateFileUrl}</a></div>` : ''}
         </div>
 
         <div class="parameters-header">
@@ -1584,6 +1638,24 @@ export class ComponentBrowserProvider {
             vscode.postMessage({ command: 'fetchVersions' });
           }
 
+          function toggleRawYaml() {
+            const rawContent = document.getElementById('rawYamlContent');
+            const toggleButton = document.getElementById('toggleRawYaml');
+            if (!rawContent || !toggleButton) return;
+
+            const isHidden = rawContent.style.display === 'none';
+            rawContent.style.display = isHidden ? 'block' : 'none';
+            toggleButton.textContent = isHidden ? 'Hide' : 'Show';
+          }
+
+          function buildTemplateFileUrlFromComponent(component) {
+            if (!component || !component.gitlabInstance || !component.sourcePath || !component.name) {
+              return '';
+            }
+            const ref = component.version || 'main';
+            return 'https://' + component.gitlabInstance + '/' + component.sourcePath + '/-/blob/' + ref + '/templates/' + component.name + '.yml';
+          }
+
           function updateComponentDetails(component) {
             console.log('Updating component details:', component);
 
@@ -1592,6 +1664,57 @@ export class ComponentBrowserProvider {
 
             // Update description
             document.getElementById('componentDescription').textContent = component.description || 'No description available';
+
+            // Update context section (summary/usage/notes) from spec-compliant header comments
+            const contextContainer = document.getElementById('componentContext');
+            const summaryRow = document.getElementById('componentSummaryRow');
+            const usageRow = document.getElementById('componentUsageRow');
+            const notesRow = document.getElementById('componentNotesRow');
+            const summary = component.summary || '';
+            const usage = component.usage || '';
+            const notes = Array.isArray(component.notes) ? component.notes : [];
+            const hasContext = summary || usage || notes.length > 0;
+
+            if (contextContainer) {
+              contextContainer.style.display = hasContext ? 'block' : 'none';
+            }
+
+            if (summaryRow) {
+              summaryRow.style.display = summary ? 'block' : 'none';
+              const summaryEl = document.getElementById('componentSummary');
+              if (summaryEl) summaryEl.textContent = summary;
+            }
+
+            if (usageRow) {
+              usageRow.style.display = usage ? 'block' : 'none';
+              const usageEl = document.getElementById('componentUsage');
+              if (usageEl) usageEl.textContent = usage;
+            }
+
+            if (notesRow) {
+              notesRow.style.display = notes.length > 0 ? 'block' : 'none';
+              const notesEl = document.getElementById('componentNotes');
+              if (notesEl) {
+                notesEl.innerHTML = notes.map(note => '<li>' + note + '</li>').join('');
+              }
+            }
+
+            // Update raw YAML section
+            const rawYamlSection = document.getElementById('rawYamlSection');
+            const rawYamlContent = document.getElementById('rawYamlContent');
+            const rawYamlToggle = document.getElementById('toggleRawYaml');
+            const rawYaml = component.rawYaml || '';
+            const hasRawYaml = rawYaml.length > 0;
+            if (rawYamlSection) {
+              rawYamlSection.style.display = hasRawYaml ? 'block' : 'none';
+            }
+            if (rawYamlContent) {
+              rawYamlContent.textContent = rawYaml;
+              rawYamlContent.style.display = 'none';
+            }
+            if (rawYamlToggle) {
+              rawYamlToggle.textContent = 'Show';
+            }
 
             // Update source if available
             if (component.source) {
@@ -1615,6 +1738,19 @@ export class ComponentBrowserProvider {
             if (component.url && componentUrlElement) {
               componentUrlElement.href = component.url;
               componentUrlElement.textContent = component.url;
+            }
+
+            // Update template file URL
+            const templateFileUrlElement = document.getElementById('templateFileUrl');
+            if (templateFileUrlElement) {
+              const computedTemplateUrl = component.templateFileUrl || buildTemplateFileUrlFromComponent(component);
+              if (computedTemplateUrl) {
+                templateFileUrlElement.href = computedTemplateUrl;
+                templateFileUrlElement.textContent = computedTemplateUrl;
+                templateFileUrlElement.style.display = 'inline';
+              } else {
+                templateFileUrlElement.style.display = 'none';
+              }
             }
 
             // Update parameters
@@ -1731,6 +1867,23 @@ export class ComponentBrowserProvider {
       </body>
       </html>
     `;
+  }
+
+  private escapeHtml(value: string): string {
+    return value
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  private buildTemplateFileUrl(component: any): string | undefined {
+    if (!component || !component.gitlabInstance || !component.sourcePath || !component.name) {
+      return undefined;
+    }
+    const ref = component.version || 'main';
+    return `https://${component.gitlabInstance}/${component.sourcePath}/-/blob/${ref}/templates/${component.name}.yml`;
   }
 
   private getNoSourcesHtml(): string {
@@ -2041,6 +2194,10 @@ ${sourceErrors.size > 0 ? '\nErrors:\n' + Array.from(sourceErrors.entries()).map
         projectGroup.components.set(comp.name, {
           name: comp.name,
           description: comp.description || 'No description available',
+          summary: comp.summary,
+          usage: comp.usage,
+          notes: comp.notes,
+          rawYaml: comp.rawYaml,
           parameters: comp.parameters || [],
           source: comp.source,
           sourcePath: comp.sourcePath,
@@ -2058,6 +2215,10 @@ ${sourceErrors.size > 0 ? '\nErrors:\n' + Array.from(sourceErrors.entries()).map
       componentGroup.versions.set(comp.version || 'latest', {
         version: comp.version || 'latest',
         description: comp.description || 'No description available',
+        summary: comp.summary,
+        usage: comp.usage,
+        notes: comp.notes,
+        rawYaml: comp.rawYaml,
         parameters: comp.parameters || [],
         documentationUrl: comp.url ? this.extractProjectUrl(comp.url) : '',
         source: comp.source,
@@ -2077,16 +2238,23 @@ ${sourceErrors.size > 0 ? '\nErrors:\n' + Array.from(sourceErrors.entries()).map
         ...project,
         components: Array.from(project.components.values()).map((component: any) => {
           // Determine the best default version using available versions if present
-          const availableVersions = component.availableVersions || [component.version || 'latest'];
-          const versions: any[] = availableVersions.filter(Boolean).map((version: string) => ({
-            version: version,
-            description: component.description || 'No description available',
-            parameters: component.parameters || [],
-            documentationUrl: component.url ? this.extractProjectUrl(component.url) : '',
-            source: component.source,
-            sourcePath: component.sourcePath,
-            gitlabInstance: component.gitlabInstance || 'gitlab.com'
-          }));
+          const availableVersions = component.availableVersions || Array.from(component.versions.keys());
+          const versions: any[] = availableVersions.filter(Boolean).map((version: string) => {
+            const versionData = component.versions.get(version) || {};
+            return {
+              version: version,
+              description: versionData.description || component.description || 'No description available',
+              summary: versionData.summary || component.summary,
+              usage: versionData.usage || component.usage,
+              notes: versionData.notes || component.notes,
+              rawYaml: versionData.rawYaml || component.rawYaml,
+              parameters: versionData.parameters || component.parameters || [],
+              documentationUrl: versionData.documentationUrl || component.documentationUrl || '',
+              source: versionData.source || component.source,
+              sourcePath: versionData.sourcePath || component.sourcePath,
+              gitlabInstance: versionData.gitlabInstance || component.gitlabInstance || 'gitlab.com'
+            };
+          });
 
           let defaultVersion = component.version || 'latest';
 

--- a/src/services/componentCacheManager.ts
+++ b/src/services/componentCacheManager.ts
@@ -5,6 +5,10 @@ import { Logger } from '../utils/logger';
 interface CachedComponent {
   name: string;
   description: string;
+  summary?: string;
+  usage?: string;
+  notes?: string[];
+  rawYaml?: string;
   parameters: Array<{
     name: string;
     description: string;
@@ -82,6 +86,10 @@ export class ComponentCacheManager {
   public addDynamicComponent(component: {
     name: string;
     description: string;
+    summary?: string;
+    usage?: string;
+    notes?: string[];
+    rawYaml?: string;
     parameters: Array<{
       name: string;
       description: string;
@@ -433,6 +441,10 @@ export class ComponentCacheManager {
       const cachedComponent: CachedComponent = {
         name: catalogComponent.name,
         description: catalogComponent.description || `Component from ${sourcePath}`,
+        summary: catalogComponent.summary,
+        usage: catalogComponent.usage,
+        notes: catalogComponent.notes,
+        rawYaml: catalogComponent.rawYaml,
         parameters: (catalogComponent.variables || []).map((v: any) => ({
           name: v.name,
           description: v.description || `Parameter: ${v.name}`,
@@ -481,6 +493,10 @@ export class ComponentCacheManager {
           return {
             name: c.name,
             description: c.description || `Component from ${sourceName}`,
+            summary: c.summary,
+            usage: c.usage,
+            notes: c.notes,
+            rawYaml: c.rawYaml,
             parameters: (c.variables || []).map((v: any) => ({
               name: v.name,
               description: v.description || `Parameter: ${v.name}`,

--- a/src/types/gitlab-catalog.ts
+++ b/src/types/gitlab-catalog.ts
@@ -1,6 +1,10 @@
 export interface GitLabCatalogComponent {
   name: string;
   description?: string;
+  summary?: string;
+  usage?: string;
+  notes?: string[];
+  rawYaml?: string;
   documentation_url?: string;
   latest_version?: string;
   variables?: GitLabCatalogVariable[];
@@ -25,6 +29,10 @@ export interface GitLabYamlFragment {
   name: string;
   fileName: string;
   description?: string;
+  summary?: string;
+  usage?: string;
+  notes?: string[];
+  rawYaml?: string;
   latest_version?: string;
   anchors: GitLabFragmentAnchor[];
 }

--- a/src/types/gitlab-catalog.ts
+++ b/src/types/gitlab-catalog.ts
@@ -14,6 +14,35 @@ export interface GitLabCatalogVariable {
   default?: any;
 }
 
+/**
+ * Represents a YAML fragment file containing reusable anchors
+ * These are files in templates/ that don't have a spec: section
+ * but contain YAML anchors (keys starting with '.') that can be
+ * extended via 'extends:' or included via 'local:'
+ */
+export interface GitLabYamlFragment {
+  type: 'fragment';
+  name: string;
+  fileName: string;
+  description?: string;
+  latest_version?: string;
+  anchors: GitLabFragmentAnchor[];
+}
+
+/**
+ * Represents a YAML anchor within a fragment file
+ */
+export interface GitLabFragmentAnchor {
+  /** Anchor name including the leading dot (e.g., '.common-script') */
+  name: string;
+  /** Description extracted from comment above the anchor */
+  description?: string;
+  /** Detected anchor type based on content analysis */
+  type: 'job' | 'variables' | 'before_script' | 'after_script' | 'rules' | 'generic';
+}
+
 export interface GitLabCatalogData {
   components: GitLabCatalogComponent[];
+  /** YAML fragments containing reusable anchors */
+  fragments?: GitLabYamlFragment[];
 }

--- a/tests/.gitlab-ci.yml
+++ b/tests/.gitlab-ci.yml
@@ -12,7 +12,7 @@ include:
     inputs:
       some_input: "value"
       some_other_input: "another_value"
-
+  - component: https://gitlab.phactory.beast-code.com/devsecops/ci-cd-components/after_scripts/memory-profiler@0.0.7
 # Test GitLab CI file
 stages:
   - test

--- a/tests/.gitlab-ci.yml
+++ b/tests/.gitlab-ci.yml
@@ -13,6 +13,7 @@ include:
       some_input: "value"
       some_other_input: "another_value"
   - component: https://gitlab.phactory.beast-code.com/devsecops/ci-cd-components/after_scripts/memory-profiler@0.0.7
+  - component: https://gitlab.phactory.beast-code.com/devsecops/ci-cd-components/after_scripts/mr-commenter@0.0.7
 # Test GitLab CI file
 stages:
   - test


### PR DESCRIPTION
fixes complex-component discovery and display.
adds raw yaml dropdown in details for fragment templates.
adds meta data standard for # @gitlab-component-helper: