### PR TITLE
feat: recognise non-canonical GitLab CI file names via additionalFileGlobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,19 @@ Add your favorite sources in VS Code settings:
 ]
 ```
 
+### 📁 Recognising non-canonical CI files
+
+Out of the box the extension activates on `.gitlab-ci.yml`, `.gitlab-ci.yaml`, and anything under a `.gitlab/` directory. If your project keeps included CI configs elsewhere, add their globs to `gitlabComponentHelper.additionalFileGlobs` — these are merged with the built-in defaults:
+
+```jsonc
+"gitlabComponentHelper.additionalFileGlobs": [
+  "**/ci/*.yml",
+  "**/pipelines/**/*.yaml"
+]
+```
+
+Patterns use VS Code's GlobPattern syntax.
+
 ---
 
 ## 🗂️ Component Discovery

--- a/package.json
+++ b/package.json
@@ -17,8 +17,10 @@
   "activationEvents": [
     "onLanguage:yaml",
     "onLanguage:shellscript",
-    "workspaceContains:.gitlab-ci.yml",
-    "workspaceContains:.gitlab-ci.yaml"
+    "workspaceContains:**/.gitlab-ci.yml",
+    "workspaceContains:**/.gitlab-ci.yaml",
+    "workspaceContains:**/.gitlab/**/*.yml",
+    "workspaceContains:**/.gitlab/**/*.yaml"
   ],
   "contributes": {
     "languages": [
@@ -236,6 +238,14 @@
             "template.yaml"
           ],
           "description": "Filenames recognised inside per-component subfolders, e.g. 'templates/foo/template.yml'."
+        },
+        "gitlabComponentHelper.additionalFileGlobs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "Extra glob patterns for files that should be treated as GitLab CI files, in addition to the built-in defaults (`**/.gitlab-ci.yml`, `**/.gitlab-ci.yaml`, `**/.gitlab/**/*.yml`, `**/.gitlab/**/*.yaml`). Use this for nested/included CI configs that live elsewhere, e.g. '**/ci/*.yml'. Patterns use VS Code GlobPattern syntax."
         }
       }
     },
@@ -280,7 +290,7 @@
     "menus": {
       "editor/context": [
         {
-          "when": "resourceFilename =~ /gitlab-ci\\.yml$/",
+          "when": "resourceLangId == yaml || resourceLangId == gitlab-ci",
           "command": "gitlab-component-helper.browseComponents",
           "group": "navigation"
         }

--- a/package.json
+++ b/package.json
@@ -245,7 +245,7 @@
             "type": "string"
           },
           "default": [],
-          "description": "Extra glob patterns for files that should be treated as GitLab CI files, in addition to the built-in defaults (`**/.gitlab-ci.yml`, `**/.gitlab-ci.yaml`, `**/.gitlab/**/*.yml`, `**/.gitlab/**/*.yaml`). Use this for nested/included CI configs that live elsewhere, e.g. '**/ci/*.yml'. Patterns use VS Code GlobPattern syntax."
+          "description": "Extra GitLab CI file globs, merged with the built-in defaults. Patterns match at any directory depth (e.g. 'ci/*.yml' is treated as '**/ci/*.yml')."
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -290,7 +290,7 @@
     "menus": {
       "editor/context": [
         {
-          "when": "resourceLangId == yaml || resourceLangId == gitlab-ci",
+          "when": "gitlabComponentHelper.isCiFile",
           "command": "gitlab-component-helper.browseComponents",
           "group": "navigation"
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,6 +10,9 @@ import { ValidationProvider } from './providers/validationProvider';
 import { parseYaml } from './utils/yamlParser';
 import { DetachedComponentTemplate } from './templates';
 import { getPerformanceMonitor } from './utils/performanceMonitor';
+import { isGitLabCIFile, invalidateFileGlobsCache } from './utils/gitlabCiFileMatcher';
+
+const CI_FILE_CONTEXT_KEY = 'gitlabComponentHelper.isCiFile';
 
 // Constants for timing delays
 const PANEL_FOCUS_DELAY_MS = 100;
@@ -552,13 +555,26 @@ export function activate(context: vscode.ExtensionContext) {
     // Initialize the validation provider
     const validationProvider = new ValidationProvider(context);
 
+    // Keep the `gitlabComponentHelper.isCiFile` context key in sync with `isGitLabCIFile` so the editor context menu
+    // shows the Browse Components command on exactly the same files the providers activate on.
+    const updateCiFileContext = (editor: vscode.TextEditor | undefined): void => {
+      const isCi = editor ? isGitLabCIFile(editor.document) : false;
+      vscode.commands.executeCommand('setContext', CI_FILE_CONTEXT_KEY, isCi);
+    };
+    updateCiFileContext(vscode.window.activeTextEditor);
+    context.subscriptions.push(
+      vscode.window.onDidChangeActiveTextEditor(updateCiFileContext),
+    );
+
     // Re-validate open documents when the user changes additional file globs so newly-matched files light up (or stop
-    // being treated as GitLab CI) without reloading the window.
+    // being treated as GitLab CI) without reloading the window. Also refresh the context key so the menu follows suit.
     context.subscriptions.push(
       vscode.workspace.onDidChangeConfiguration(e => {
         if (e.affectsConfiguration('gitlabComponentHelper.additionalFileGlobs')) {
           logger.info('[Extension] additionalFileGlobs setting changed, re-validating open documents', 'Extension');
+          invalidateFileGlobsCache();
           validationProvider.revalidateOpenDocuments();
+          updateCiFileContext(vscode.window.activeTextEditor);
         }
       })
     );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -550,7 +550,18 @@ export function activate(context: vscode.ExtensionContext) {
     );
 
     // Initialize the validation provider
-    new ValidationProvider(context);
+    const validationProvider = new ValidationProvider(context);
+
+    // Re-validate open documents when the user changes additional file globs so newly-matched files light up (or stop
+    // being treated as GitLab CI) without reloading the window.
+    context.subscriptions.push(
+      vscode.workspace.onDidChangeConfiguration(e => {
+        if (e.affectsConfiguration('gitlabComponentHelper.additionalFileGlobs')) {
+          logger.info('[Extension] additionalFileGlobs setting changed, re-validating open documents', 'Extension');
+          validationProvider.revalidateOpenDocuments();
+        }
+      })
+    );
 
     // Register command to show performance statistics
     logger.debug('[Extension] Registering showPerformanceStats command...', 'Extension');

--- a/src/providers/completionProvider.ts
+++ b/src/providers/completionProvider.ts
@@ -5,16 +5,10 @@ import { GitLabCatalogComponent, GitLabCatalogVariable } from '../types/gitlab-c
 import { getComponentCacheManager } from '../services/cache/componentCacheManager';
 import { getVariableCompletions, GITLAB_PREDEFINED_VARIABLES, containsGitLabVariables, expandComponentUrl } from '../utils/gitlabVariables';
 import { Logger } from '../utils/logger';
+import { isGitLabCIFile } from '../utils/gitlabCiFileMatcher';
 
 export class CompletionProvider implements vscode.CompletionItemProvider {
   private logger = Logger.getInstance();
-
-  // Helper function to check if file is a GitLab CI file
-  private isGitLabCIFile(document: vscode.TextDocument): boolean {
-    const fileName = document.fileName.toLowerCase();
-    return fileName.endsWith('.gitlab-ci.yml') || fileName.endsWith('.gitlab-ci.yaml') ||
-           fileName.includes('gitlab-ci') || document.languageId === 'gitlab-ci';
-  }
 
   public async provideCompletionItems(
     document: vscode.TextDocument,
@@ -23,7 +17,7 @@ export class CompletionProvider implements vscode.CompletionItemProvider {
     _context: vscode.CompletionContext
   ): Promise<vscode.CompletionItem[] | vscode.CompletionList | null> {
     // First check if this is a GitLab CI file
-    if (!this.isGitLabCIFile(document)) {
+    if (!isGitLabCIFile(document)) {
       this.logger.debug(`[CompletionProvider] Skipping completion for non-GitLab CI file: ${document.fileName} (language: ${document.languageId})`, 'CompletionProvider');
       return null;
     }

--- a/src/providers/hoverProvider.ts
+++ b/src/providers/hoverProvider.ts
@@ -3,21 +3,15 @@ import { getComponentUnderCursor, Component, ComponentParameter, detectIncludeCo
 import { Logger } from '../utils/logger';
 import { getVariableInfo } from '../utils/gitlabVariables';
 import { parseYaml } from '../utils/yamlParser';
+import { isGitLabCIFile } from '../utils/gitlabCiFileMatcher';
 
 export class HoverProvider implements vscode.HoverProvider {
   private logger = Logger.getInstance();
 
-  // Helper function to check if file is a GitLab CI file
-  private isGitLabCIFile(document: vscode.TextDocument): boolean {
-    const fileName = document.fileName.toLowerCase();
-    return fileName.endsWith('.gitlab-ci.yml') || fileName.endsWith('.gitlab-ci.yaml') ||
-           fileName.includes('gitlab-ci') || document.languageId === 'gitlab-ci';
-  }
-
   // Update the hover provider to display component information properly
   public async provideHover(document: vscode.TextDocument, position: vscode.Position): Promise<vscode.Hover | null> {
     // First check if this is a GitLab CI file
-    if (!this.isGitLabCIFile(document)) {
+    if (!isGitLabCIFile(document)) {
       this.logger.debug(`[HoverProvider] Skipping hover for non-GitLab CI file: ${document.fileName} (language: ${document.languageId})`, 'HoverProvider');
       return null;
     }

--- a/src/providers/validationProvider.ts
+++ b/src/providers/validationProvider.ts
@@ -5,6 +5,7 @@ import { parseYaml } from '../utils/yamlParser';
 import { Component } from '../types/git-component';
 import { Logger } from '../utils/logger';
 import { expandComponentUrl, containsGitLabVariables } from '../utils/gitlabVariables';
+import { isGitLabCIFile, getConfiguredFileGlobs } from '../utils/gitlabCiFileMatcher';
 import { spawn } from 'child_process';
 
 export class ValidationProvider implements vscode.CodeActionProvider {
@@ -25,17 +26,17 @@ export class ValidationProvider implements vscode.CodeActionProvider {
         this.diagnosticCollection = vscode.languages.createDiagnosticCollection('gitlab-component-helper');
         context.subscriptions.push(this.diagnosticCollection);
 
-        // Register code action provider for GitLab CI files (supports yaml, gitlab-ci, and shellscript languages)
-        this.logger.debug('[ValidationProvider] Registering code action provider for yaml, gitlab-ci, and shellscript languages', 'ValidationProvider');
+        // Register code action provider for GitLab CI files (supports yaml, gitlab-ci, shellscript, and configured globs)
+        this.logger.debug('[ValidationProvider] Registering code action provider for yaml, gitlab-ci, and shellscript languages plus configured file globs', 'ValidationProvider');
+        const codeActionSelectors: vscode.DocumentSelector = [
+            { language: 'yaml' },
+            { language: 'gitlab-ci' },
+            { language: 'shellscript' },
+            ...getConfiguredFileGlobs().map(pattern => ({ pattern })),
+        ];
         context.subscriptions.push(
             vscode.languages.registerCodeActionsProvider(
-                [
-                    { language: 'yaml' },
-                    { language: 'gitlab-ci' },
-                    { language: 'shellscript' },
-                    { pattern: '**/*.gitlab-ci.yml' },
-                    { pattern: '**/.gitlab-ci.yml' }
-                ],
+                codeActionSelectors,
                 this,
                 {
                     providedCodeActionKinds: [vscode.CodeActionKind.QuickFix]
@@ -70,25 +71,22 @@ export class ValidationProvider implements vscode.CodeActionProvider {
         );
 
         this.logger.debug('[ValidationProvider] Validating currently open documents', 'ValidationProvider');
+        this.revalidateOpenDocuments();
+
+        this.logger.debug('[ValidationProvider] Initialization complete', 'ValidationProvider');
+    }
+
+    public revalidateOpenDocuments(): void {
         vscode.workspace.textDocuments.forEach(doc => {
             this.logger.debug(`[ValidationProvider] Found open document: ${doc.fileName} (${doc.languageId})`, 'ValidationProvider');
             this.validate(doc);
         });
-
-        this.logger.debug('[ValidationProvider] Initialization complete', 'ValidationProvider');
     }
 
     private async validate(document: vscode.TextDocument) {
         this.logger.debug(`[ValidationProvider] validate() called for: ${document.fileName}, languageId: ${document.languageId}`, 'ValidationProvider');
 
-        // Support yaml, gitlab-ci, and shellscript languages, and files ending with gitlab-ci patterns
-        const isGitLabCIFile = document.languageId === 'gitlab-ci' ||
-                              document.languageId === 'yaml' ||
-                              document.languageId === 'shellscript' ||
-                              document.fileName.endsWith('.gitlab-ci.yml') ||
-                              document.fileName.endsWith('/.gitlab-ci.yml');
-
-        if (!isGitLabCIFile) {
+        if (!isGitLabCIFile(document)) {
             this.logger.debug(`[ValidationProvider] Skipping validation - not a supported file type`, 'ValidationProvider');
             return;
         }
@@ -419,14 +417,7 @@ export class ValidationProvider implements vscode.CodeActionProvider {
         const document = e.document;
         const documentId = document.uri.toString();
 
-        // Check if this is a GitLab CI file
-        const isGitLabCIFile = document.languageId === 'gitlab-ci' ||
-                              document.languageId === 'yaml' ||
-                              document.languageId === 'shellscript' ||
-                              document.fileName.endsWith('.gitlab-ci.yml') ||
-                              document.fileName.endsWith('/.gitlab-ci.yml');
-
-        if (!isGitLabCIFile) {
+        if (!isGitLabCIFile(document)) {
             return;
         }
 

--- a/src/providers/validationProvider.ts
+++ b/src/providers/validationProvider.ts
@@ -5,7 +5,7 @@ import { parseYaml } from '../utils/yamlParser';
 import { Component } from '../types/git-component';
 import { Logger } from '../utils/logger';
 import { expandComponentUrl, containsGitLabVariables } from '../utils/gitlabVariables';
-import { isGitLabCIFile, getConfiguredFileGlobs } from '../utils/gitlabCiFileMatcher';
+import { isGitLabCIFile } from '../utils/gitlabCiFileMatcher';
 import { spawn } from 'child_process';
 
 export class ValidationProvider implements vscode.CodeActionProvider {
@@ -26,17 +26,15 @@ export class ValidationProvider implements vscode.CodeActionProvider {
         this.diagnosticCollection = vscode.languages.createDiagnosticCollection('gitlab-component-helper');
         context.subscriptions.push(this.diagnosticCollection);
 
-        // Register code action provider for GitLab CI files (supports yaml, gitlab-ci, shellscript, and configured globs)
-        this.logger.debug('[ValidationProvider] Registering code action provider for yaml, gitlab-ci, and shellscript languages plus configured file globs', 'ValidationProvider');
-        const codeActionSelectors: vscode.DocumentSelector = [
-            { language: 'yaml' },
-            { language: 'gitlab-ci' },
-            { language: 'shellscript' },
-            ...getConfiguredFileGlobs().map(pattern => ({ pattern })),
-        ];
+        // Register code action provider for the languages the providers run against.
+        this.logger.debug('[ValidationProvider] Registering code action provider for yaml, gitlab-ci, and shellscript', 'ValidationProvider');
         context.subscriptions.push(
             vscode.languages.registerCodeActionsProvider(
-                codeActionSelectors,
+                [
+                    { language: 'yaml' },
+                    { language: 'gitlab-ci' },
+                    { language: 'shellscript' },
+                ],
                 this,
                 {
                     providedCodeActionKinds: [vscode.CodeActionKind.QuickFix]

--- a/src/utils/gitlabCiFileMatcher.ts
+++ b/src/utils/gitlabCiFileMatcher.ts
@@ -1,5 +1,9 @@
 import * as vscode from "vscode";
 
+/**
+ * Built-in glob patterns that always identify a file as a GitLab CI file. Covers the canonical entrypoint and the
+ * conventional `.gitlab/` directory used for nested/included pipeline config.
+ */
 export const DEFAULT_GITLAB_CI_FILE_GLOBS = [
   "**/.gitlab-ci.yml",
   "**/.gitlab-ci.yaml",
@@ -7,19 +11,43 @@ export const DEFAULT_GITLAB_CI_FILE_GLOBS = [
   "**/.gitlab/**/*.yaml",
 ];
 
+/**
+ * Languages the providers explicitly support regardless of filename.
+ */
+const ALLOWED_LANGUAGE_IDS = new Set(["gitlab-ci", "shellscript"]);
+
+/**
+ * Normalise a user-supplied glob so it matches the same way users intuitively expect.
+ *
+ * `vscode.languages.match` anchors string globs at the start of the document's absolute path, so an unanchored entry
+ * never matches a real file. We prepend a globstar segment when the pattern isn't already anchored at any-depth.
+ *
+ * @param pattern - Raw glob string as supplied by the user via settings.
+ * @returns Glob string that matches at any directory depth.
+ */
+function normaliseGlob(pattern: string): string {
+  if (pattern.startsWith("**/") || pattern.startsWith("/")) return pattern;
+  return `**/${pattern}`;
+}
+
+/**
+ * Return the full set of globs that identify a GitLab CI file.
+ *
+ * @returns Combined, normalised glob list ready to feed to `vscode.languages.match`.
+ */
 export function getConfiguredFileGlobs(): string[] {
   const additional = vscode.workspace
     .getConfiguration("gitlabComponentHelper")
     .get<string[]>("additionalFileGlobs", []);
-  return [...DEFAULT_GITLAB_CI_FILE_GLOBS, ...additional];
+  return [...DEFAULT_GITLAB_CI_FILE_GLOBS, ...additional.map(normaliseGlob)];
 }
 
 /**
- *  Languages the providers explicitly support regardless of filename. `shellscript` is here because providers register
- *  on it to surface inside `script:` blocks. A globs-only check wouldn't catch those documents.
+ * Decide whether the providers should treat a document as a GitLab CI file.
+ *
+ * @param document - The text document being inspected by a provider.
+ * @returns `true` if the providers should activate on this document; `false` otherwise.
  */
-const ALLOWED_LANGUAGE_IDS = new Set(["gitlab-ci", "shellscript"]);
-
 export function isGitLabCIFile(document: vscode.TextDocument): boolean {
   if (ALLOWED_LANGUAGE_IDS.has(document.languageId)) return true;
 

--- a/src/utils/gitlabCiFileMatcher.ts
+++ b/src/utils/gitlabCiFileMatcher.ts
@@ -1,20 +1,20 @@
-import * as vscode from "vscode";
+import * as vscode from 'vscode';
 
 /**
  * Built-in glob patterns that always identify a file as a GitLab CI file. Covers the canonical entrypoint and the
  * conventional `.gitlab/` directory used for nested/included pipeline config.
  */
 export const DEFAULT_GITLAB_CI_FILE_GLOBS = [
-  "**/.gitlab-ci.yml",
-  "**/.gitlab-ci.yaml",
-  "**/.gitlab/**/*.yml",
-  "**/.gitlab/**/*.yaml",
+  '**/.gitlab-ci.yml',
+  '**/.gitlab-ci.yaml',
+  '**/.gitlab/**/*.yml',
+  '**/.gitlab/**/*.yaml',
 ];
 
 /**
- * Languages the providers explicitly support regardless of filename.
+ * Languages whose documents are always in-scope for the providers regardless of filename.
  */
-const ALLOWED_LANGUAGE_IDS = new Set(["gitlab-ci", "shellscript"]);
+const ALLOWED_LANGUAGE_IDS = new Set(['gitlab-ci', 'shellscript']);
 
 /**
  * Normalise a user-supplied glob so it matches the same way users intuitively expect.
@@ -26,20 +26,34 @@ const ALLOWED_LANGUAGE_IDS = new Set(["gitlab-ci", "shellscript"]);
  * @returns Glob string that matches at any directory depth.
  */
 function normaliseGlob(pattern: string): string {
-  if (pattern.startsWith("**/") || pattern.startsWith("/")) return pattern;
+  if (pattern.startsWith('**/') || pattern.startsWith('/')) return pattern;
   return `**/${pattern}`;
 }
 
+let cachedGlobs: string[] | undefined;
+
 /**
- * Return the full set of globs that identify a GitLab CI file.
+ * Return the full set of globs that identify a GitLab CI file. Cached after the first call to avoid re-reading config.
  *
  * @returns Combined, normalised glob list ready to feed to `vscode.languages.match`.
  */
 export function getConfiguredFileGlobs(): string[] {
+  if (cachedGlobs) return cachedGlobs;
   const additional = vscode.workspace
-    .getConfiguration("gitlabComponentHelper")
-    .get<string[]>("additionalFileGlobs", []);
-  return [...DEFAULT_GITLAB_CI_FILE_GLOBS, ...additional.map(normaliseGlob)];
+    .getConfiguration('gitlabComponentHelper')
+    .get<string[]>('additionalFileGlobs', []);
+  cachedGlobs = [
+    ...DEFAULT_GITLAB_CI_FILE_GLOBS,
+    ...additional.map(normaliseGlob),
+  ];
+  return cachedGlobs;
+}
+
+/**
+ * Drop the cached glob list so the next call to {@link getConfiguredFileGlobs} re-reads from config.
+ */
+export function invalidateFileGlobsCache(): void {
+  cachedGlobs = undefined;
 }
 
 /**

--- a/src/utils/gitlabCiFileMatcher.ts
+++ b/src/utils/gitlabCiFileMatcher.ts
@@ -1,0 +1,30 @@
+import * as vscode from "vscode";
+
+export const DEFAULT_GITLAB_CI_FILE_GLOBS = [
+  "**/.gitlab-ci.yml",
+  "**/.gitlab-ci.yaml",
+  "**/.gitlab/**/*.yml",
+  "**/.gitlab/**/*.yaml",
+];
+
+export function getConfiguredFileGlobs(): string[] {
+  const additional = vscode.workspace
+    .getConfiguration("gitlabComponentHelper")
+    .get<string[]>("additionalFileGlobs", []);
+  return [...DEFAULT_GITLAB_CI_FILE_GLOBS, ...additional];
+}
+
+/**
+ *  Languages the providers explicitly support regardless of filename. `shellscript` is here because providers register
+ *  on it to surface inside `script:` blocks. A globs-only check wouldn't catch those documents.
+ */
+const ALLOWED_LANGUAGE_IDS = new Set(["gitlab-ci", "shellscript"]);
+
+export function isGitLabCIFile(document: vscode.TextDocument): boolean {
+  if (ALLOWED_LANGUAGE_IDS.has(document.languageId)) return true;
+
+  for (const glob of getConfiguredFileGlobs()) {
+    if (vscode.languages.match({ pattern: glob }, document) > 0) return true;
+  }
+  return false;
+}

--- a/tests/unit/gitlab-ci-file-matcher.test.js
+++ b/tests/unit/gitlab-ci-file-matcher.test.js
@@ -1,13 +1,5 @@
 /**
- * GitLab CI File Matcher Behavior Contract
- *
- * Mirrors the matching contract enforced by src/utils/gitlabCiFileMatcher.ts.
- * The real helper delegates to vscode.languages.match against the union of
- * built-in defaults and gitlabComponentHelper.additionalFileGlobs. This test
- * reproduces that decision using minimatch on raw paths to lock the behaviour
- * we expect before the extension host even gets involved.
- *
- * End-to-end coverage of the helper lives in tests/extension-host.
+ * GitLab CI File Matcher behavior contract tests
  */
 /* eslint-env node */
 const assert = require('assert');

--- a/tests/unit/gitlab-ci-file-matcher.test.js
+++ b/tests/unit/gitlab-ci-file-matcher.test.js
@@ -1,0 +1,91 @@
+/**
+ * GitLab CI File Matcher Behavior Contract
+ *
+ * Mirrors the matching contract enforced by src/utils/gitlabCiFileMatcher.ts.
+ * The real helper delegates to vscode.languages.match against the union of
+ * built-in defaults and gitlabComponentHelper.additionalFileGlobs. This test
+ * reproduces that decision using minimatch on raw paths to lock the behaviour
+ * we expect before the extension host even gets involved.
+ *
+ * End-to-end coverage of the helper lives in tests/extension-host.
+ */
+/* eslint-env node */
+const assert = require('assert');
+const { minimatch } = require('minimatch');
+
+const DEFAULT_GLOBS = [
+  '**/.gitlab-ci.yml',
+  '**/.gitlab-ci.yaml',
+  '**/.gitlab/**/*.yml',
+  '**/.gitlab/**/*.yaml',
+];
+
+const ALLOWED_LANGUAGE_IDS = new Set(['gitlab-ci', 'shellscript']);
+
+function isGitLabCIFile(filePath, languageId, additionalGlobs = []) {
+  if (ALLOWED_LANGUAGE_IDS.has(languageId)) return true;
+  const globs = [...DEFAULT_GLOBS, ...additionalGlobs];
+  return globs.some(glob => minimatch(filePath, glob, { dot: true }));
+}
+
+const cases = [
+  // Canonical names always match under defaults.
+  { path: 'repo/.gitlab-ci.yml', langId: 'yaml', expected: true, label: 'canonical .yml' },
+  { path: 'repo/.gitlab-ci.yaml', langId: 'yaml', expected: true, label: 'canonical .yaml' },
+  { path: '.gitlab-ci.yml', langId: 'yaml', expected: true, label: 'root canonical' },
+
+  // .gitlab/ directory convention is matched out of the box.
+  { path: 'repo/.gitlab/ci/build.yml', langId: 'yaml', expected: true, label: '.gitlab/ nested .yml' },
+  { path: 'repo/.gitlab/pipelines/deploy.yaml', langId: 'yaml', expected: true, label: '.gitlab/ deep .yaml' },
+
+  // Non-canonical YAML outside .gitlab/ is silent under defaults.
+  { path: 'repo/ci/build.yml', langId: 'yaml', expected: false, label: 'ci/ not in defaults' },
+  { path: 'repo/pipelines/release.yaml', langId: 'yaml', expected: false, label: 'pipelines/ not in defaults' },
+  { path: 'repo/random.yml', langId: 'yaml', expected: false, label: 'unrelated yaml' },
+
+  // Language ID escape hatch: an explicit gitlab-ci association always wins.
+  { path: 'repo/anything.txt', langId: 'gitlab-ci', expected: true, label: 'gitlab-ci languageId override' },
+
+  // shellscript documents are always considered in-scope so providers can surface
+  // inside `script:` blocks regardless of filename.
+  { path: 'repo/some-script.sh', langId: 'shellscript', expected: true, label: 'shellscript language always matches' },
+  { path: 'untitled:Untitled-1', langId: 'shellscript', expected: true, label: 'untitled shellscript matches' },
+
+  // Plain YAML that no glob matches must not be treated as a GitLab CI file —
+  // this is the regression guard for validation no longer firing on arbitrary YAML.
+  { path: 'repo/docker-compose.yml', langId: 'yaml', expected: false, label: 'plain YAML, no matching glob, not GitLab CI' },
+  { path: 'repo/kustomize/base.yaml', langId: 'yaml', expected: false, label: 'arbitrary YAML in unrelated subdir' },
+];
+
+const additionalGlobs = ['**/ci/*.yml'];
+const customCases = [
+  { path: 'repo/ci/build.yml', langId: 'yaml', expected: true, label: 'ci/ now matches additional glob' },
+  { path: 'repo/ci/sub/build.yml', langId: 'yaml', expected: false, label: 'additional glob is single-level only' },
+  { path: 'repo/.gitlab-ci.yml', langId: 'yaml', expected: true, label: 'defaults still apply with additional globs' },
+];
+
+let failures = 0;
+console.log('=== gitlab-ci-file-matcher tests ===');
+
+for (const c of cases) {
+  const actual = isGitLabCIFile(c.path, c.langId);
+  if (actual !== c.expected) {
+    console.log(`  FAIL: ${c.label} — expected ${c.expected}, got ${actual} for ${c.path} (${c.langId})`);
+    failures += 1;
+  } else {
+    console.log(`  ok:   ${c.label}`);
+  }
+}
+
+for (const c of customCases) {
+  const actual = isGitLabCIFile(c.path, c.langId, additionalGlobs);
+  if (actual !== c.expected) {
+    console.log(`  FAIL: ${c.label} — expected ${c.expected}, got ${actual} for ${c.path} (${c.langId})`);
+    failures += 1;
+  } else {
+    console.log(`  ok:   ${c.label}`);
+  }
+}
+
+assert.strictEqual(failures, 0, `${failures} matcher case(s) failed`);
+console.log('All gitlab-ci-file-matcher cases passed.');

--- a/tests/unit/gitlab-ci-file-matcher.test.js
+++ b/tests/unit/gitlab-ci-file-matcher.test.js
@@ -22,9 +22,14 @@ const DEFAULT_GLOBS = [
 
 const ALLOWED_LANGUAGE_IDS = new Set(['gitlab-ci', 'shellscript']);
 
+function normaliseGlob(pattern) {
+  if (pattern.startsWith('**/') || pattern.startsWith('/')) return pattern;
+  return `**/${pattern}`;
+}
+
 function isGitLabCIFile(filePath, languageId, additionalGlobs = []) {
   if (ALLOWED_LANGUAGE_IDS.has(languageId)) return true;
-  const globs = [...DEFAULT_GLOBS, ...additionalGlobs];
+  const globs = [...DEFAULT_GLOBS, ...additionalGlobs.map(normaliseGlob)];
   return globs.some(glob => minimatch(filePath, glob, { dot: true }));
 }
 
@@ -64,6 +69,16 @@ const customCases = [
   { path: 'repo/.gitlab-ci.yml', langId: 'yaml', expected: true, label: 'defaults still apply with additional globs' },
 ];
 
+// Normalisation: a user-supplied glob without a leading `**/` or `/` is anchored
+// at the start of the absolute path by vscode.languages.match — which never matches.
+// We prefix `**/` automatically so the intuitive form works.
+const unanchoredGlobs = ['.gitlab2/**/*.yml'];
+const normalisationCases = [
+  { path: 'repo/.gitlab2/foo/bar.yml', langId: 'yaml', expected: true, label: 'unanchored user glob matches at any depth' },
+  { path: '.gitlab2/foo/bar.yml', langId: 'yaml', expected: true, label: 'unanchored user glob still matches at root' },
+  { path: 'repo/other/bar.yml', langId: 'yaml', expected: false, label: 'unanchored user glob does not over-match' },
+];
+
 let failures = 0;
 console.log('=== gitlab-ci-file-matcher tests ===');
 
@@ -79,6 +94,16 @@ for (const c of cases) {
 
 for (const c of customCases) {
   const actual = isGitLabCIFile(c.path, c.langId, additionalGlobs);
+  if (actual !== c.expected) {
+    console.log(`  FAIL: ${c.label} — expected ${c.expected}, got ${actual} for ${c.path} (${c.langId})`);
+    failures += 1;
+  } else {
+    console.log(`  ok:   ${c.label}`);
+  }
+}
+
+for (const c of normalisationCases) {
+  const actual = isGitLabCIFile(c.path, c.langId, unanchoredGlobs);
   if (actual !== c.expected) {
     console.log(`  FAIL: ${c.label} — expected ${c.expected}, got ${actual} for ${c.path} (${c.langId})`);
     failures += 1;


### PR DESCRIPTION
## Summary
- Adds `gitlabComponentHelper.additionalFileGlobs` so hover, completion, validation, and code actions activate on non-canonical GitLab CI file names (nested/included configs like `ci/build.yml`, `pipelines/deploy.yaml`). User-supplied globs are auto-normalised: an unanchored entry like `.gitlab2/**/*.yml` is treated as `**/.gitlab2/**/*.yml` so it matches at any directory depth.
- Ships built-in defaults that cover `**/.gitlab-ci.yml`, `**/.gitlab-ci.yaml`, and anything under `**/.gitlab/**/*.{yml,yaml}` — the conventional location for nested config — so `.gitlab/`-style layouts work out of the box.
- Consolidates the three near-duplicate `isGitLabCIFile` checks (hover, completion, validation) behind a single helper at `src/utils/gitlabCiFileMatcher.ts`. Globs are authoritative; `gitlab-ci` and `shellscript` documents are always-in-scope so user-defined language associations (`files.associations`) keep working. Helper memoises the combined glob list and invalidates on config change.
- Editor context-menu now gated on a `gitlabComponentHelper.isCiFile` context key that mirrors the matcher — set on activation, active-editor change, and config change — so "Browse Components" shows on exactly the documents the providers activate on, globs included.
- Link related issue(s): Closes #121

## Change Type
- [x] feat
- [ ] fix
- [x] refactor
- [ ] docs
- [ ] test
- [ ] chore

## Context
### User-facing impact
- Authors who split pipelines into multiple included files now get hover docs, completion, and include validation in those files too. The `.gitlab/` directory case requires no configuration; other layouts add a glob to `gitlabComponentHelper.additionalFileGlobs`.
- Changes to `additionalFileGlobs` take effect immediately — `workspace.onDidChangeConfiguration` re-validates open documents without a window reload.
- The legacy `fileName.includes('gitlab-ci')` substring escape hatch is gone. Files that previously activated only because their name contained the substring `gitlab-ci` (e.g. `my-gitlab-ci-helper.yml`) now need either a matching glob or the `gitlab-ci` language association. This is intentional but is the one observable narrowing — call out for the changelog.
- Validation tightening: validation no longer fires on every plain YAML document; it now requires a glob match or one of the always-in-scope language IDs (`gitlab-ci`, `shellscript`). Removes false-positive runs on unrelated YAML (Compose, k8s, etc.). shellscript documents remain always-in-scope so users who associate CI shell snippets with the shellscript language keep working.

### GitLab scope
- [ ] gitlab.com
- [ ] self-managed GitLab
- [x] both

### Affected areas
- [ ] Component Browser
- [x] Hover provider
- [x] Completion provider
- [x] Validation provider
- [ ] Cache and refresh behavior
- [ ] GitLab API calls/auth/token storage
- [ ] Docs only

## Validation
### Local checks
- [x] `npm run compile`
- [x] `npm test` or targeted tests
- [ ] Manual verification in VS Code Extension Host

### Manual test notes
- Canonical baseline: open `.gitlab-ci.yml` with a `component:` include → hover, completion, validation all behave as before.
- `.gitlab/` default: create `.gitlab/ci/build.yml` containing
  ```yaml
  include:
    - component: $CI_SERVER_FQDN/components/opentofu/full-pipeline@2.9.0
      inputs:
        terraform_version: "1.5.0"
  ```
  → providers activate without any user configuration.
- User-added glob: with `ci/build.yml` (same content) open, add `"gitlabComponentHelper.additionalFileGlobs": ["**/ci/*.yml"]` → hover/completion/validation light up immediately, no reload.
- Remove the glob → providers go silent on `ci/build.yml` while remaining active on `.gitlab/ci/build.yml`.
- Unanchored user glob: with `repo/.gitlab2/foo/bar.yml` open, add `"gitlabComponentHelper.additionalFileGlobs": [".gitlab2/**/*.yml"]` (no leading `**/`) → providers activate. The setting is auto-normalised to match at any depth.
- Context menu: right-click in `.gitlab-ci.yml`, `.gitlab/ci/build.yml`, and any file matched via a custom glob → "GitLab CI: Browse Components" appears. Right-click in `docker-compose.yml` → it does not.
- Negative case: open a `docker-compose.yml` (plain YAML, no matching glob) → matcher returns false; no diagnostics from this extension.

## Breaking Changes
- [x] No breaking changes
- [ ] Breaking changes (describe below)

No formal breaking change, but two observable narrowings worth noting:
1. The `fileName.includes('gitlab-ci')` substring escape hatch is removed. Affected users add the file's path to `additionalFileGlobs` or rely on a `gitlab-ci` language association.
2. Validation no longer fires on every plain YAML document. This is desirable (no more diagnostics on unrelated YAML like Compose or k8s manifests), and any user who genuinely had a non-canonical file working before via the substring path can opt in with `additionalFileGlobs`. shellscript documents remain always-in-scope; the narrowing is YAML-only.
3. Editor context menu now hidden on plain YAML files. Previously the `when` clause matched `gitlab-ci\.yml$`, so the menu showed on `.gitlab-ci.yml`-style files only — but in practice users opened other YAML and saw the same regex match. Now the menu uses a context key (`gitlabComponentHelper.isCiFile`) sourced from the matcher, so it appears on exactly the documents the providers activate on.

## Screenshots / Recordings (if UI behavior changed)
- n/a — no UI surface changes. Hover/completion/validation appearance is unchanged; only the set of files they activate on grows.

## Risk and Rollback
- Main risks:
  - A user relying on the removed substring escape hatch sees providers go quiet in files they expected to work. Mitigation: `additionalFileGlobs` covers every such case and is documented in the README.
  - VS Code's `GlobPattern` semantics differ subtly from minimatch in edge cases; the matcher delegates to `vscode.languages.match` to use the platform's own matcher, with the unit test mirroring expected behaviour via minimatch.
- Rollback strategy: revert this commit (single commit on the branch). Settings written by users to `additionalFileGlobs` are harmless after rollback — the old code ignores unknown settings.

## Release Notes Draft
- feat: recognise non-canonical GitLab CI file names via `additionalFileGlobs` (and out-of-the-box `**/.gitlab/**/*.{yml,yaml}`), with a single consolidated file-type matcher across providers and context menu.

## Checklist
- [x] Branch is up to date with target branch
- [x] Commit messages follow conventional commits
- [x] Added/updated docs for behavior or settings changes
- [x] Added/updated tests for new behavior
- [x] No secrets or tokens in code, logs, screenshots, or test fixtures
