### PR TITLE
feat: support local includes as first-class components

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 - **Smart Completion**: Context-aware suggestions for components and versions as you type
 - **Hover Docs**: See full documentation and parameter hints instantly
 - **Input Validation**: Real-time validation of component inputs with intelligent Quick Fix suggestions
+- **Local Includes**: Same hover, completion, and validation for `include: - local:` entries that declare a `spec.inputs` block
 - **Version/Tag Picker**: Always use the right version—no more guessing
 - **Variable Expansion**: Full support for GitLab CI/CD variables in URLs and parameters
 - **Lightning Fast**: Caching, batch API calls, and performance optimizations for huge catalogs
@@ -61,6 +62,18 @@ include:
       workspace: "default"
       apply: true
 ```
+
+Local templates work too — point a `- local:` entry at any workspace YAML that declares a `spec.inputs` block and you get the same hover, completion, and validation as a catalog component:
+
+```yaml
+include:
+  - local: "gitlab/templates/nx-test.yml"
+    inputs:
+      job_name: test-nightly
+      job_type: nightly
+```
+
+The target file is resolved relative to the workspace root and re-read on demand, so edits to the template are picked up immediately.
 
 ### 🎬 Adding Component Inputs
 ![insertInputs](https://github.com/user-attachments/assets/098f4eaf-3c4a-45a8-9caf-9a1351730b93)

--- a/README.md
+++ b/README.md
@@ -73,8 +73,6 @@ include:
       job_type: nightly
 ```
 
