### PR TITLE
fix(deps): bump engines.vscode to match @types/vscode 1.120

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -114,7 +114,7 @@ body:
     id: vscode-version
     attributes:
       label: VS Code version
-      placeholder: e.g. 1.109.0
+      placeholder: e.g. 1.120.0
     validations:
       required: true
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "icon": "images/icon.png",
   "engines": {
     "node": ">=22.0.0",
-    "vscode": ">=1.109.0"
+    "vscode": ">=1.120.0"
   },
   "publisher": "eFAILution",
   "repository": {


### PR DESCRIPTION
## Problem

The release job for the 0.10.4 cut failed at \`vsce package\`:

\`\`\`
Error: @types/vscode ^1.120.0 greater than engines.vscode >=1.109.0.
Either upgrade engines.vscode or use an older @types/vscode version
\`\`\`

#118 (dev-dependencies consolidation) accepted Dependabot's @types/vscode 1.109 → 1.120 bump but left \`engines.vscode\` at \`>=1.109.0\`. vsce considers this a lie about minimum supported VS Code version and refuses to package.

PR #85 previously handled the same situation by **pinning @types/vscode** back down to engines. Following operator's pick, we go the other way this time and **bump engines** to 1.120 to take the latest VS Code API surface.

## Test plan

- [x] \`npm run check-types\` passes locally
- [ ] CI green
- [ ] After merge, the release job re-runs and successfully cuts 0.10.4 (or 0.10.5 if 0.10.4 was partially tagged — verify before publishing to Marketplace)

## Impact

- Drops install support for VS Code 1.109-1.119
- Bug report template placeholder bumped from 1.109.0 → 1.120.0 for consistency