### PR TITLE
feat(discovery): configurable component discovery (schema + helpers)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 .DS_Store
 .env
 .venv
-.vscode
 env/
 venv/
 ENV/
@@ -33,7 +32,8 @@ node_modules
 .pylintrc
 
 # User Configs
-.vscode/
+.vscode/*
+!.vscode/launch.json
 .vscode-test
 out
 out-test

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,31 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}"
+      ],
+      "outFiles": [
+        "${workspaceFolder}/out/**/*.js"
+      ],
+      "preLaunchTask": "npm: compile"
+    },
+    {
+      "name": "Extension Tests",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}",
+        "--extensionTestsPath=${workspaceFolder}/out-test/suite/index"
+      ],
+      "outFiles": [
+        "${workspaceFolder}/out/**/*.js",
+        "${workspaceFolder}/out-test/**/*.js"
+      ],
+      "preLaunchTask": "npm: pretest:extension-host"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -158,9 +158,82 @@
                 "type": "string",
                 "default": "gitlab.com",
                 "description": "GitLab instance hostname"
+              },
+              "discovery": {
+                "type": "object",
+                "description": "Per-source discovery overrides (uses gitlabComponentHelper.discovery.* defaults if omitted)",
+                "properties": {
+                  "templateRoots": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Repository directories to scan for components"
+                  },
+                  "maxDepth": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 3,
+                    "description": "Subdirectory depth to recurse under each template root"
+                  },
+                  "filePatterns": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Filename globs (e.g. '*.yml'); path globs are not supported"
+                  },
+                  "templateFileNames": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Filenames recognised inside per-component subfolders (e.g. 'template.yml')"
+                  }
+                }
               }
             }
           }
+        },
+        "gitlabComponentHelper.discovery.templateRoots": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "templates"
+          ],
+          "description": "Repository directories scanned for components when cataloguing a source. Up to 5 entries.",
+          "maxItems": 5
+        },
+        "gitlabComponentHelper.discovery.maxDepth": {
+          "type": "number",
+          "default": 1,
+          "minimum": 0,
+          "maximum": 3,
+          "description": "Subdirectory depth to recurse under each template root. 0 = root only, 1 = one level (default, matches GitLab spec)."
+        },
+        "gitlabComponentHelper.discovery.filePatterns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "*.yml",
+            "*.yaml"
+          ],
+          "description": "Filename globs identifying component template files. Filename only, no path globs."
+        },
+        "gitlabComponentHelper.discovery.templateFileNames": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "template.yml",
+            "template.yaml"
+          ],
+          "description": "Filenames recognised inside per-component subfolders, e.g. 'templates/foo/template.yml'."
         }
       }
     },