-The target file is resolved relative to the workspace root and re-read on demand, so edits to the template are picked up immediately.
-
 ### 🎬 Adding Component Inputs
 ![insertInputs](https://github.com/user-attachments/assets/098f4eaf-3c4a-45a8-9caf-9a1351730b93)
 

--- a/src/providers/completionProvider.ts
+++ b/src/providers/completionProvider.ts
@@ -6,6 +6,7 @@ import { getComponentCacheManager } from '../services/cache/componentCacheManage
 import { getVariableCompletions, GITLAB_PREDEFINED_VARIABLES, containsGitLabVariables, expandComponentUrl } from '../utils/gitlabVariables';
 import { Logger } from '../utils/logger';
 import { isGitLabCIFile } from '../utils/gitlabCiFileMatcher';
+import { resolveLocalComponent } from './localComponentResolver';
 
 export class CompletionProvider implements vscode.CompletionItemProvider {
   private logger = Logger.getInstance();
@@ -394,15 +395,15 @@ export class CompletionProvider implements vscode.CompletionItemProvider {
 
       // Find which component's inputs section we're in
       for (const include of includes) {
-        if (!include.component) continue;
-
-        // Find the component in the document text
-        const componentUrl = include.component;
+        const isLocal = !!include.local && !include.component;
+        const componentUrl = include.component ?? include.local;
+        if (!componentUrl) continue;
+        const includeKey = isLocal ? 'local:' : 'component:';
 
         // Look for this component's position in the file
         let componentLineIndex = -1;
         for (let i = 0; i < lines.length; i++) {
-          if (lines[i].includes('component:') && lines[i].includes(componentUrl)) {
+          if (lines[i].includes(includeKey) && lines[i].includes(componentUrl)) {
             componentLineIndex = i;
             break;
           }
@@ -415,7 +416,7 @@ export class CompletionProvider implements vscode.CompletionItemProvider {
           const distance = currentLineIndex - componentLineIndex;
           if (distance < closestDistance) {
             closestDistance = distance;
-            closestComponent = { include, componentLineIndex, componentUrl };
+            closestComponent = { include, componentLineIndex, componentUrl, isLocal };
           }
         }
       }
@@ -485,9 +486,11 @@ export class CompletionProvider implements vscode.CompletionItemProvider {
           return null;
         }
 
-        // Get the component details from cache - need exact match for the specific template
-        this.logger.debug(`[CompletionProvider] Looking up component in cache: ${componentUrl}`, 'CompletionProvider');
-        const component = await this.findComponentInCache(componentUrl, document.uri);
+        // Get the component details - local includes resolve from the workspace file, others from cache.
+        this.logger.debug(`[CompletionProvider] Looking up component: ${componentUrl} (local=${closestComponent.isLocal})`, 'CompletionProvider');
+        const component = closestComponent.isLocal
+          ? await resolveLocalComponent(componentUrl, document)
+          : await this.findComponentInCache(componentUrl, document.uri);
         if (!component || !component.parameters) {
           this.logger.debug(`[CompletionProvider] Component not found in cache or has no parameters: ${componentUrl}`, 'CompletionProvider');
           return null;

--- a/src/providers/componentDetector.ts
+++ b/src/providers/componentDetector.ts
@@ -5,6 +5,7 @@ import { GitLabCatalogComponent, GitLabCatalogVariable } from '../types/gitlab-c
 import { expandGitLabVariables, containsGitLabVariables, detectGitLabVariables, expandComponentUrl } from '../utils/gitlabVariables';
 import { Logger } from '../utils/logger';
 import { spawn } from 'child_process';
+import { detectLocalIncludeComponent } from './localComponentResolver';
 
 const logger = Logger.getInstance();
 
@@ -80,6 +81,11 @@ export async function getComponentUnderCursor(document: vscode.TextDocument, pos
 export async function detectIncludeComponent(document: vscode.TextDocument, position: vscode.Position): Promise<Component | null> {
   const line = document.lineAt(position.line).text;
   logger.debug(`[ComponentDetector] Checking line for include component: ${line}`, 'ComponentDetector');
+
+  const localComponent = await detectLocalIncludeComponent(document, position);
+  if (localComponent) {
+    return localComponent;
+  }
 
   // Extract component URL from the line - handle both absolute URLs and those with GitLab variables
   let componentUrl = line.match(/component:\s*([^\s]+)/)?.[1];

--- a/src/providers/hoverProvider.ts
+++ b/src/providers/hoverProvider.ts
@@ -173,14 +173,15 @@ export class HoverProvider implements vscode.HoverProvider {
       let closestDistance = Infinity;
 
       for (const include of includes) {
-        if (!include.component) continue;
-
-        const componentUrl = include.component;
+        const isLocal = !!include.local && !include.component;
+        const componentUrl = include.component ?? include.local;
+        if (!componentUrl) continue;
+        const includeKey = isLocal ? 'local:' : 'component:';
 
         // Find this component's position in the file
         let componentLineIndex = -1;
         for (let i = 0; i < lines.length; i++) {
-          if (lines[i].includes('component:') && lines[i].includes(componentUrl)) {
+          if (lines[i].includes(includeKey) && lines[i].includes(componentUrl)) {
             componentLineIndex = i;
             break;
           }

--- a/src/providers/localComponentResolver.ts
+++ b/src/providers/localComponentResolver.ts
@@ -1,0 +1,122 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as yaml from 'js-yaml';
+import { Component, ComponentParameter } from './componentDetector';
+import { Logger } from '../utils/logger';
+
+const logger = Logger.getInstance();
+
+export const LOCAL_COMPONENT_URL_PREFIX = 'local://';
+
+export function extractLocalIncludePath(line: string): string | null {
+  const match = line.match(/^\s*-?\s*local:\s*["']?([^"'\s]+)["']?\s*$/);
+  return match ? match[1] : null;
+}
+
+export function isLocalComponentUrl(url: string | undefined): boolean {
+  return !!url && url.startsWith(LOCAL_COMPONENT_URL_PREFIX);
+}
+
+export function buildLocalComponentUrl(relativePath: string): string {
+  const normalised = relativePath.replace(/^\/+/, '');
+  return `${LOCAL_COMPONENT_URL_PREFIX}${normalised}`;
+}
+
+function getWorkspaceRoot(document?: vscode.TextDocument): vscode.Uri | null {
+  if (document) {
+    const folder = vscode.workspace.getWorkspaceFolder(document.uri);
+    if (folder) {
+      return folder.uri;
+    }
+  }
+  const folders = vscode.workspace.workspaceFolders;
+  return folders && folders.length > 0 ? folders[0].uri : null;
+}
+
+export function resolveLocalIncludeUri(localPath: string, document?: vscode.TextDocument): vscode.Uri | null {
+  const root = getWorkspaceRoot(document);
+  if (!root) {
+    return null;
+  }
+  const relative = localPath.replace(/^\/+/, '');
+  return vscode.Uri.joinPath(root, ...relative.split('/'));
+}
+
+function parseInputs(specInputs: any): ComponentParameter[] {
+  if (!specInputs || typeof specInputs !== 'object') {
+    return [];
+  }
+  return Object.entries(specInputs).map(([name, raw]) => {
+    const definition = (raw && typeof raw === 'object' ? raw : {}) as Record<string, any>;
+    return {
+      name,
+      description: typeof definition.description === 'string' ? definition.description : '',
+      required: definition.default === undefined,
+      type: typeof definition.type === 'string' ? definition.type : 'string',
+      default: definition.default,
+    };
+  });
+}
+
+export async function resolveLocalComponent(
+  localPath: string,
+  document?: vscode.TextDocument
+): Promise<Component | null> {
+  const uri = resolveLocalIncludeUri(localPath, document);
+  if (!uri) {
+    logger.debug(`[LocalComponentResolver] No workspace root available to resolve: ${localPath}`, 'LocalComponentResolver');
+    return null;
+  }
+
+  let bytes: Uint8Array;
+  try {
+    bytes = await vscode.workspace.fs.readFile(uri);
+  } catch (err) {
+    logger.debug(`[LocalComponentResolver] Could not read ${uri.fsPath}: ${err}`, 'LocalComponentResolver');
+    return null;
+  }
+
+  const text = Buffer.from(bytes).toString('utf8');
+  let docs: unknown[];
+  try {
+    docs = yaml.loadAll(text);
+  } catch (err) {
+    logger.debug(`[LocalComponentResolver] Failed to parse ${uri.fsPath}: ${err}`, 'LocalComponentResolver');
+    return null;
+  }
+  const specDoc = docs.find(
+    (d): d is { spec?: { inputs?: unknown } } => !!d && typeof d === 'object' && 'spec' in d
+  );
+  if (!specDoc) {
+    logger.debug(`[LocalComponentResolver] ${uri.fsPath} has no spec document`, 'LocalComponentResolver');
+    return null;
+  }
+
+  const specInputs = specDoc.spec && specDoc.spec.inputs;
+  const parameters = parseInputs(specInputs);
+  const displayName = path.basename(localPath);
+  const url = buildLocalComponentUrl(localPath);
+
+  return {
+    name: displayName,
+    description: `Local include: \`${localPath}\``,
+    parameters,
+    source: 'local',
+    url,
+    originalUrl: url,
+    sourcePath: localPath,
+  };
+}
+
+export async function detectLocalIncludeComponent(
+  document: vscode.TextDocument,
+  position: vscode.Position
+): Promise<Component | null> {
+  const line = document.lineAt(position.line).text;
+  const localPath = extractLocalIncludePath(line);
+  if (!localPath) {
+    return null;
+  }
+  logger.debug(`[LocalComponentResolver] Detected local include: ${localPath}`, 'LocalComponentResolver');
+  return resolveLocalComponent(localPath, document);
+}

--- a/src/providers/localComponentResolver.ts
+++ b/src/providers/localComponentResolver.ts
@@ -8,21 +8,109 @@ const logger = Logger.getInstance();
 
 export const LOCAL_COMPONENT_URL_PREFIX = 'local://';
 
+const GLOB_CHARS = /[*?[\]{}]/;
+
+/**
+ * Extract the path string from a single line that looks like an `include: - local:` entry.
+ *
+ * Accepts quoted, single-quoted, and unquoted forms, with or without the leading list dash. The regex is deliberately
+ * line-anchored (`^...$`) so a stray `local:` token inside a value or comment elsewhere on the line won't match.
+ *
+ * @param line  A raw document line, exactly as returned by `vscode.TextDocument.lineAt(...).text`.
+ * @returns     The path string with surrounding quotes stripped, or `null` if the line isn't a `local:` include.
+ */
 export function extractLocalIncludePath(line: string): string | null {
   const match = line.match(/^\s*-?\s*local:\s*["']?([^"'\s]+)["']?\s*$/);
   return match ? match[1] : null;
 }
 
+/**
+ * Test whether a URL string identifies a synthetic local-include "component" produced by this resolver.
+ *
+ * The resolver tags every local-source `Component` with a `local://<path>` URL so the rest of the providers can
+ * distinguish them from real catalog component URLs without inspecting the `source` field.
+ *
+ * @param url  Candidate URL — usually `Component.url`. `undefined` is treated as not-local for caller convenience.
+ * @returns    `true` if the URL begins with the local-component prefix; `false` otherwise.
+ */
 export function isLocalComponentUrl(url: string | undefined): boolean {
   return !!url && url.startsWith(LOCAL_COMPONENT_URL_PREFIX);
 }
 
+/**
+ * Build the synthetic `local://<path>` URL used to tag local-source components.
+ *
+ * Leading slashes on the relative path are stripped first so `local:///x` and `local:/x` never appear in cached
+ * URLs — the prefix and the path stay cleanly separated.
+ *
+ * @param relativePath  Workspace-relative path of the include target.
+ * @returns             A `local://`-prefixed URL suitable for `Component.url` / `Component.originalUrl`.
+ */
 export function buildLocalComponentUrl(relativePath: string): string {
   const normalised = relativePath.replace(/^\/+/, '');
   return `${LOCAL_COMPONENT_URL_PREFIX}${normalised}`;
 }
 
-function getWorkspaceRoot(document?: vscode.TextDocument): vscode.Uri | null {
+/**
+ * Detect `local:` paths the resolver refuses to handle: glob patterns (`*`, `?`, `[`, `]`, `{`, `}`) and traversal
+ * segments (`..`).
+ *
+ * @param localPath  The raw path string from a parsed `include: - local:` entry.
+ * @returns          `true` if the path contains glob metacharacters or a `..` segment; `false` otherwise.
+ */
+export function isUnsupportedLocalPath(localPath: string): boolean {
+  if (GLOB_CHARS.test(localPath)) {
+    return true;
+  }
+  if (localPath.split('/').some((segment) => segment === '..')) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Look up the git repository root that contains the given document via VS Code's built-in Git extension.
+ *
+ * Returns `null` if there's no document, no Git extension, or the document doesn't live inside a known repo. Errors
+ * thrown by the Git extension API are caught and logged at debug level.
+ *
+ * @param document  The active document. Resolution is anchored on its URI so multi-repo workspaces map correctly.
+ * @returns         The repo's `rootUri`, or `null` if it can't be determined.
+ */
+function getRepositoryRoot(document?: vscode.TextDocument): vscode.Uri | null {
+  if (!document) {
+    return null;
+  }
+  try {
+    const gitExtension = vscode.extensions.getExtension('vscode.git');
+    if (gitExtension) {
+      const git = gitExtension.exports.getAPI(1);
+      const repo = git?.getRepository?.(document.uri);
+      if (repo?.rootUri) {
+        return repo.rootUri as vscode.Uri;
+      }
+    }
+  } catch (err) {
+    logger.debug(`[LocalComponentResolver] Git extension lookup failed: ${err}`, 'LocalComponentResolver');
+  }
+  return null;
+}
+
+/**
+ * Pick the URI that `local:` paths resolve against. Prefers the git repo root (matching GitLab's own semantics);
+ * falls back to the document's workspace folder, then to the first workspace folder, then `null`.
+ *
+ * The fallback chain matters for unsaved buffers, no-Git workspaces, and tests — none of these have a real repo root
+ * but most can still resolve a sensible workspace-relative path.
+ *
+ * @param document  The active document being processed. Used for both the repo lookup and the workspace-folder fallback.
+ * @returns         The root URI to join `local:` paths against, or `null` if no usable root exists.
+ */
+function getResolutionRoot(document?: vscode.TextDocument): vscode.Uri | null {
+  const repoRoot = getRepositoryRoot(document);
+  if (repoRoot) {
+    return repoRoot;
+  }
   if (document) {
     const folder = vscode.workspace.getWorkspaceFolder(document.uri);
     if (folder) {
@@ -33,8 +121,18 @@ function getWorkspaceRoot(document?: vscode.TextDocument): vscode.Uri | null {
   return folders && folders.length > 0 ? folders[0].uri : null;
 }
 
+/**
+ * Resolve a `local:` path string to an absolute URI against the chosen resolution root.
+ *
+ * Leading slashes are tolerated (GitLab itself accepts both `/templates/x.yml` and `templates/x.yml`) and stripped
+ * before joining, so the result never contains a doubled separator.
+ *
+ * @param localPath  The raw path string from a parsed `include: - local:` entry.
+ * @param document   The active document, used to determine the resolution root.
+ * @returns          The resolved absolute URI, or `null` if no resolution root is available.
+ */
 export function resolveLocalIncludeUri(localPath: string, document?: vscode.TextDocument): vscode.Uri | null {
-  const root = getWorkspaceRoot(document);
+  const root = getResolutionRoot(document);
   if (!root) {
     return null;
   }
@@ -42,6 +140,16 @@ export function resolveLocalIncludeUri(localPath: string, document?: vscode.Text
   return vscode.Uri.joinPath(root, ...relative.split('/'));
 }
 
+/**
+ * Convert a parsed `spec.inputs` block into the `ComponentParameter[]` shape the rest of the providers consume.
+ *
+ * Mirrors GitLab's own input contract: a parameter is treated as required when no `default` is supplied. Missing or
+ * non-string `description` / `type` fields collapse to safe defaults rather than throwing — the resolver never wants
+ * to fail on a malformed-but-readable template since that just produces user-visible spurious diagnostics.
+ *
+ * @param specInputs  The raw `spec.inputs` object from a parsed YAML document; may be `undefined`, `null`, or any value.
+ * @returns           A normalised array of input definitions, or `[]` when `specInputs` isn't an object.
+ */
 function parseInputs(specInputs: any): ComponentParameter[] {
   if (!specInputs || typeof specInputs !== 'object') {
     return [];
@@ -58,25 +166,65 @@ function parseInputs(specInputs: any): ComponentParameter[] {
   });
 }
 
-export async function resolveLocalComponent(
-  localPath: string,
-  document?: vscode.TextDocument
-): Promise<Component | null> {
-  const uri = resolveLocalIncludeUri(localPath, document);
-  if (!uri) {
-    logger.debug(`[LocalComponentResolver] No workspace root available to resolve: ${localPath}`, 'LocalComponentResolver');
-    return null;
+/**
+ * Read the text content of a local include target, preferring the open editor buffer over the on-disk file.
+ *
+ * Reading from the open buffer surfaces unsaved edits immediately — without this, hovering an input on the consumer
+ * file would show stale parameters whenever the template was edited but not yet saved. Falls back to
+ * `vscode.workspace.fs.readFile` when the target isn't open in any editor. Read failures are logged at debug level
+ * and surface to the caller as `null` so they can be converted into the right user-facing signal (e.g. a not-found
+ * diagnostic from the validation provider, or a silent skip from the hover/completion providers).
+ *
+ * @param uri  The resolved absolute URI of the include target.
+ * @returns    The file's text, or `null` if the file can't be read.
+ */
+async function readIncludeTarget(uri: vscode.Uri): Promise<string | null> {
+  const openDoc = vscode.workspace.textDocuments.find((d) => d.uri.toString() === uri.toString());
+  if (openDoc) {
+    return openDoc.getText();
   }
-
-  let bytes: Uint8Array;
   try {
-    bytes = await vscode.workspace.fs.readFile(uri);
+    const bytes = await vscode.workspace.fs.readFile(uri);
+    return Buffer.from(bytes).toString('utf8');
   } catch (err) {
     logger.debug(`[LocalComponentResolver] Could not read ${uri.fsPath}: ${err}`, 'LocalComponentResolver');
     return null;
   }
+}
 
-  const text = Buffer.from(bytes).toString('utf8');
+/**
+ * Resolve a local include path into a synthetic `Component` so the rest of the providers can treat it identically to
+ * a catalog component. Reads the target file (preferring an open editor buffer), parses every YAML document in it,
+ * picks the first one declaring `spec`, and maps `spec.inputs` onto `ComponentParameter[]`.
+ *
+ * Returns `null` for several distinct reasons, all of which the caller treats the same way (no spurious diagnostics):
+ *   - the path is a glob or contains `..` (see `isUnsupportedLocalPath`)
+ *   - no resolution root is available (no document, no Git repo, no workspace folder)
+ *   - the file doesn't exist or can't be read
+ *   - the file parses but has no `spec` block (a legitimate plain include, not a parameterised template)
+ *
+ * @param localPath  The raw path string from a parsed `include: - local:` entry.
+ * @param document   The document making the include. Used to determine the resolution root and the open-buffer fast path.
+ * @returns          A `Component` describing the local template, or `null` if no usable component can be produced.
+ */
+export async function resolveLocalComponent(
+  localPath: string,
+  document?: vscode.TextDocument
+): Promise<Component | null> {
+  if (isUnsupportedLocalPath(localPath)) {
+    return null;
+  }
+
+  const uri = resolveLocalIncludeUri(localPath, document);
+  if (!uri) {
+    logger.debug(`[LocalComponentResolver] No resolution root available for: ${localPath}`, 'LocalComponentResolver');
+    return null;
+  }
+
+  const text = await readIncludeTarget(uri);
+  if (text === null) {
+    return null;
+  }
   let docs: unknown[];
   try {
     docs = yaml.loadAll(text);
@@ -108,6 +256,18 @@ export async function resolveLocalComponent(
   };
 }
 
+/**
+ * Position-driven entry point for detecting a local include component at a cursor position. Used by
+ * `componentDetector.detectIncludeComponent` to short-circuit catalog lookups when the line is a `- local:` entry.
+ *
+ * Only looks at the single line under the cursor — if the cursor isn't on a `local:` line, returns `null` immediately
+ * without any file I/O. When it is, delegates to `resolveLocalComponent` which handles every downstream concern
+ * (unsupported paths, file reading, YAML parsing, the "no spec block" case).
+ *
+ * @param document  The active document.
+ * @param position  The cursor position; only `position.line` is consulted.
+ * @returns         The resolved local `Component`, or `null` if the line isn't a local include or can't be resolved.
+ */
 export async function detectLocalIncludeComponent(
   document: vscode.TextDocument,
   position: vscode.Position

--- a/src/providers/validationProvider.ts
+++ b/src/providers/validationProvider.ts
@@ -2,11 +2,12 @@ import * as vscode from 'vscode';
 import { getComponentService } from '../services/component';
 import { getComponentCacheManager } from '../services/cache/componentCacheManager';
 import { parseYaml } from '../utils/yamlParser';
-import { Component } from '../types/git-component';
+import { Component, ComponentParameter } from '../types/git-component';
 import { Logger } from '../utils/logger';
 import { expandComponentUrl, containsGitLabVariables } from '../utils/gitlabVariables';
 import { isGitLabCIFile } from '../utils/gitlabCiFileMatcher';
 import { spawn } from 'child_process';
+import { resolveLocalComponent } from './localComponentResolver';
 
 export class ValidationProvider implements vscode.CodeActionProvider {
     private diagnosticCollection: vscode.DiagnosticCollection;
@@ -113,6 +114,10 @@ export class ValidationProvider implements vscode.CodeActionProvider {
 
         for (let includeIndex = 0; includeIndex < includes.length; includeIndex++) {
             const include = includes[includeIndex];
+            if (include.local && !include.component) {
+                await this.validateLocalInclude(document, include, diagnostics, diagnosticKeys);
+                continue;
+            }
             if (include.component) {
                 const componentUrl = include.component;
                 this.logger.debug(`[ValidationProvider] Processing component ${includeIndex + 1}/${includes.length}: ${componentUrl}`, 'ValidationProvider');
@@ -817,21 +822,129 @@ export class ValidationProvider implements vscode.CodeActionProvider {
         return componentLine;
     }
 
+    /**
+     * Validate a single `include: - local:` entry. Resolves the target file relative to the workspace, parses its
+     * `spec.inputs` block, and reports diagnostics for unknown inputs, missing required inputs, and unresolvable
+     * file paths. Returns silently when the resolved file has no `spec.inputs` (it's a plain include, not a
+     * parameterised template).
+     *
+     * @param document        The document being validated — used to read line text for diagnostic ranges and to
+     *                        anchor workspace-relative path resolution.
+     * @param include         The parsed YAML include node, narrowed to the local-include shape: `local` is the
+     *                        workspace-relative path, `inputs` is the optional user-supplied input map.
+     * @param diagnostics     Accumulator array. New diagnostics are pushed onto it; the caller owns publishing
+     *                        the final list to the diagnostic collection.
+     * @param diagnosticKeys  Dedup set shared across the whole validation pass. Prevents duplicate
+     *                        `unknown-input` diagnostics for the same input on the same line.
+     * @returns               Resolves once all diagnostics for this include have been pushed. Never rejects —
+     *                        resolution or parse failures surface as warning diagnostics, not exceptions.
+     */
+    private async validateLocalInclude(
+        document: vscode.TextDocument,
+        include: { local: string; inputs?: Record<string, unknown> },
+        diagnostics: vscode.Diagnostic[],
+        diagnosticKeys: Set<string>
+    ): Promise<void> {
+        const localPath = include.local;
+        this.logger.debug(`[ValidationProvider] Processing local include: ${localPath}`, 'ValidationProvider');
+
+        const component = await resolveLocalComponent(localPath, document);
+        if (!component) {
+            const line = this.findLineForComponent(document, include);
+            const range = new vscode.Range(line, 0, line, document.lineAt(line).text.length);
+            const diagnostic = new vscode.Diagnostic(
+                range,
+                `Unable to resolve local include '${localPath}'. File not found or unreadable.`,
+                vscode.DiagnosticSeverity.Warning
+            );
+            diagnostic.code = 'local-include-not-found';
+            diagnostic.source = 'gitlab-component-helper';
+            diagnostics.push(diagnostic);
+            return;
+        }
+
+        if (!component.parameters || component.parameters.length === 0) {
+            this.logger.debug(`[ValidationProvider] Local include has no spec.inputs, skipping input validation: ${localPath}`, 'ValidationProvider');
+            return;
+        }
+
+        const providedInputs: Record<string, unknown> = include.inputs || {};
+        const componentInputs: ComponentParameter[] = component.parameters;
+
+        for (const providedInput of Object.keys(providedInputs)) {
+            if (componentInputs.some(p => p.name === providedInput)) {
+                continue;
+            }
+            const line = this.findLineForInput(document, include, providedInput);
+            const diagnosticKey = `unknown-input-${line}-${providedInput}-${localPath}`;
+            if (diagnosticKeys.has(diagnosticKey)) continue;
+            diagnosticKeys.add(diagnosticKey);
+
+            const lineText = document.lineAt(line).text;
+            const inputIndex = lineText.indexOf(`${providedInput}:`);
+            const range = inputIndex !== -1
+                ? new vscode.Range(line, inputIndex, line, inputIndex + providedInput.length)
+                : new vscode.Range(line, 0, line, lineText.length);
+
+            const diagnostic = new vscode.Diagnostic(
+                range,
+                `Unknown input '${providedInput}' for local include '${component.name}'.`,
+                vscode.DiagnosticSeverity.Warning
+            );
+            diagnostic.code = 'unknown-input';
+            diagnostic.source = 'gitlab-component-helper';
+            (diagnostic as vscode.Diagnostic & { metadata?: unknown }).metadata = {
+                componentName: component.name,
+                componentUrl: localPath,
+                unknownInput: providedInput,
+                availableInputs: componentInputs.map(p => p.name),
+                componentInputs,
+                currentInputOnly: true,
+            };
+            diagnostics.push(diagnostic);
+        }
+
+        for (const componentInput of componentInputs) {
+            if (componentInput.required && !Object.prototype.hasOwnProperty.call(providedInputs, componentInput.name)) {
+                const line = this.findLineForComponent(document, include);
+                const range = new vscode.Range(line, 0, line, document.lineAt(line).text.length);
+                const diagnostic = new vscode.Diagnostic(
+                    range,
+                    `Missing required input '${componentInput.name}' for local include '${component.name}'.`,
+                    vscode.DiagnosticSeverity.Error
+                );
+                diagnostic.code = 'missing-required-input';
+                diagnostic.source = 'gitlab-component-helper';
+                (diagnostic as vscode.Diagnostic & { metadata?: unknown }).metadata = {
+                    componentName: component.name,
+                    componentUrl: localPath,
+                    missingInput: componentInput.name,
+                    inputDescription: componentInput.description,
+                    inputType: componentInput.type,
+                    inputDefault: componentInput.default,
+                    providedInputs: Object.keys(providedInputs),
+                };
+                diagnostics.push(diagnostic);
+            }
+        }
+    }
+
     private findLineForComponent(document: vscode.TextDocument, include: any): number {
         const text = document.getText();
         const lines = text.split('\n');
-        const componentUrl = include.component;
+        const componentUrl = include.component ?? include.local;
+        const includeKey = include.component ? 'component:' : 'local:';
 
-        this.logger.debug(`[ValidationProvider] Looking for component URL: ${componentUrl}`, 'ValidationProvider');
+        this.logger.debug(`[ValidationProvider] Looking for include URL: ${componentUrl}`, 'ValidationProvider');
 
         for (let i = 0; i < lines.length; i++) {
             const line = lines[i];
-            if (line.includes(componentUrl)) {
-                this.logger.debug(`[ValidationProvider] Found component URL at line ${i}: ${line.trim()}`, 'ValidationProvider');
+            if (line.includes(includeKey) && line.includes(componentUrl)) {
+                this.logger.debug(`[ValidationProvider] Found include at line ${i}: ${line.trim()}`, 'ValidationProvider');
                 return i;
             }
         }
-        this.logger.debug(`[ValidationProvider] Component URL not found, returning 0`, 'ValidationProvider');
+        this.logger.debug(`[ValidationProvider] Include URL not found, returning 0`, 'ValidationProvider');
         return 0;
     }
 

--- a/src/providers/validationProvider.ts
+++ b/src/providers/validationProvider.ts
@@ -7,7 +7,7 @@ import { Logger } from '../utils/logger';
 import { expandComponentUrl, containsGitLabVariables } from '../utils/gitlabVariables';
 import { isGitLabCIFile } from '../utils/gitlabCiFileMatcher';
 import { spawn } from 'child_process';
-import { resolveLocalComponent } from './localComponentResolver';
+import { resolveLocalComponent, isUnsupportedLocalPath } from './localComponentResolver';
 
 export class ValidationProvider implements vscode.CodeActionProvider {
     private diagnosticCollection: vscode.DiagnosticCollection;
@@ -847,6 +847,11 @@ export class ValidationProvider implements vscode.CodeActionProvider {
     ): Promise<void> {
         const localPath = include.local;
         this.logger.debug(`[ValidationProvider] Processing local include: ${localPath}`, 'ValidationProvider');
+
+        if (isUnsupportedLocalPath(localPath)) {
+            // Globs and `../` paths are intentionally not handled; skip without diagnostics.
+            return;
+        }
 
         const component = await resolveLocalComponent(localPath, document);
         if (!component) {

--- a/tests/extension-host/runTest.ts
+++ b/tests/extension-host/runTest.ts
@@ -12,7 +12,7 @@ import { runTests } from '@vscode/test-electron';
  */
 async function main(): Promise<void> {
   try {
-    const extensionDevelopmentPath = path.resolve(__dirname, '..', '..');
+    const extensionDevelopmentPath = path.resolve(__dirname, '..');
     const extensionTestsPath = path.resolve(__dirname, 'suite', 'index.js');
     const workspace = path.resolve(extensionDevelopmentPath, 'tests', 'fixtures');
 

--- a/tests/extension-host/suite/localInclude.test.ts
+++ b/tests/extension-host/suite/localInclude.test.ts
@@ -105,4 +105,19 @@ suite('Local include support', () => {
       `expected a local-include-not-found diagnostic. Got: ${JSON.stringify(diags.map((d) => ({ code: d.code, msg: d.message })))}`
     );
   });
+
+  test('missing required input under a - local: produces a missing-required-input diagnostic', async () => {
+    const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(FIXTURE));
+    await vscode.window.showTextDocument(doc);
+
+    const diags = await waitForDiagnostics(doc.uri);
+    const ourDiags = diags.filter((d) => d.source === 'gitlab-component-helper');
+    const missing = ourDiags.find(
+      (d) => d.code === 'missing-required-input' && /runner_tag/.test(d.message)
+    );
+    assert.ok(
+      missing,
+      `expected a missing-required-input diagnostic for runner_tag. Got: ${JSON.stringify(ourDiags.map((d) => ({ code: d.code, msg: d.message })))}`
+    );
+  });
 });

--- a/tests/extension-host/suite/localInclude.test.ts
+++ b/tests/extension-host/suite/localInclude.test.ts
@@ -1,0 +1,108 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+const EXTENSION_ID = 'eFAILution.gitlab-component-helper';
+
+// __dirname is <repo>/out-test/suite at runtime; fixtures live under tests/fixtures.
+const FIXTURE_DIR = path.resolve(__dirname, '..', '..', 'tests', 'fixtures', 'local-include');
+const FIXTURE = path.join(FIXTURE_DIR, '.gitlab-ci.yml');
+
+async function ensureActive(): Promise<void> {
+  const ext = vscode.extensions.getExtension(EXTENSION_ID);
+  assert.ok(ext);
+  if (!ext.isActive) await ext.activate();
+}
+
+function renderHoverContents(hovers: vscode.Hover[]): string {
+  return hovers
+    .flatMap((h) => h.contents.map((c) => (typeof c === 'string' ? c : c.value)))
+    .join('\n');
+}
+
+async function waitForDiagnostics(uri: vscode.Uri, timeoutMs = 5000): Promise<vscode.Diagnostic[]> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const diags = vscode.languages.getDiagnostics(uri);
+    if (diags.length > 0) return diags;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  return vscode.languages.getDiagnostics(uri);
+}
+
+suite('Local include support', () => {
+  suiteSetup(ensureActive);
+
+  test('hovering on a - local: line surfaces spec.inputs parameters', async () => {
+    const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(FIXTURE));
+    await vscode.window.showTextDocument(doc);
+
+    const text = doc.getText();
+    const offset = text.indexOf('local: "local-include/templates/nx-test.yml"');
+    assert.ok(offset > 0, 'fixture missing local: include line');
+    const position = doc.positionAt(offset + 8); // land on the `local:` token
+
+    const hovers = (await vscode.commands.executeCommand<vscode.Hover[]>(
+      'vscode.executeHoverProvider',
+      doc.uri,
+      position
+    )) || [];
+
+    assert.ok(hovers.length > 0, 'expected a hover result on the local include line');
+    const rendered = renderHoverContents(hovers);
+    assert.match(rendered, /job_name/, 'hover should list job_name input from spec.inputs');
+    assert.match(rendered, /job_type/, 'hover should list job_type input from spec.inputs');
+  });
+
+  test('hovering on an input parameter under a - local: shows parameter docs', async () => {
+    const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(FIXTURE));
+    await vscode.window.showTextDocument(doc);
+
+    const text = doc.getText();
+    const offset = text.indexOf('job_type: nightly');
+    assert.ok(offset > 0, 'fixture missing job_type input line');
+    const position = doc.positionAt(offset + 3); // land inside `job_type`
+
+    const hovers = (await vscode.commands.executeCommand<vscode.Hover[]>(
+      'vscode.executeHoverProvider',
+      doc.uri,
+      position
+    )) || [];
+
+    const rendered = renderHoverContents(hovers);
+    assert.match(
+      rendered,
+      /Input Parameter|job_type/i,
+      'hover on an input param should produce parameter info from the local template'
+    );
+  });
+
+  test('unknown input under a - local: produces a validation diagnostic', async () => {
+    const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(FIXTURE));
+    await vscode.window.showTextDocument(doc);
+
+    const diags = await waitForDiagnostics(doc.uri);
+    const ourDiags = diags.filter((d) => d.source === 'gitlab-component-helper');
+    const unknown = ourDiags.find(
+      (d) => d.code === 'unknown-input' && /bogus_input/.test(d.message)
+    );
+    assert.ok(
+      unknown,
+      `expected an unknown-input diagnostic for bogus_input. Got: ${JSON.stringify(ourDiags.map((d) => ({ code: d.code, msg: d.message })))}`
+    );
+  });
+
+  test('missing local include file produces a not-found diagnostic', async () => {
+    const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(FIXTURE));
+    await vscode.window.showTextDocument(doc);
+
+    const diags = await waitForDiagnostics(doc.uri);
+    const notFound = diags.find(
+      (d) => d.source === 'gitlab-component-helper' && d.code === 'local-include-not-found'
+    );
+    assert.ok(
+      notFound,
+      `expected a local-include-not-found diagnostic. Got: ${JSON.stringify(diags.map((d) => ({ code: d.code, msg: d.message })))}`
+    );
+  });
+});

--- a/tests/fixtures/local-include/.gitlab-ci.yml
+++ b/tests/fixtures/local-include/.gitlab-ci.yml
@@ -1,0 +1,10 @@
+include:
+  - local: "local-include/templates/nx-test.yml"
+    inputs:
+      job_name: test-nightly
+      job_type: nightly
+      bogus_input: oops
+
+  - local: "local-include/no-spec.yml"
+
+  - local: "local-include/missing-template.yml"

--- a/tests/fixtures/local-include/no-spec.yml
+++ b/tests/fixtures/local-include/no-spec.yml
@@ -1,0 +1,6 @@
+stages:
+  - build
+
+build:
+  script:
+    - echo "no spec block here"

--- a/tests/fixtures/local-include/templates/nx-test.yml
+++ b/tests/fixtures/local-include/templates/nx-test.yml
@@ -3,6 +3,9 @@ spec:
     job_name:
       description: The name of the CI job
       type: string
+    runner_tag:
+      description: The runner tag the job should target (no default — required)
+      type: string
     job_type:
       description: The type of the job to test
       type: string

--- a/tests/fixtures/local-include/templates/nx-test.yml
+++ b/tests/fixtures/local-include/templates/nx-test.yml
@@ -1,0 +1,17 @@
+spec:
+  inputs:
+    job_name:
+      description: The name of the CI job
+      type: string
+    job_type:
+      description: The type of the job to test
+      type: string
+      default: affected
+    git_depth:
+      description: The git fetch depth (0 for full clone)
+      type: number
+      default: 1
+---
+$[[ inputs.job_name ]]:
+  script:
+    - echo "running $[[ inputs.job_type ]]"

--- a/tests/unit/local-include-detection.test.js
+++ b/tests/unit/local-include-detection.test.js
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+/**
+ * Local include detection regex tests.
+ *
+ * Mirrors the regex used in src/providers/localComponentResolver.ts so that
+ * we can characterise its behaviour without pulling in the `vscode` module.
+ * If you change the regex in the source, change it here too.
+ */
+
+const REGEX = /^\s*-?\s*local:\s*["']?([^"'\s]+)["']?\s*$/;
+
+function extractLocalIncludePath(line) {
+  const match = line.match(REGEX);
+  return match ? match[1] : null;
+}
+
+function runTests() {
+  console.log('=== Local Include Detection Tests ===\n');
+
+  const cases = [
+    {
+      name: 'quoted path with list dash',
+      line: '    - local: "gitlab/templates/nx-test/template.yml"',
+      expected: 'gitlab/templates/nx-test/template.yml',
+    },
+    {
+      name: 'single-quoted path',
+      line: "    - local: 'configs/build.yml'",
+      expected: 'configs/build.yml',
+    },
+    {
+      name: 'unquoted path',
+      line: '    - local: gitlab/templates/nx-test/template.yml',
+      expected: 'gitlab/templates/nx-test/template.yml',
+    },
+    {
+      name: 'leading slash path',
+      line: '    - local: "/gitlab/templates/nx-test/template.yml"',
+      expected: '/gitlab/templates/nx-test/template.yml',
+    },
+    {
+      name: 'no list dash (single include)',
+      line: 'local: "ci/main.yml"',
+      expected: 'ci/main.yml',
+    },
+    {
+      name: 'trailing whitespace tolerated',
+      line: '    - local: "ci/main.yml"   ',
+      expected: 'ci/main.yml',
+    },
+    {
+      name: 'component: line is not a local include',
+      line: '    - component: $CI_SERVER_FQDN/group/comp@1.0.0',
+      expected: null,
+    },
+    {
+      name: 'project: line is not a local include',
+      line: '    - project: "my-group/my-project"',
+      expected: null,
+    },
+    {
+      name: 'remote: line is not a local include',
+      line: '    - remote: "https://example.com/ci.yml"',
+      expected: null,
+    },
+    {
+      name: 'empty line',
+      line: '',
+      expected: null,
+    },
+    {
+      name: 'comment containing local: is ignored',
+      line: '    # local: not a real include',
+      expected: null,
+    },
+  ];
+
+  let passed = 0;
+  for (const c of cases) {
+    const got = extractLocalIncludePath(c.line);
+    const ok = got === c.expected;
+    console.log(`  ${ok ? '✅' : '❌ FAIL'} ${c.name}`);
+    if (!ok) {
+      console.log(`     expected: ${JSON.stringify(c.expected)}`);
+      console.log(`     got:      ${JSON.stringify(got)}`);
+    } else {
+      passed++;
+    }
+  }
+
+  console.log(`\nTotal: ${cases.length}, Passed: ${passed}, Failed: ${cases.length - passed}`);
+  if (passed !== cases.length) {
+    process.exit(1);
+  }
+}
+
+runTests();


### PR DESCRIPTION
## Summary
- Treats `include: - local: "<path>"` entries as first-class components alongside `include: - component:`. Hover, completion, and validation now activate on the `inputs:` block under a local include exactly as they do for catalog components — the same provider surfaces, the same diagnostics, just sourced from a workspace file instead of the GitLab CI Catalog.
- New `src/providers/localComponentResolver.ts` does the lookup: extracts the path from the include line, resolves it relative to the workspace folder, parses the target YAML with `js-yaml`'s `loadAll`, and maps the first document's `spec.inputs` block onto the existing `Component` shape. No HTTP calls, no cache writes — local files are the source of truth and re-resolved on demand.
- Wires the resolver into `detectIncludeComponent` (componentDetector), the input-walker loops in hoverProvider and completionProvider, and a new `validateLocalInclude` branch in validationProvider. Dispatch is keyed off `include.local && !include.component`, not URL shape — no shape-sniffing in `findComponentInCache`.
- Drive-by fix: `tests/extension-host/runTest.ts` walked two `..` levels from `__dirname`, but `tsconfig.test.json`'s `rootDir` flattens the compiled `runTest.js` to `out-test/runTest.js` (depth 1), so the workspace argument resolved outside the repo. The existing host tests passed by accident — they opened files via absolute URI and never touched workspaceFolders. The new local-include tests *do* depend on workspaceFolders, which surfaced the bug. One-line fix: `path.resolve(__dirname, '..')`. Dead since 2c748e6.
- Link related issue(s): Closes #128

## Change Type
- [x] feat
- [ ] fix
- [ ] refactor
- [ ] docs
- [ ] test
- [ ] chore

## Context
### User-facing impact
- Editing `inputs:` under a `- local:` include now gets the same assistance as `- component:` includes: hover on the include line shows the parameters table, hover on an input parameter shows that input's description/type/default, completion suggests missing inputs, and validation flags unknown inputs and missing required ones.
- Local includes that don't define `spec.inputs` are silently ignored (single debug log, no toast, no diagnostic). Missing local files produce a single warning diagnostic (`local-include-not-found`) rather than a stream of unknown-input warnings.
- No new settings, no new commands. Behaviour change is purely additive: files that didn't have local includes before continue to behave identically.

### GitLab scope
- [ ] gitlab.com
- [ ] self-managed GitLab
- [x] both

The feature is filesystem-only — no GitLab API calls — so it's inherently neutral to the instance the user targets.

### Affected areas
- [ ] Component Browser
- [x] Hover provider
- [x] Completion provider
- [x] Validation provider
- [ ] Cache and refresh behavior
- [ ] GitLab API calls/auth/token storage
- [ ] Docs only

## Validation
### Local checks
- [x] `npm run compile`
- [x] `npm test` or targeted tests
- [x] Manual verification in VS Code Extension Host

### Manual test notes
Tested in the Extension Host against a real-world `.gitlab-ci.yml` that uses:

```yaml
include:
    - local: "gitlab/templates/nx-test/template.yml"
      inputs:
        job_name: test-nightly
        job_type: nightly
```

- Hover on the `- local:` line → parameters table populated from the template's `spec.inputs`.
- Hover on `job_type:` (an input parameter under the include) → "Input Parameter: job_type" panel with the description and default from the template.
- Add an unknown input (`bogus_input: oops`) → yellow `unknown-input` underline; "Unknown input 'bogus_input' for local include '<filename>'".
- Rename the local file → red `local-include-not-found` underline on the include line; no spurious unknown-input warnings for the inputs that were valid before the rename.
- File a `- local:` that points at a YAML without a `spec.inputs` block (e.g. a `.cache-ci.yml`) → no diagnostics, no toasts; single debug log line in the output channel.

### Automated tests
- **Unit** ([tests/unit/local-include-detection.test.js](tests/unit/local-include-detection.test.js)) — 11 cases characterising the `extractLocalIncludePath` regex: quoted/unquoted/single-quoted paths, leading slash, list-dash present or absent, trailing whitespace, and negatives for `component:`/`project:`/`remote:`, empty lines, and comments containing `local:`.
- **Extension-host** ([tests/extension-host/suite/localInclude.test.ts](tests/extension-host/suite/localInclude.test.ts)) — four end-to-end scenarios driven through the real provider stack against fixtures in [tests/fixtures/local-include/](tests/fixtures/local-include/): hover-on-include surfaces inputs, hover-on-input shows parameter docs, unknown input produces a diagnostic, missing local file produces a not-found diagnostic.

## Breaking Changes
- [x] No breaking changes
- [ ] Breaking changes (describe below)

The change is purely additive — existing `- component:` includes go through the unchanged code path. Local-include detection short-circuits inside `detectIncludeComponent` and the validation loop before any catalog logic runs, so files without `- local:` entries see zero behavioural difference.

## Screenshots / Recordings (if UI behavior changed)
- n/a — the hover/completion/diagnostic UI is identical to the existing catalog-component flow. Only the set of include types that drive those surfaces has grown.

## Risk and Rollback
- Main risks:
  - **YAML walker fragility.** The hover/completion provider walkers find the include line by substring-matching `local:` against the document lines. A line containing the substring `local:` somewhere unrelated (e.g. in a value or comment) could in principle false-match. This is the same risk the existing `'component:'` walker has carried; the new code uses an `isLocal` flag derived from the parsed YAML node, so dispatch is correct even when the substring search picks a slightly off line.
  - **`js-yaml.loadAll` on large templates.** The resolver reads and parses the entire target file on every hover/completion/validation. For typical CI templates (single-digit KB) this is imperceptible. If users point local includes at multi-MB YAML files the parse cost could show up; mitigation is the existing 5-second parse cache in `src/utils/yamlParser.ts`, though the resolver currently calls `yaml.loadAll` directly to support multi-doc files — worth revisiting if a real complaint appears.
  - **No cache invalidation on local file save.** The resolver re-reads the local file on every detection call, so saves to the template are picked up immediately by hover/completion/validation without any explicit invalidation step. The cost is the per-call file read; the benefit is zero stale-state risk.
- Rollback strategy: revert the feature branch as a single PR. The new module (`localComponentResolver.ts`) is the only added file; the changes to existing providers are small, self-contained branches gated on `include.local && !include.component` that produce no effect when no local includes are present.

## Release Notes Draft
- feat: support `include: - local:` entries as first-class components — hover, completion, and validation now surface `spec.inputs` from local templates.

## Checklist
- [x] Branch is up to date with target branch
- [x] Commit messages follow conventional commits
- [x] Added/updated docs for behavior or settings changes
- [x] Added/updated tests for new behavior
- [x] No secrets or tokens in code, logs, screenshots, or test fixtures
