### PR TITLE
ci(security): add Argus reusable hardening workflow

### DIFF
--- a/.github/workflows/security-hardening.yml
+++ b/.github/workflows/security-hardening.yml
@@ -1,0 +1,28 @@
+name: Security Hardening
+
+on:
+  pull_request:
+    branches: [beta, main]
+  push:
+    branches: [beta, main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+  pull-requests: write
+  checks: write
+
+jobs:
+  argus-hardening:
+    name: Argus Reusable Hardening
+    # Pinned to the commit for Argus v0.6.8 for supply-chain safety.
+    uses: huntridge-labs/argus/.github/workflows/reusable-security-hardening.yml@0e74137817fbf4be257f76a976c04b7f730de4dc
+    with:
+      scanners: codeql,gitleaks,osv,dependency-review
+      enable_code_security: true
+      allow_failure: true
+      severity_threshold: high
+      post_pr_comment: true
+    secrets: inherit

--- a/.github/workflows/security-hardening.yml
+++ b/.github/workflows/security-hardening.yml
@@ -11,8 +11,10 @@ permissions:
   contents: read
   security-events: write
   actions: read
+  packages: read
   pull-requests: write
   checks: write
+  id-token: write
 
 jobs:
   argus-hardening:


### PR DESCRIPTION
## Summary
- add dedicated Security Hardening workflow using Argus reusable pipeline
- pin Argus reusable workflow to immutable commit SHA (v0.6.8 commit)
- scope scanners for this TypeScript extension: codeql, gitleaks, osv, dependency-review
- keep initial rollout non-blocking (allow_failure: true)\n\n## Why
- shifts security checks earlier in PR/push flow
- improves supply-chain safety by avoiding floating workflow refs

## Notes
- targets beta/main on push and PR events
- can tighten severity gating after baseline results