--- a/src/services/component/discoveryConfig.ts
+++ b/src/services/component/discoveryConfig.ts
@@ -1,0 +1,159 @@
+import * as vscode from 'vscode';
+
+export interface DiscoveryConfig {
+  templateRoots: string[];
+  maxDepth: number;
+  filePatterns: string[];
+  templateFileNames: string[];
+}
+
+export interface DiscoveryOverride {
+  templateRoots?: string[];
+  maxDepth?: number;
+  filePatterns?: string[];
+  templateFileNames?: string[];
+}
+
+export interface ComponentSourceWithDiscovery {
+  name?: string;
+  path?: string;
+  gitlabInstance?: string;
+  discovery?: DiscoveryOverride;
+}
+
+export const HARD_DEFAULTS: Readonly<DiscoveryConfig> = Object.freeze({
+  templateRoots: ['templates'],
+  maxDepth: 1,
+  filePatterns: ['*.yml', '*.yaml'],
+  templateFileNames: ['template.yml', 'template.yaml'],
+});
+
+export const DISCOVERY_LIMITS = Object.freeze({
+  maxDepth: 3,
+  templateRootsCount: 5,
+  filePatternsCount: 10,
+  templateFileNamesCount: 10,
+});
+
+export function mergeDiscoveryConfig(
+  global: DiscoveryOverride | undefined,
+  override: DiscoveryOverride | undefined,
+): DiscoveryConfig {
+  return {
+    templateRoots:
+      override?.templateRoots ?? global?.templateRoots ?? [...HARD_DEFAULTS.templateRoots],
+    maxDepth: override?.maxDepth ?? global?.maxDepth ?? HARD_DEFAULTS.maxDepth,
+    filePatterns:
+      override?.filePatterns ?? global?.filePatterns ?? [...HARD_DEFAULTS.filePatterns],
+    templateFileNames:
+      override?.templateFileNames ??
+      global?.templateFileNames ??
+      [...HARD_DEFAULTS.templateFileNames],
+  };
+}
+
+export function clampDiscoveryConfig(config: DiscoveryConfig): DiscoveryConfig {
+  return {
+    templateRoots: dedupe(
+      config.templateRoots
+        .slice(0, DISCOVERY_LIMITS.templateRootsCount)
+        .map(normalizeRoot)
+        .filter((root): root is string => Boolean(root)),
+    ),
+    maxDepth: clamp(config.maxDepth, 0, DISCOVERY_LIMITS.maxDepth),
+    filePatterns: dedupe(
+      config.filePatterns
+        .slice(0, DISCOVERY_LIMITS.filePatternsCount)
+        .filter(isFilenamePattern),
+    ),
+    templateFileNames: dedupe(
+      config.templateFileNames
+        .slice(0, DISCOVERY_LIMITS.templateFileNamesCount)
+        .filter(isFilenameOnly),
+    ),
+  };
+}
+
+export function buildTemplatePathCandidates(
+  componentName: string,
+  config: DiscoveryConfig,
+): string[] {
+  const candidates: string[] = [];
+  for (const root of config.templateRoots) {
+    for (const pattern of config.filePatterns) {
+      const ext = patternExtension(pattern);
+      if (ext !== undefined) {
+        candidates.push(`${root}/${componentName}${ext}`);
+      }
+    }
+    for (const fileName of config.templateFileNames) {
+      candidates.push(`${root}/${componentName}/${fileName}`);
+    }
+  }
+  return dedupe(candidates);
+}
+
+export function matchesFilePattern(filename: string, patterns: string[]): boolean {
+  return patterns.some((pattern) => {
+    const ext = patternExtension(pattern);
+    if (ext !== undefined) {
+      return ext === '' ? true : filename.endsWith(ext);
+    }
+    return filename === pattern;
+  });
+}
+
+export function readGlobalDiscoveryConfig(): DiscoveryOverride {
+  const config = vscode.workspace.getConfiguration('gitlabComponentHelper');
+  const override: DiscoveryOverride = {};
+  const roots = config.get<string[]>('discovery.templateRoots');
+  const depth = config.get<number>('discovery.maxDepth');
+  const patterns = config.get<string[]>('discovery.filePatterns');
+  const templateFileNames = config.get<string[]>('discovery.templateFileNames');
+  if (Array.isArray(roots)) override.templateRoots = roots;
+  if (typeof depth === 'number') override.maxDepth = depth;
+  if (Array.isArray(patterns)) override.filePatterns = patterns;
+  if (Array.isArray(templateFileNames)) override.templateFileNames = templateFileNames;
+  return override;
+}
+
+export function getDiscoveryConfigForSource(
+  source?: ComponentSourceWithDiscovery,
+): DiscoveryConfig {
+  return clampDiscoveryConfig(
+    mergeDiscoveryConfig(readGlobalDiscoveryConfig(), source?.discovery),
+  );
+}
+
+function clamp(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min;
+  return Math.min(Math.max(Math.trunc(value), min), max);
+}
+
+function normalizeRoot(root: string): string {
+  if (typeof root !== 'string') return '';
+  const trimmed = root.trim().replace(/^\/+/, '').replace(/\/+$/, '');
+  if (!trimmed || trimmed.includes('..')) return '';
+  return trimmed;
+}
+
+function isFilenamePattern(pattern: string): boolean {
+  if (typeof pattern !== 'string' || !pattern) return false;
+  if (pattern.includes('/') || pattern.includes('..')) return false;
+  return pattern.startsWith('*') || /^[\w.-]+$/.test(pattern);
+}
+
+function isFilenameOnly(name: string): boolean {
+  return typeof name === 'string' && !!name && !name.includes('/') && !name.includes('..');
+}
+
+function patternExtension(pattern: string): string | undefined {
+  if (pattern.startsWith('*')) {
+    return pattern.slice(1);
+  }
+  return undefined;
+}
+
+function dedupe<T>(items: T[]): T[] {
+  return Array.from(new Set(items));
+}

