### PR TITLE
fix(ci): skip release-it dry-run for fork PRs

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -13,6 +13,13 @@ jobs:
   release-dry-run:
     name: Release Dry Run
     runs-on: ubuntu-latest
+    # Skip for fork PRs. Release-it's dry-run inspects commits to preview
+    # what would be released — but fork PRs are squash-merged, replacing
+    # the contributor's commits with a maintainer-authored one. So the
+    # dry-run on the fork's commits has no signal about the eventual
+    # release, and `github.head_ref` doesn't resolve to a ref in this repo
+    # anyway, which made the checkout fail every time.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Problem

The Release Dry Run job in `pr-check.yml` has been failing on every external contributor's PR because `actions/checkout` is configured with `ref: github.head_ref` — the PR source branch name. For fork PRs that branch only exists in the contributor's repo, so the checkout aborts with `"A branch or tag with the name '<head_ref>' could not be found"`. Verified against open PRs #114, #116, and #108.

## Fix

Rather than rework the checkout to support both fork and same-repo PRs (which kept revealing more layered issues — detached HEAD, missing upstream — each fix exposing the next), recognize that the dry-run has no useful signal on fork PRs in the first place:

- The dry-run previews what release-it would do **with the PR's commits**
- Fork PRs are squash-merged in this repo, so the contributor's commits are replaced by a maintainer-authored one
- The contributor's commit messages never reach main → the dry-run can't actually preview the eventual release

Add an `if:` guard that skips the job for fork PRs. Same-repo PRs (internal feature branches, Dependabot) continue to run the dry-run as before.

## Test plan

- [ ] CI green on this PR (same-repo → dry-run runs and should pass as it did before)
- [ ] After merge, re-run PR Check on #116 and #114: Release Dry Run should be SKIPPED (counts as success)