### PR TITLE
fix(completion,validation): resolve GitLab repo from the active file, not workspace[0]

### DIFF
--- a/src/providers/completionProvider.ts
+++ b/src/providers/completionProvider.ts
@@ -493,7 +493,7 @@ export class CompletionProvider implements vscode.CompletionItemProvider {
 
         // Get the component details from cache - need exact match for the specific template
         this.logger.debug(`[CompletionProvider] Looking up component in cache: ${componentUrl}`, 'CompletionProvider');
-        const component = await this.findComponentInCache(componentUrl);
+        const component = await this.findComponentInCache(componentUrl, document.uri);
         if (!component || !component.parameters) {
           this.logger.debug(`[CompletionProvider] Component not found in cache or has no parameters: ${componentUrl}`, 'CompletionProvider');
           return null;
@@ -584,8 +584,10 @@ export class CompletionProvider implements vscode.CompletionItemProvider {
     }
   }
 
-  // Helper method to find component in cache (similar to validation provider)
-  private async findComponentInCache(componentUrl: string): Promise<any | null> {
+  // Helper method to find component in cache (similar to validation provider).
+  // `forUri` is the active document's URI — used so variable expansion picks
+  // the GitLab host matching the file's containing repo, not workspace[0].
+  private async findComponentInCache(componentUrl: string, forUri?: vscode.Uri): Promise<any | null> {
     try {
       const cacheManager = getComponentCacheManager();
       const components = await cacheManager.getComponents();
@@ -594,7 +596,7 @@ export class CompletionProvider implements vscode.CompletionItemProvider {
       // `new URL()` below throws and we never find the component in the cache.
       let resolvedUrl = componentUrl;
       if (containsGitLabVariables(componentUrl)) {
-        const gitContext = await getGitRepositoryContext();
+        const gitContext = await getGitRepositoryContext(forUri);
         if (gitContext.gitlabInstance) {
           resolvedUrl = expandComponentUrl(componentUrl, {
             gitlabInstance: gitContext.gitlabInstance,

--- a/src/providers/componentDetector.ts
+++ b/src/providers/componentDetector.ts
@@ -94,8 +94,9 @@ export async function detectIncludeComponent(document: vscode.TextDocument, posi
     const variables = detectGitLabVariables(componentUrl);
     logger.debug(`[ComponentDetector] Component URL contains GitLab variables: ${variables.join(', ')}`, 'ComponentDetector');
 
-    // Try to get Git repository context first
-    const gitContext = await getGitRepositoryContext();
+    // Try to get Git repository context first, scoped to the active file so
+    // multi-repo workspaces resolve to the correct GitLab host.
+    const gitContext = await getGitRepositoryContext(document.uri);
     let expandedUrl = componentUrl;
 
     if (gitContext.gitlabInstance && gitContext.projectPath) {
@@ -667,30 +668,41 @@ async function fetchComponentDynamically(componentUrl: string, originalUrl?: str
 }
 
 /**
- * Get Git repository context for variable expansion
+ * Get Git repository context for variable expansion.
+ *
+ * When `forUri` is supplied (typically the active document's URI), the lookup
+ * resolves to the repository that contains that specific file. This matters in
+ * multi-repo workspaces where workspaceFolders[0] would otherwise pick the
+ * wrong GitLab host. When `forUri` is omitted, falls back to the workspace
+ * root for compatibility with callers that don't have a document handle.
  */
-export async function getGitRepositoryContext(): Promise<{
+export async function getGitRepositoryContext(forUri?: vscode.Uri): Promise<{
   gitlabInstance?: string;
   projectPath?: string;
   commitSha?: string;
 }> {
   try {
-    const workspaceFolders = vscode.workspace.workspaceFolders;
-    if (!workspaceFolders || workspaceFolders.length === 0) {
-      return {};
-    }
-
-    const workspacePath = workspaceFolders[0].uri.fsPath;
-
     // Use VS Code's Git extension API if available
     const gitExtension = vscode.extensions.getExtension('vscode.git');
     if (gitExtension) {
       const git = gitExtension.exports.getAPI(1);
-      if (git && git.repositories.length > 0) {
-        const repo = git.repositories.find((r: any) =>
-          workspacePath.startsWith(r.rootUri.fsPath)
-        ) || git.repositories[0];
-
+      if (git) {
+        let repo: any = null;
+        if (forUri) {
+          // File-relative lookup. If the file isn't in any tracked repo,
+          // do NOT fall through to workspace[0] — that would re-introduce
+          // the "wrong host" bug we're fixing.
+          repo = git.getRepository(forUri);
+        } else if (git.repositories.length > 0) {
+          const workspaceFolders = vscode.workspace.workspaceFolders;
+          if (!workspaceFolders || workspaceFolders.length === 0) {
+            return {};
+          }
+          const workspacePath = workspaceFolders[0].uri.fsPath;
+          repo = git.repositories.find((r: any) =>
+            workspacePath.startsWith(r.rootUri.fsPath)
+          ) || git.repositories[0];
+        }
         if (repo) {
           // Get remote URLs
           const remotes = repo.state.remotes;

--- a/src/providers/validationProvider.ts
+++ b/src/providers/validationProvider.ts
@@ -128,8 +128,10 @@ export class ValidationProvider implements vscode.CodeActionProvider {
                 if (containsGitLabVariables(componentUrl)) {
                     this.logger.debug(`[ValidationProvider] Component URL contains variables, expanding: ${componentUrl}`, 'ValidationProvider');
 
-                    // Try to get some context from workspace/git for expansion
-                    const workspaceContext = await this.getWorkspaceContext();
+                    // Try to get some context from workspace/git for expansion.
+                    // Pass the document URI so multi-repo workspaces resolve to
+                    // the GitLab host of the file's containing repo.
+                    const workspaceContext = await this.getWorkspaceContext(document.uri);
 
                     // Only attempt expansion if we have sufficient context
                     if (workspaceContext.gitlabInstance && workspaceContext.projectPath) {
@@ -1209,9 +1211,13 @@ export class ValidationProvider implements vscode.CodeActionProvider {
     }
 
     /**
-     * Get workspace context for GitLab variable expansion
+     * Get workspace context for GitLab variable expansion.
+     *
+     * `forUri` is the URI of the document being validated. When supplied, the
+     * GitLab repo lookup is scoped to the file's containing repo so multi-repo
+     * workspaces resolve to the correct host.
      */
-    private async getWorkspaceContext(): Promise<{
+    private async getWorkspaceContext(forUri?: vscode.Uri): Promise<{
         gitlabInstance?: string;
         projectPath?: string;
         serverUrl?: string;
@@ -1227,7 +1233,7 @@ export class ValidationProvider implements vscode.CodeActionProvider {
             const workspaceFolder = workspaceFolders[0].uri.fsPath;
 
             // Try to get Git remote information for the current repository
-            const gitContext = await this.getGitRepositoryContext(workspaceFolder);
+            const gitContext = await this.getGitRepositoryContext(workspaceFolder, forUri);
             if (gitContext.gitlabInstance && gitContext.projectPath) {
                 this.logger.debug(`[ValidationProvider] Using Git repository context: ${gitContext.gitlabInstance}/${gitContext.projectPath}`, 'ValidationProvider');
                 return {
@@ -1286,9 +1292,13 @@ export class ValidationProvider implements vscode.CodeActionProvider {
     }
 
     /**
-     * Extract Git repository information from the workspace
+     * Extract Git repository information from the workspace.
+     *
+     * When `forUri` is supplied, the lookup resolves to the repository that
+     * contains that specific file — required for multi-repo workspaces where
+     * workspaceFolders[0] would otherwise pick the wrong GitLab host.
      */
-    private async getGitRepositoryContext(workspacePath: string): Promise<{
+    private async getGitRepositoryContext(workspacePath: string, forUri?: vscode.Uri): Promise<{
         gitlabInstance?: string;
         projectPath?: string;
         commitSha?: string;
@@ -1298,10 +1308,17 @@ export class ValidationProvider implements vscode.CodeActionProvider {
             const gitExtension = vscode.extensions.getExtension('vscode.git');
             if (gitExtension) {
                 const git = gitExtension.exports.getAPI(1);
-                if (git && git.repositories.length > 0) {
-                    const repo = git.repositories.find((r: any) =>
-                        workspacePath.startsWith(r.rootUri.fsPath)
-                    ) || git.repositories[0];
+                if (git) {
+                    let repo: any = null;
+                    if (forUri) {
+                        // File-relative lookup; null if file isn't in any repo.
+                        // Do NOT fall through to workspace[0] here.
+                        repo = git.getRepository(forUri);
+                    } else if (git.repositories.length > 0) {
+                        repo = git.repositories.find((r: any) =>
+                            workspacePath.startsWith(r.rootUri.fsPath)
+                        ) || git.repositories[0];
+                    }
 
                     if (repo) {
                         // Get remote URLs


### PR DESCRIPTION
## Summary

Closes #122.

GitLab variable expansion (\`\$CI_SERVER_FQDN\` and friends) in component URLs was rooted in \`workspaceFolders[0]\`, so in VS Code windows containing multiple git projects (a normal monorepo / "open many folders" workflow), the substitution silently used the wrong GitLab host. Completions and diagnostics would return null with no diagnostic clue.

This fix scopes the git-repo lookup to the active file's URI via the git extension's \`getRepository(uri)\` API, which walks up from the URI to find the closest containing repo.

## Changes

| File | Change |
|---|---|
| \`componentDetector.ts\` | \`getGitRepositoryContext\` now accepts \`forUri?: vscode.Uri\`; when provided, uses \`git.getRepository(forUri)\` instead of the workspace-rooted find. Caller in \`getComponentUnderCursor\` passes \`document.uri\`. |
| \`completionProvider.ts\` | \`findComponentInCache\` accepts \`forUri\`, threads it to \`getGitRepositoryContext\`. Caller passes \`document.uri\`. |
| \`validationProvider.ts\` | \`getWorkspaceContext\` and the private \`getGitRepositoryContext\` accept \`forUri\` and use the same file-relative resolution. Caller in \`validate(document)\` passes \`document.uri\`. |

## Design notes

- **When \`forUri\` resolves to no repo** → return empty context. Do NOT fall through to workspace[0]; that would re-introduce the bug we're fixing.
- **When \`forUri\` is omitted** → fall back to workspace[0] for backward compatibility with non-document callers.
- **\`detectNonGitLabRepository\` is intentionally left workspace-rooted.** That's a separate concern (presence check), worth its own follow-up if it becomes a problem.

## Followups not addressed here (noted in #122)

- \`componentDetector.ts:762\` rejects any host not containing \`"gitlab"\` — silently drops self-hosted instances with non-\`gitlab*\` hostnames.
- \`componentDetector.ts:672\` and \`validationProvider.ts:1291\` are near-identical implementations. Should be consolidated.

## Test plan

- [x] \`npm run check-types\` — clean
- [x] \`npm test\` — 13/13 pass
- [x] \`npm run lint\` — 0 errors (218 warnings, +2 from existing \`any\` pattern preserved)
- [ ] CI green
- [ ] Manual: open a window with two GitLab repos (different hosts), confirm variable expansion uses the file's repo