--- a/src/services/component/index.ts
+++ b/src/services/component/index.ts
@@ -7,5 +7,20 @@ export { UrlParser, ParsedComponentUrl } from './urlParser';
 export { VersionManager } from './versionManager';
 export { ComponentFetcher } from './componentFetcher';
 
+// Discovery configuration
+export {
+  DiscoveryConfig,
+  DiscoveryOverride,
+  ComponentSourceWithDiscovery,
+  HARD_DEFAULTS,
+  DISCOVERY_LIMITS,
+  mergeDiscoveryConfig,
+  clampDiscoveryConfig,
+  buildTemplatePathCandidates,
+  matchesFilePattern,
+  readGlobalDiscoveryConfig,
+  getDiscoveryConfigForSource,
+} from './discoveryConfig';
+
 // Command registration
 export { registerAddProjectTokenCommand } from './commands';

--- a/tests/unit/discovery-config.test.js
+++ b/tests/unit/discovery-config.test.js
@@ -1,0 +1,306 @@
+/**
+ * Discovery Config Behavior Contract
+ *
+ * Mirrors the pure helpers in src/services/component/discoveryConfig.ts and
+ * asserts the merge / clamp / candidate-building rules that the extension
+ * relies on when discovering components in user repositories.
+ *
+ * Per tests/run-tests.js convention, this is an inline-logic characterization
+ * test. The corresponding source module is verified end-to-end at the
+ * extension-host layer.
+ */
+/* eslint-env node */
+const assert = require('assert');
+
+const HARD_DEFAULTS = Object.freeze({
+  templateRoots: ['templates'],
+  maxDepth: 1,
+  filePatterns: ['*.yml', '*.yaml'],
+  templateFileNames: ['template.yml', 'template.yaml'],
+});
+
+const DISCOVERY_LIMITS = Object.freeze({
+  maxDepth: 3,
+  templateRootsCount: 5,
+  filePatternsCount: 10,
+  templateFileNamesCount: 10,
+});
+
+function mergeDiscoveryConfig(global, override) {
+  return {
+    templateRoots:
+      override?.templateRoots ?? global?.templateRoots ?? [...HARD_DEFAULTS.templateRoots],
+    maxDepth: override?.maxDepth ?? global?.maxDepth ?? HARD_DEFAULTS.maxDepth,
+    filePatterns:
+      override?.filePatterns ?? global?.filePatterns ?? [...HARD_DEFAULTS.filePatterns],
+    templateFileNames:
+      override?.templateFileNames ??
+      global?.templateFileNames ??
+      [...HARD_DEFAULTS.templateFileNames],
+  };
+}
+
+function clamp(value, min, max) {
+  if (!Number.isFinite(value)) return min;
+  return Math.min(Math.max(Math.trunc(value), min), max);
+}
+
+function normalizeRoot(root) {
+  if (typeof root !== 'string') return '';
+  const trimmed = root.trim().replace(/^\/+/, '').replace(/\/+$/, '');
+  if (!trimmed || trimmed.includes('..')) return '';
+  return trimmed;
+}
+
+function isFilenamePattern(pattern) {
+  if (typeof pattern !== 'string' || !pattern) return false;
+  if (pattern.includes('/') || pattern.includes('..')) return false;
+  return pattern.startsWith('*') || /^[\w.-]+$/.test(pattern);
+}
+
+function isFilenameOnly(name) {
+  return typeof name === 'string' && !!name && !name.includes('/') && !name.includes('..');
+}
+
+function dedupe(items) {
+  return Array.from(new Set(items));
+}
+
+function clampDiscoveryConfig(config) {
+  return {
+    templateRoots: dedupe(
+      config.templateRoots
+        .slice(0, DISCOVERY_LIMITS.templateRootsCount)
+        .map(normalizeRoot)
+        .filter(Boolean),
+    ),
+    maxDepth: clamp(config.maxDepth, 0, DISCOVERY_LIMITS.maxDepth),
+    filePatterns: dedupe(
+      config.filePatterns
+        .slice(0, DISCOVERY_LIMITS.filePatternsCount)
+        .filter(isFilenamePattern),
+    ),
+    templateFileNames: dedupe(
+      config.templateFileNames
+        .slice(0, DISCOVERY_LIMITS.templateFileNamesCount)
+        .filter(isFilenameOnly),
+    ),
+  };
+}
+
+function patternExtension(pattern) {
+  if (pattern.startsWith('*')) {
+    return pattern.slice(1);
+  }
+  return undefined;
+}
+
+function buildTemplatePathCandidates(componentName, config) {
+  const candidates = [];
+  for (const root of config.templateRoots) {
+    for (const pattern of config.filePatterns) {
+      const ext = patternExtension(pattern);
+      if (ext !== undefined) {
+        candidates.push(`${root}/${componentName}${ext}`);
+      }
+    }
+    for (const fileName of config.templateFileNames) {
+      candidates.push(`${root}/${componentName}/${fileName}`);
+    }
+  }
+  return dedupe(candidates);
+}
+
+function matchesFilePattern(filename, patterns) {
+  return patterns.some((pattern) => {
+    const ext = patternExtension(pattern);
+    if (ext !== undefined) {
+      return ext === '' ? true : filename.endsWith(ext);
+    }
+    return filename === pattern;
+  });
+}
+
+let passed = 0;
+let failed = 0;
+function check(name, fn) {
+  try {
+    fn();
+    console.log(`  ✅ ${name}`);
+    passed++;
+  } catch (error) {
+    console.log(`  ❌ ${name}`);
+    console.log(`     ${error.message}`);
+    failed++;
+  }
+}
+
+console.log('=== Discovery Config Behavior Contract ===\n');
+
+console.log('--- mergeDiscoveryConfig ---');
+check('falls back to hard defaults when nothing provided', () => {
+  assert.deepStrictEqual(mergeDiscoveryConfig(undefined, undefined), {
+    templateRoots: ['templates'],
+    maxDepth: 1,
+    filePatterns: ['*.yml', '*.yaml'],
+    templateFileNames: ['template.yml', 'template.yaml'],
+  });
+});
+check('uses global override when no source override', () => {
+  const result = mergeDiscoveryConfig(
+    { templateRoots: ['ci/components'], maxDepth: 2 },
+    undefined,
+  );
+  assert.deepStrictEqual(result.templateRoots, ['ci/components']);
+  assert.strictEqual(result.maxDepth, 2);
+  assert.deepStrictEqual(result.filePatterns, ['*.yml', '*.yaml']);
+});
+check('source override wins over global', () => {
+  const result = mergeDiscoveryConfig(
+    { templateRoots: ['global'], maxDepth: 1 },
+    { templateRoots: ['source-specific'] },
+  );
+  assert.deepStrictEqual(result.templateRoots, ['source-specific']);
+  assert.strictEqual(result.maxDepth, 1, 'unspecified source field still pulls from global');
+});
+check('partial override does not bleed into other fields', () => {
+  const result = mergeDiscoveryConfig({}, { maxDepth: 3 });
+  assert.deepStrictEqual(result.templateRoots, ['templates']);
+  assert.strictEqual(result.maxDepth, 3);
+});
+
+console.log('\n--- clampDiscoveryConfig ---');
+check('caps maxDepth at limit', () => {
+  const result = clampDiscoveryConfig({
+    templateRoots: ['templates'],
+    maxDepth: 99,
+    filePatterns: ['*.yml'],
+    templateFileNames: ['template.yml'],
+  });
+  assert.strictEqual(result.maxDepth, DISCOVERY_LIMITS.maxDepth);
+});
+check('floors maxDepth at zero', () => {
+  const result = clampDiscoveryConfig({
+    templateRoots: ['templates'],
+    maxDepth: -5,
+    filePatterns: ['*.yml'],
+    templateFileNames: ['template.yml'],
+  });
+  assert.strictEqual(result.maxDepth, 0);
+});
+check('coerces non-finite maxDepth to zero', () => {
+  const result = clampDiscoveryConfig({
+    templateRoots: ['templates'],
+    maxDepth: Number.NaN,
+    filePatterns: [],
+    templateFileNames: [],
+  });
+  assert.strictEqual(result.maxDepth, 0);
+});
+check('limits templateRoots count and strips slashes', () => {
+  const tooMany = Array.from({ length: 20 }, (_, i) => `/root${i}/`);
+  const result = clampDiscoveryConfig({
+    templateRoots: tooMany,
+    maxDepth: 1,
+    filePatterns: ['*.yml'],
+    templateFileNames: ['template.yml'],
+  });
+  assert.strictEqual(result.templateRoots.length, DISCOVERY_LIMITS.templateRootsCount);
+  result.templateRoots.forEach((root) => {
+    assert.ok(!root.startsWith('/'), `expected no leading slash in "${root}"`);
+    assert.ok(!root.endsWith('/'), `expected no trailing slash in "${root}"`);
+  });
+});
+check('rejects path-traversal in templateRoots', () => {
+  const result = clampDiscoveryConfig({
+    templateRoots: ['../escape', 'templates'],
+    maxDepth: 1,
+    filePatterns: ['*.yml'],
+    templateFileNames: [],
+  });
+  assert.deepStrictEqual(result.templateRoots, ['templates']);
+});
+check('rejects path globs in filePatterns', () => {
+  const result = clampDiscoveryConfig({
+    templateRoots: ['templates'],
+    maxDepth: 1,
+    filePatterns: ['*.yml', 'foo/*.yml', '../bad', '*.yaml'],
+    templateFileNames: [],
+  });
+  assert.deepStrictEqual(result.filePatterns, ['*.yml', '*.yaml']);
+});
+check('dedupes templateRoots after normalization', () => {
+  const result = clampDiscoveryConfig({
+    templateRoots: ['templates', '/templates/', 'templates'],
+    maxDepth: 1,
+    filePatterns: ['*.yml'],
+    templateFileNames: [],
+  });
+  assert.deepStrictEqual(result.templateRoots, ['templates']);
+});
+check('rejects templateFileNames containing slashes', () => {
+  const result = clampDiscoveryConfig({
+    templateRoots: ['templates'],
+    maxDepth: 1,
+    filePatterns: [],
+    templateFileNames: ['template.yml', 'sub/template.yml'],
+  });
+  assert.deepStrictEqual(result.templateFileNames, ['template.yml']);
+});
+
+console.log('\n--- buildTemplatePathCandidates ---');
+check('produces 4 default candidates matching legacy hardcoded set', () => {
+  const config = clampDiscoveryConfig(mergeDiscoveryConfig(undefined, undefined));
+  const candidates = buildTemplatePathCandidates('foo', config);
+  assert.deepStrictEqual(candidates, [
+    'templates/foo.yml',
+    'templates/foo.yaml',
+    'templates/foo/template.yml',
+    'templates/foo/template.yaml',
+  ]);
+});
+check('expands across multiple roots', () => {
+  const candidates = buildTemplatePathCandidates('foo', {
+    templateRoots: ['templates', 'ci/components'],
+    maxDepth: 1,
+    filePatterns: ['*.yml'],
+    templateFileNames: ['template.yml'],
+  });
+  assert.deepStrictEqual(candidates, [
+    'templates/foo.yml',
+    'templates/foo/template.yml',
+    'ci/components/foo.yml',
+    'ci/components/foo/template.yml',
+  ]);
+});
+check('skips non-extension patterns when building flat candidates', () => {
+  const candidates = buildTemplatePathCandidates('foo', {
+    templateRoots: ['templates'],
+    maxDepth: 1,
+    filePatterns: ['component.yml'],
+    templateFileNames: ['template.yml'],
+  });
+  assert.deepStrictEqual(candidates, ['templates/foo/template.yml']);
+});
+
+console.log('\n--- matchesFilePattern ---');
+check('matches glob extension', () => {
+  assert.strictEqual(matchesFilePattern('foo.yml', ['*.yml']), true);
+  assert.strictEqual(matchesFilePattern('foo.yaml', ['*.yml']), false);
+});
+check('matches exact filename', () => {
+  assert.strictEqual(matchesFilePattern('component.yml', ['component.yml']), true);
+  assert.strictEqual(matchesFilePattern('other.yml', ['component.yml']), false);
+});
+check('returns false for empty pattern list', () => {
+  assert.strictEqual(matchesFilePattern('foo.yml', []), false);
+});
+
+console.log('\n=== Discovery Config Test Summary ===');
+console.log(`Total: ${passed + failed}`);
+console.log(`Passed: ${passed} ✅`);
+if (failed > 0) {
+  console.log(`Failed: ${failed} ❌`);
+  process.exit(1);
+}
+console.log('🎉 All discovery config contract tests passed!');


