### PR TITLE
chore(security): reduce OSV and CodeQL noise

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,5 @@
+[[PackageOverrides]]
+ecosystem = "npm"
+group = "dev"
+vulnerability.ignore = true
+reason = "Security reporting should focus on shipped product dependencies; dev-only npm packages are tracked separately."

--- a/src/providers/validationProvider.ts
+++ b/src/providers/validationProvider.ts
@@ -226,8 +226,8 @@ export class ValidationProvider implements vscode.CodeActionProvider {
                             this.logger.debug(`[ValidationProvider] Component not found or accessible: ${expandedUrl}`, 'ValidationProvider');
                             componentFetchFailed = true;
 
-                            // For testing purposes, create a mock component for example URLs
-                            if (expandedUrl.includes('gitlab.example.com') || expandedUrl.includes('my-group/my-component')) {
+                            // For testing purposes, create a mock component for known example URLs
+                            if (this.isExampleMockComponentUrl(expandedUrl)) {
                                 this.logger.debug(`[ValidationProvider] Creating mock component for testing: ${expandedUrl}`, 'ValidationProvider');
                                 component = {
                                     name: 'mock-component',
@@ -398,6 +398,18 @@ export class ValidationProvider implements vscode.CodeActionProvider {
 
         this.logger.debug(`[ValidationProvider] Created ${diagnostics.length} total diagnostics for ${document.fileName}`, 'ValidationProvider');
         this.diagnosticCollection.set(document.uri, diagnostics);
+    }
+
+    private isExampleMockComponentUrl(componentUrl: string): boolean {
+        try {
+            const parsed = new URL(componentUrl);
+            const isExampleHost = parsed.hostname === 'gitlab.example.com';
+            const hasExpectedPath = parsed.pathname.includes('/my-group/my-component');
+            return isExampleHost || hasExpectedPath;
+        } catch {
+            // Fallback for malformed input in tests.
+            return componentUrl.includes('my-group/my-component');
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- add repo-level OSV scanner config to ignore npm dev-group vulnerability findings
- keep OSV enabled in the Argus hardening pipeline while focusing results on shipped dependencies
- tighten validation provider example URL matching to avoid CodeQL substring-sanitization noise

## Why
- security reporting should emphasize product risk rather than dev-only npm dependencies
- CodeQL should report actionable issues, not test/example substring matches

## Notes
- uses root osv-scanner.toml auto-discovery for the repo package-lock.json
- leaves Argus workflow pinning and scanner set unchanged on beta except for OSV behavior via config