### PR DESCRIPTION
## Summary

First slice of user-configurable component discovery so non-standard repository layouts (custom template roots, deeper nesting, alternate filenames) can be catalogued without code changes.

This PR adds the schema and the pure helper module. **The fetcher is not yet wired** — runtime behavior is intentionally unchanged so this slice can be reviewed in isolation. Wiring follows in a separate PR.

## Type of Change

- [x] New feature (non-breaking, additive)
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Changes

- **Settings schema** (`package.json`): four new flat dotted-key settings under `gitlabComponentHelper.discovery.*` so VS Code renders them as native Settings UI controls instead of "Edit in settings.json"
  - `templateRoots` — string array, capped at 5
  - `maxDepth` — number, clamped 0–3
  - `filePatterns` — filename-only globs (no path globs)
  - `templateFileNames` — filenames recognised inside per-component subfolders
- **Per-source override**: optional `discovery` object on `componentSources` items for repo-specific tweaks
- **Pure helper module** (`src/services/component/discoveryConfig.ts`): `mergeDiscoveryConfig`, `clampDiscoveryConfig`, `buildTemplatePathCandidates`, `matchesFilePattern`, plus a vscode-bound reader. ~150 LOC. Hard limits prevent tree-walk blowups (maxDepth ≤ 3, ≤ 5 roots, filename-only globs, path-traversal stripped).
- **Defaults reproduce current hardcoded behavior exactly** — no-op for users who don't set anything
- **Tests** (`tests/unit/discovery-config.test.js`): 18 contract assertions covering merge precedence, clamping, candidate building, and pattern matching, in the inline-logic style documented in `tests/run-tests.js`
- **`.vscode/launch.json`** + `.gitignore` exception: contributors get F5-debug working out of the box (Extension Dev Host + extension-host test runner). `.gitignore` switched from `.vscode/` to `.vscode/*` so the launch.json re-include rule works.

## Testing

- [x] `npm run check-types` clean
- [x] `npm test` — 13/13 test files pass (was 12; this PR adds the new contract tests)
- [x] Pre-commit + pre-push hooks pass
- [x] Manual: F5 debug confirmed Settings UI renders the four new entries with correct controls (string array editors, clamped number input)
- [x] Manual: cataloging behavior unchanged (no wiring yet)

## Out of Scope (Follow-ups)

- Wiring `discoveryConfig` into `componentFetcher.ts` (slice 2, separate PR)
- Per-source diagnostic command (`gitlab-component-helper.diagnoseDiscovery`) so misconfigurations are visible — also slice 2
- Migrating `gitlabComponentHelper.gitlabToken` from plain-text setting to SecretStorage — orthogonal, separate PR

## Checklist

- [x] Code follows project style
- [x] Self-reviewed
- [x] Tests added
- [x] All tests passing
- [x] No merge conflicts (branched off current beta tip)