### PR TITLE
fix: component: URLs and Component Browser "Template File" links

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,7 @@ import { registerAddProjectTokenCommand, getComponentService } from './services/
 import * as vscode from 'vscode';
 import { HoverProvider } from './providers/hoverProvider';
 import { CompletionProvider } from './providers/completionProvider';
+import { ComponentDocumentLinkProvider } from './providers/documentLinkProvider';
 import { ComponentBrowserProvider } from './providers/componentBrowserProvider';
 import { detectIncludeComponent } from './providers/componentDetector';
 import { getComponentCacheManager, ComponentCacheManager } from './services/cache/componentCacheManager';
@@ -91,6 +92,19 @@ export function activate(context: vscode.ExtensionContext) {
         ],
         new CompletionProvider(),
         ':', ' ', '@'  // Add @ as a trigger character for version completions
+      )
+    );
+
+    // Register document link provider so `component:` URLs (including those using GitLab variables like
+    // $CI_SERVER_FQDN) become clickable and point at the GitLab project tree at the requested ref.
+    logger.debug('[Extension] Registering document link provider...', 'Extension');
+    context.subscriptions.push(
+      vscode.languages.registerDocumentLinkProvider(
+        [
+          { language: 'yaml' },
+          { language: 'gitlab-ci' }
+        ],
+        new ComponentDocumentLinkProvider()
       )
     );
 

--- a/src/providers/componentBrowserProvider.ts
+++ b/src/providers/componentBrowserProvider.ts
@@ -1196,8 +1196,7 @@ export class ComponentBrowserProvider {
           function viewDetailsById(componentName, version, projectId) {
             const componentData = window.componentVersionData[componentName];
             if (componentData && componentData[version]) {
-              // Send the raw component data; the server computes the template-file URL when it
-              // renders the details panel.
+              // Send the raw component data; the server computes the template-file URL when it renders the details panel.
               const component = {
                 ...componentData[version],
                 name: componentName,

--- a/src/providers/componentBrowserProvider.ts
+++ b/src/providers/componentBrowserProvider.ts
@@ -5,6 +5,7 @@ import { GitLabCatalogComponent, GitLabCatalogVariable } from '../types/gitlab-c
 import { Component, ComponentParameter } from './componentDetector';
 import { containsGitLabVariables, expandGitLabVariables } from '../utils/gitlabVariables';
 import { Logger } from '../utils/logger';
+import { templateFileUrlForResolved } from '../utils/templateFileUrl';
 
 // Constants for timing delays
 const EDITOR_ACTIVATION_DELAY_MS = 50;
@@ -510,10 +511,14 @@ export class ComponentBrowserProvider {
               selectedVersion
             );
             if (updatedComponent) {
-              // Send the updated component details to the webview
+              // Send the updated component details to the webview, with the template-file URL precomputed
+              // server-side so the webview never has to do its own URL routing.
               detailsPanel.webview.postMessage({
                 command: 'componentDetailsUpdated',
-                component: updatedComponent
+                component: {
+                  ...updatedComponent,
+                  templateFileUrl: this.buildTemplateFileUrl(updatedComponent),
+                }
               });
             } else {
               detailsPanel.webview.postMessage({
@@ -1191,11 +1196,12 @@ export class ComponentBrowserProvider {
           function viewDetailsById(componentName, version, projectId) {
             const componentData = window.componentVersionData[componentName];
             if (componentData && componentData[version]) {
+              // Send the raw component data; the server computes the template-file URL when it
+              // renders the details panel.
               const component = {
                 ...componentData[version],
                 name: componentName,
                 version: version,
-                templateFileUrl: buildTemplateFileUrl(componentData[version], componentName, version)
               };
               vscode.postMessage({ command: 'viewComponentDetails', component });
             }
@@ -1213,14 +1219,6 @@ export class ComponentBrowserProvider {
               };
               vscode.postMessage({ command: 'insertComponent', component });
             }
-          }
-
-          function buildTemplateFileUrl(versionData, componentName, version) {
-            if (!versionData || !versionData.sourcePath || !versionData.gitlabInstance) {
-              return '';
-            }
-            const ref = version || 'main';
-            return 'https://' + versionData.gitlabInstance + '/' + versionData.sourcePath + '/-/blob/' + ref + '/templates/' + componentName + '.yml';
           }
 
           function filterComponents() {
@@ -1594,7 +1592,7 @@ export class ComponentBrowserProvider {
           ${component.documentationUrl ?
             `<div><strong>Project URL:</strong> <a href="${component.documentationUrl}" target="_blank" id="componentDocUrl">${component.documentationUrl}</a></div>` : ''}
           ${component.url ?
-            `<div><strong>Component URL:</strong> <a href="${component.url}" target="_blank" id="componentUrl">${component.url}</a></div>` : ''}
+            `<div><strong>Component URL:</strong> <code id="componentUrl">${component.url}</code></div>` : ''}
           ${templateFileUrl ?
             `<div><strong>Template File:</strong> <a href="${templateFileUrl}" target="_blank" id="templateFileUrl">${templateFileUrl}</a></div>` : ''}
         </div>
@@ -1745,14 +1743,6 @@ export class ComponentBrowserProvider {
             toggleButton.textContent = isHidden ? 'Hide' : 'Show';
           }
 
-          function buildTemplateFileUrlFromComponent(component) {
-            if (!component || !component.gitlabInstance || !component.sourcePath || !component.name) {
-              return '';
-            }
-            const ref = component.version || 'main';
-            return 'https://' + component.gitlabInstance + '/' + component.sourcePath + '/-/blob/' + ref + '/templates/' + component.name + '.yml';
-          }
-
           function updateComponentDetails(component) {
             console.log('Updating component details:', component);
 
@@ -1833,17 +1823,16 @@ export class ComponentBrowserProvider {
             // Update component URL
             const componentUrlElement = document.getElementById('componentUrl');
             if (component.url && componentUrlElement) {
-              componentUrlElement.href = component.url;
               componentUrlElement.textContent = component.url;
             }
 
-            // Update template file URL
+            // Update template file URL. The server precomputes templateFileUrl and includes it in the
+            // payload; if it's absent (no resolved templatePath), the row is hidden.
             const templateFileUrlElement = document.getElementById('templateFileUrl');
             if (templateFileUrlElement) {
-              const computedTemplateUrl = component.templateFileUrl || buildTemplateFileUrlFromComponent(component);
-              if (computedTemplateUrl) {
-                templateFileUrlElement.href = computedTemplateUrl;
-                templateFileUrlElement.textContent = computedTemplateUrl;
+              if (component.templateFileUrl) {
+                templateFileUrlElement.href = component.templateFileUrl;
+                templateFileUrlElement.textContent = component.templateFileUrl;
                 templateFileUrlElement.style.display = 'inline';
               } else {
                 templateFileUrlElement.style.display = 'none';
@@ -1976,11 +1965,15 @@ export class ComponentBrowserProvider {
   }
 
   private buildTemplateFileUrl(component: any): string | undefined {
-    if (!component || !component.gitlabInstance || !component.sourcePath || !component.name) {
+    if (!component || !component.gitlabInstance || !component.sourcePath || !component.templatePath) {
       return undefined;
     }
-    const ref = component.version || 'main';
-    return `https://${component.gitlabInstance}/${component.sourcePath}/-/blob/${ref}/templates/${component.name}.yml`;
+    return templateFileUrlForResolved({
+      gitlabInstance: component.gitlabInstance,
+      projectPath: component.sourcePath,
+      version: component.version,
+      templatePath: component.templatePath,
+    });
   }
 
   private getNoSourcesHtml(): string {

--- a/src/providers/componentDetector.ts
+++ b/src/providers/componentDetector.ts
@@ -579,6 +579,7 @@ async function fetchComponentDynamically(componentUrl: string, originalUrl?: str
     // Use the componentService to get proper description and README data
     let componentDescription = foundComponent.description;
     let readmeContent = '';
+    let resolvedTemplatePath: string | undefined;
 
     // Always fetch full component metadata for README content, even if we have a description
     try {
@@ -593,6 +594,7 @@ async function fetchComponentDynamically(componentUrl: string, originalUrl?: str
           componentDescription = fullComponent.description;
         }
         readmeContent = fullComponent.readme || '';
+        resolvedTemplatePath = fullComponent.templatePath;
       } else {
         logger.debug(`[ComponentDetector] Full component fetch returned null`, 'ComponentDetector');
       }
@@ -625,6 +627,7 @@ async function fetchComponentDynamically(componentUrl: string, originalUrl?: str
       originalUrl: originalUrl || componentUrl,
       gitlabInstance: gitlabInstance,
       sourcePath: projectPath,
+      templatePath: resolvedTemplatePath,
       documentationUrl: foundComponent.documentation_url,
       readme: readmeContent, // Include README content from full fetch
       context: {
@@ -654,7 +657,8 @@ async function fetchComponentDynamically(componentUrl: string, originalUrl?: str
         sourcePath: projectPath,
         gitlabInstance: gitlabInstance,
         version: version,
-        url: componentUrl
+        url: componentUrl,
+        templatePath: resolvedTemplatePath
       };
 
       cacheManager.addDynamicComponent(cacheComponent);

--- a/src/providers/componentDetector.ts
+++ b/src/providers/componentDetector.ts
@@ -24,6 +24,7 @@ export interface Component {
   url?: string; // Component URL
   gitlabInstance?: string; // GitLab instance
   sourcePath?: string; // Source path
+  templatePath?: string; // Repo-relative path to the template file, resolved at fetch time
   originalUrl?: string; // Original URL with variables (if any)
   // Add this context property that's needed by the hover provider
   context?: {
@@ -255,6 +256,7 @@ export async function detectIncludeComponent(document: vscode.TextDocument, posi
           originalUrl: originalUrl,
           gitlabInstance: exactMatch.gitlabInstance,
           sourcePath: exactMatch.sourcePath,
+          templatePath: (exactMatch as any).templatePath,
           readme: (exactMatch as any).readme || '', // Include README from cache
           context: {
             gitlabInstance: exactMatch.gitlabInstance,
@@ -295,6 +297,7 @@ export async function detectIncludeComponent(document: vscode.TextDocument, posi
           originalUrl: originalUrl,
           gitlabInstance: cachedComponent.gitlabInstance,
           sourcePath: cachedComponent.sourcePath,
+          templatePath: (cachedComponent as any).templatePath,
           readme: (cachedComponent as any).readme || '', // Include README from cache
           context: {
             gitlabInstance: cachedComponent.gitlabInstance,
@@ -324,7 +327,8 @@ export async function detectIncludeComponent(document: vscode.TextDocument, posi
             url: componentUrl,
             gitlabInstance: requestedGitlabInstance,
             sourcePath: requestedProjectPath,
-            source: `${requestedGitlabInstance}/${requestedProjectPath}`
+            source: `${requestedGitlabInstance}/${requestedProjectPath}`,
+            templatePath: specificVersionComponent.templatePath
           });
 
           return specificVersionComponent;
@@ -426,7 +430,7 @@ export async function detectIncludeComponent(document: vscode.TextDocument, posi
 
     return {
       name: componentName,
-      description: `**Component not in cache**\n\nURL: ${componentUrl}\n\n❌ **Auto-fetch failed**: Could not retrieve component details automatically.\n\nThis could be due to:\n- Network connectivity issues\n- Private repository access restrictions\n- Component not found at the specified location\n\nTry refreshing the component cache using the "GitLab Component Helper: Refresh Components" command to get full details.`,
+      description: `**Component not in cache**\n\n❌ **Auto-fetch failed**: Could not retrieve component details automatically.\n\nThis could be due to:\n- Network connectivity issues\n- Private repository access restrictions\n- Component not found at the specified location\n\nTry refreshing the component cache using the "GitLab Component Helper: Refresh Components" command to get full details.`,
       parameters: [],
       version: version,
       source: `${gitlabInstance}/${projectPath}`,
@@ -444,7 +448,7 @@ export async function detectIncludeComponent(document: vscode.TextDocument, posi
 
     return {
       name: componentUrl,
-      description: `**Component not in cache**\n\nURL: ${componentUrl}\n\n❌ **Auto-fetch failed**: Error parsing component URL.\n\nThe component URL format appears to be invalid. Please check the URL format and try refreshing the component cache using the "GitLab Component Helper: Refresh Components" command.`,
+      description: `**Component not in cache**\n\n❌ **Auto-fetch failed**: Error parsing component URL.\n\nThe component URL format appears to be invalid. Please check the URL format and try refreshing the component cache using the "GitLab Component Helper: Refresh Components" command.`,
       parameters: [],
       url: componentUrl,
       originalUrl: originalUrl,

--- a/src/providers/documentLinkProvider.ts
+++ b/src/providers/documentLinkProvider.ts
@@ -1,0 +1,97 @@
+import * as vscode from 'vscode';
+import { Logger } from '../utils/logger';
+import { UrlParser } from '../services/component/urlParser';
+import { containsGitLabVariables, expandComponentUrl } from '../utils/gitlabVariables';
+import { getGitRepositoryContext } from './componentDetector';
+import { getComponentCacheManager } from '../services/cache/componentCacheManager';
+import { templateFileUrlForResolved } from '../utils/templateFileUrl';
+import { isGitLabCIFile } from '../utils/gitlabCiFileMatcher';
+
+const COMPONENT_LINE = /^(\s*-?\s*component:\s*)(\S+)/;
+
+export class ComponentDocumentLinkProvider implements vscode.DocumentLinkProvider {
+  private logger = Logger.getInstance();
+  private urlParser = new UrlParser();
+
+  public async provideDocumentLinks(
+    document: vscode.TextDocument,
+    _token: vscode.CancellationToken
+  ): Promise<vscode.DocumentLink[]> {
+    if (!isGitLabCIFile(document)) {
+      return [];
+    }
+
+    const links: vscode.DocumentLink[] = [];
+    let gitContext: Awaited<ReturnType<typeof getGitRepositoryContext>> | null = null;
+    const cacheManager = getComponentCacheManager();
+    const cachedComponents = await cacheManager.getComponents();
+
+    for (let lineIndex = 0; lineIndex < document.lineCount; lineIndex++) {
+      const lineText = document.lineAt(lineIndex).text;
+      const match = COMPONENT_LINE.exec(lineText);
+      if (!match) {
+        continue;
+      }
+
+      const prefix = match[1];
+      const rawUrl = match[2];
+      const startCol = prefix.length;
+      const endCol = startCol + rawUrl.length;
+
+      let expandedUrl = rawUrl;
+      if (containsGitLabVariables(rawUrl)) {
+        if (gitContext === null) {
+          gitContext = await getGitRepositoryContext();
+        }
+        if (gitContext.gitlabInstance) {
+          expandedUrl = expandComponentUrl(rawUrl, {
+            gitlabInstance: gitContext.gitlabInstance,
+            projectPath: gitContext.projectPath || '',
+            serverUrl: `https://${gitContext.gitlabInstance}`,
+            commitSha: gitContext.commitSha || 'main',
+          });
+        } else {
+          continue;
+        }
+      }
+
+      const parsed = this.urlParser.parseCustomComponentUrl(expandedUrl);
+      if (!parsed) {
+        continue;
+      }
+
+      const cached = cachedComponents.find(
+        (c) =>
+          c.gitlabInstance === parsed.gitlabInstance &&
+          c.sourcePath === parsed.path &&
+          c.name === parsed.name &&
+          (!parsed.version || c.version === parsed.version)
+      );
+
+      // Only produce a link when the cache has a resolved templatePath for the component. Uncached components are
+      // skipped: better no link than a misleading one. The catalog discovery populates templatePath for every entry
+      // in a configured componentSource, so the only time this misses is for components from projects the user
+      // hasn't configured (or before the first cache refresh completes).
+      if (!cached?.templatePath) {
+        continue;
+      }
+
+      const target = templateFileUrlForResolved({
+        gitlabInstance: parsed.gitlabInstance,
+        projectPath: parsed.path,
+        version: parsed.version,
+        templatePath: cached.templatePath,
+      });
+
+      const range = new vscode.Range(lineIndex, startCol, lineIndex, endCol);
+      const link = new vscode.DocumentLink(range, vscode.Uri.parse(target));
+      const refLabel = parsed.version && parsed.version !== 'main' ? parsed.version : 'main';
+      link.tooltip = `Open ${parsed.name} template at ${refLabel} on ${parsed.gitlabInstance}/${parsed.path}`;
+      links.push(link);
+    }
+
+    this.logger.debug(`[ComponentDocumentLinkProvider] Produced ${links.length} links for ${document.fileName}`, 'ComponentDocumentLinkProvider');
+    return links;
+  }
+
+}

--- a/src/providers/documentLinkProvider.ts
+++ b/src/providers/documentLinkProvider.ts
@@ -90,7 +90,10 @@ export class ComponentDocumentLinkProvider implements vscode.DocumentLinkProvide
       links.push(link);
     }
 
-    this.logger.debug(`[ComponentDocumentLinkProvider] Produced ${links.length} links for ${document.fileName}`, 'ComponentDocumentLinkProvider');
+    this.logger.debug(
+      `[ComponentDocumentLinkProvider] Produced ${links.length} links for ${document.fileName}`,
+      "ComponentDocumentLinkProvider",
+    );
     return links;
   }
 

--- a/src/providers/hoverProvider.ts
+++ b/src/providers/hoverProvider.ts
@@ -4,6 +4,7 @@ import { Logger } from '../utils/logger';
 import { getVariableInfo } from '../utils/gitlabVariables';
 import { parseYaml } from '../utils/yamlParser';
 import { isGitLabCIFile } from '../utils/gitlabCiFileMatcher';
+import { templateFileUrlForResolved } from '../utils/templateFileUrl';
 
 export class HoverProvider implements vscode.HoverProvider {
   private logger = Logger.getInstance();
@@ -97,17 +98,20 @@ export class HoverProvider implements vscode.HoverProvider {
 
       hoverContent.appendMarkdown(`${description}\n\n`);
 
-      // Source information with clickable link
-      if (component.context) {
-        const sourceUrl = `https://${component.context.gitlabInstance}/${component.context.path}`;
-        hoverContent.appendMarkdown(`**Source:** [${component.context.gitlabInstance}/${component.context.path}](${sourceUrl})\n\n`);
+      // Source link. When we have a resolved templatePath we link directly to the template (matching the inline editor
+      // link and the Component Browser's "Template File" link). Without templatePath we fall back to plain text
+      if (component.context && component.templatePath) {
+        const sourceUrl = templateFileUrlForResolved({
+          gitlabInstance: component.context.gitlabInstance,
+          projectPath: component.context.path,
+          version: component.version,
+          templatePath: component.templatePath,
+        });
+        hoverContent.appendMarkdown(`**Source:** [${sourceUrl}](${sourceUrl})\n\n`);
+      } else if (component.context) {
+        hoverContent.appendMarkdown(`**Source:** ${component.context.gitlabInstance}/${component.context.path}\n\n`);
       } else if (component.source) {
-        // Try to create a clickable link from the source string
-        let sourceUrl = component.source;
-        if (!sourceUrl.startsWith('http')) {
-          sourceUrl = `https://${component.source}`;
-        }
-        hoverContent.appendMarkdown(`**Source:** [${component.source}](${sourceUrl})\n\n`);
+        hoverContent.appendMarkdown(`**Source:** ${component.source}\n\n`);
       }
 
       // Version

--- a/src/providers/validationProvider.ts
+++ b/src/providers/validationProvider.ts
@@ -898,7 +898,8 @@ export class ValidationProvider implements vscode.CodeActionProvider {
                 sourcePath: component.context.path,
                 gitlabInstance: component.context.gitlabInstance,
                 version: component.version || 'main',
-                url: componentUrl
+                url: componentUrl,
+                templatePath: component.templatePath
             });
 
             this.logger.debug(`[ValidationProvider] Added component to cache: ${component.name}`, 'ValidationProvider');

--- a/src/services/cache/componentCacheManager.ts
+++ b/src/services/cache/componentCacheManager.ts
@@ -13,6 +13,10 @@ import {
   DEFAULT_COMPONENT_TYPE_PROJECT,
 } from '../../constants/cache';
 
+// Bump when the on-disk CachedComponent shape changes. Mismatched caches are discarded on load so the new fields can be
+// populated by re-fetching.
+const CURRENT_CACHE_VERSION = '1.1.0';
+
 /**
  * ComponentCacheManager - Main orchestrator for component caching
  *
@@ -124,6 +128,7 @@ export class ComponentCacheManager {
     gitlabInstance: string;
     version: string;
     url: string;
+    templatePath?: string;
   }): void {
     try {
       // Check if component already exists (avoid duplicates)
@@ -525,6 +530,17 @@ export class ComponentCacheManager {
 
       const cacheData = this.context.globalState.get<PersistentCacheData>('componentCache');
 
+      if (cacheData && cacheData.version !== CURRENT_CACHE_VERSION) {
+        this.logger.info(
+          `[ComponentCache] Cache schema upgrade (${cacheData.version || 'unversioned'} -> ${CURRENT_CACHE_VERSION}); discarding existing cache so it can be repopulated with the new schema`,
+          'ComponentCache'
+        );
+        this.components = [];
+        this.lastRefreshTime = 0;
+        this.versionCache.clearCache();
+        return;
+      }
+
       if (cacheData && cacheData.components && Array.isArray(cacheData.components)) {
         this.components = cacheData.components;
         this.lastRefreshTime = cacheData.lastRefreshTime || 0;
@@ -585,7 +601,7 @@ export class ComponentCacheManager {
         components: this.components,
         lastRefreshTime: this.lastRefreshTime,
         projectVersionsCache: this.versionCache.serializeCache(),
-        version: '1.0.0', // For future cache format migrations
+        version: CURRENT_CACHE_VERSION,
       };
 
       await this.context.globalState.update('componentCache', cacheData);

--- a/src/services/cache/componentCacheManager.ts
+++ b/src/services/cache/componentCacheManager.ts
@@ -531,8 +531,10 @@ export class ComponentCacheManager {
       const cacheData = this.context.globalState.get<PersistentCacheData>('componentCache');
 
       if (cacheData && cacheData.version !== CURRENT_CACHE_VERSION) {
+        const fromVersion = cacheData.version || 'unversioned';
         this.logger.info(
-          `[ComponentCache] Cache schema upgrade (${cacheData.version || 'unversioned'} -> ${CURRENT_CACHE_VERSION}); discarding existing cache so it can be repopulated with the new schema`,
+          `[ComponentCache] Cache schema upgrade (${fromVersion} -> ${CURRENT_CACHE_VERSION}); ` +
+            `discarding existing cache so it can be repopulated with the new schema`,
           'ComponentCache'
         );
         this.components = [];

--- a/src/services/cache/projectCache.ts
+++ b/src/services/cache/projectCache.ts
@@ -63,6 +63,7 @@ export class ProjectCache {
             gitlabInstance: gitlabInstance,
             version: c.latest_version || 'main',
             url: componentUrl,
+            templatePath: c.templatePath,
           };
         });
 
@@ -165,6 +166,7 @@ export class ProjectCache {
         gitlabInstance: gitlabInstance,
         version: version,
         url: `https://${gitlabInstance}/${sourcePath}/${catalogComponent.name}@${version}`,
+        templatePath: catalogComponent.templatePath,
       };
 
       this.logger.info(

--- a/src/services/component/componentFetcher.ts
+++ b/src/services/component/componentFetcher.ts
@@ -172,18 +172,17 @@ export class ComponentFetcher {
                 default: v.default
               })) || [];
 
-            // Some catalog entries omit variable details. Try parsing the template directly.
-            if (extractedParameters.length === 0) {
-              const templateResult = await this.fetchTemplate(
-                apiBaseUrl,
-                encodedProjectPath,
-                componentName,
-                version,
-                catalogFetchOptions
-              );
-              if (templateResult?.parameters?.length) {
-                extractedParameters = templateResult.parameters;
-              }
+            // Always probe the template so we know the on-repo path (needed for the template-file link). When the
+            // catalog omits variable details we also harvest the parsed parameters as a backup.
+            const templateResult = await this.fetchTemplate(
+              apiBaseUrl,
+              encodedProjectPath,
+              componentName,
+              version,
+              catalogFetchOptions
+            );
+            if (extractedParameters.length === 0 && templateResult?.parameters?.length) {
+              extractedParameters = templateResult.parameters;
             }
 
             const component = {
@@ -199,7 +198,8 @@ export class ComponentFetcher {
               parameters: extractedParameters,
               version,
               source: `${gitlabInstance}/${projectPath}`,
-              documentationUrl: catalogComponent.documentation_url
+              documentationUrl: catalogComponent.documentation_url,
+              templatePath: templateResult?.templatePath
             };
 
             this.logger.logPerformance('fetchComponentMetadata (catalog)', Date.now() - startTime);

--- a/src/services/component/componentFetcher.ts
+++ b/src/services/component/componentFetcher.ts
@@ -259,11 +259,13 @@ export class ComponentFetcher {
       const project = projectInfo.value;
 
       // Process template result
+      let resolvedTemplatePath: string | undefined;
       if (templateResult.status === 'fulfilled' && templateResult.value) {
-        const { content, parameters: extractedParams } = templateResult.value;
+        const { content, parameters: extractedParams, templatePath } = templateResult.value;
         templateContent = content;
         parameters = extractedParams;
-        this.logger.debug(`Found component template with ${parameters.length} parameters`);
+        resolvedTemplatePath = templatePath;
+        this.logger.debug(`Found component template with ${parameters.length} parameters at ${templatePath}`);
       }
 
       // Build component description with proper fallbacks
@@ -281,7 +283,8 @@ export class ComponentFetcher {
         description: cleanDescription,
         parameters,
         version,
-        source: `${gitlabInstance}/${projectPath}`
+        source: `${gitlabInstance}/${projectPath}`,
+        templatePath: resolvedTemplatePath
       };
 
       this.logger.logPerformance('fetchComponentMetadata (full)', Date.now() - startTime, {
@@ -315,7 +318,7 @@ export class ComponentFetcher {
     componentName: string,
     version: string,
     fetchOptions?: any
-  ): Promise<{ content: string; parameters: any[] } | null> {
+  ): Promise<{ content: string; parameters: any[]; templatePath: string } | null> {
     try {
       const templatePathCandidates = [
         `templates/${componentName}.yml`,
@@ -363,7 +366,7 @@ export class ComponentFetcher {
         );
       });
 
-      return { content: templateContent, parameters: parsedSpec.variables };
+      return { content: templateContent, parameters: parsedSpec.variables, templatePath: resolvedTemplatePath };
     } catch (error) {
       this.logger.debug(`Could not fetch component template: ${error}`);
       return null;
@@ -525,7 +528,8 @@ export class ComponentFetcher {
             name,
             description,
             variables,
-            latest_version: ref
+            latest_version: ref,
+            templatePath: file.path
           };
         },
         batchSize

--- a/src/types/cache.ts
+++ b/src/types/cache.ts
@@ -77,6 +77,7 @@ export interface CachedComponent {
   version: string;
   url: string;
   availableVersions?: string[];
+  templatePath?: string;
 }
 
 /**

--- a/src/types/git-component.ts
+++ b/src/types/git-component.ts
@@ -5,6 +5,7 @@ export interface Component {
     version?: string;
     source?: string;
     documentationUrl?: string;
+    templatePath?: string;
     context?: {
         gitlabInstance: string;
         path: string;

--- a/src/utils/templateFileUrl.ts
+++ b/src/utils/templateFileUrl.ts
@@ -1,0 +1,92 @@
+/**
+ * Builder for the public GitLab URL that points at a component's template file on the source project's web UI.
+ *
+ * The cache stores `templatePath` — the repo-relative path the fetcher landed on, e.g.
+ * `templates/install-yu-ci-tools/template.yml` (directory form) or `templates/install-yu-ci-tools.yml` (single-file
+ * form) — for every component populated via catalog discovery. {@link templateFileUrlForResolved} turns that into a
+ * navigable GitLab URL whose shape depends on the layout:
+ *
+ *   - Single-file form (`templates/<name>.yml`, 2 segments): `/-/blob/<ref>/templates/<name>.yml` — the file itself.
+ *   - Directory form (`templates/<name>/template.yml`, 3+ segments): `/-/tree/<ref>/templates/<name>` — the directory
+ *     that contains the template plus any sibling files (README, fragments, etc.).
+ *
+ * The `<ref>` defaults to `main` when the component URL doesn't pin a version, and is URL-encoded so refs that contain
+ * `/` (e.g. `feature/branch-name`) work.
+ */
+
+/**
+ * URL-encode a ref so refs containing `/` (e.g. `feature/branch-name`) are safe to embed in a GitLab
+ * `/-/blob/<ref>/...` or `/-/tree/<ref>/...` URL. An absent or `main` ref is returned literally so the link points at
+ * the project's default branch view in the common case.
+ *
+ * @param version  The ref to encode, or `undefined` to default to `main`.
+ * @returns        A URL-safe ref string suitable for direct interpolation into a GitLab ref-scoped URL.
+ */
+function ref(version: string | undefined): string {
+  return version && version !== 'main' ? encodeURIComponent(version) : 'main';
+}
+
+/**
+ * Build the path-and-route portion of a GitLab URL appropriate to the layout of the resolved template path:
+ *
+ * - Single-file form (`templates/<name>.yml`, 2 segments): `/-/blob/<ref>/templates/<name>.yml` — the file itself.
+ * - Directory form (`templates/<name>/template.yml`, 3+ segments): `/-/tree/<ref>/templates/<name>` — the directory
+ *   that contains the template plus any sibling files (README, fragments, etc.).
+ *
+ * @param templatePath  Repo-relative path of the template (file path, not directory). Must contain at least one `/`.
+ * @param encodedRef    Already URL-encoded ref to embed in the URL.
+ * @returns             The path portion starting with `/-/blob/...` or `/-/tree/...`, ready to append to the project
+ *                      root URL.
+ */
+function pathForTemplate(templatePath: string, encodedRef: string): string {
+  const segments = templatePath.split('/');
+  if (segments.length <= 2) {
+    return `/-/blob/${encodedRef}/${templatePath}`;
+  }
+  const directory = segments.slice(0, -1).join('/');
+  return `/-/tree/${encodedRef}/${directory}`;
+}
+
+/**
+ * Build a GitLab URL pointing at a component template whose on-repo path is already known. The shape of the URL
+ * depends on the template's layout:
+ *
+ * - Single-file form (`templates/<name>.yml`): links to the file via `/-/blob/<ref>/<templatePath>`.
+ * - Directory form (`templates/<name>/template.yml` or similar): links to the parent directory via
+ *   `/-/tree/<ref>/templates/<name>` so the README, fragments, and template are all visible together.
+ *
+ * @param input                 Inputs describing the resolved template file.
+ * @param input.gitlabInstance  GitLab host, e.g. `gitlab.com`. No protocol prefix.
+ * @param input.projectPath     Source project path, e.g. `group/subgroup/project`.
+ * @param input.version         Ref to pin the link to (branch, tag, or SHA). Defaults to `main` when absent.
+ * @param input.templatePath    Repo-relative path of the template file as recorded by the fetcher, e.g.
+ *                              `templates/install-yu-ci-tools/template.yml`.
+ * @returns                     A fully-qualified GitLab URL — either a `/-/blob/` link to the file (single-file
+ *                              form) or a `/-/tree/` link to the parent directory (directory form).
+ *
+ * @example
+ *   templateFileUrlForResolved({
+ *     gitlabInstance: 'gitlab.com',
+ *     projectPath: 'group/project',
+ *     version: 'v2.9.0',
+ *     templatePath: 'templates/install-yu-ci-tools.yml',
+ *   });
+ *   // => 'https://gitlab.com/group/project/-/blob/v2.9.0/templates/install-yu-ci-tools.yml'
+ *
+ * @example
+ *   templateFileUrlForResolved({
+ *     gitlabInstance: 'gitlab.com',
+ *     projectPath: 'group/project',
+ *     version: 'v2.9.0',
+ *     templatePath: 'templates/install-yu-ci-tools/template.yml',
+ *   });
+ *   // => 'https://gitlab.com/group/project/-/tree/v2.9.0/templates/install-yu-ci-tools'
+ */
+export function templateFileUrlForResolved(input: {
+  gitlabInstance: string;
+  projectPath: string;
+  version?: string;
+  templatePath: string;
+}): string {
+  return `https://${input.gitlabInstance}/${input.projectPath}${pathForTemplate(input.templatePath, ref(input.version))}`;
+}

--- a/tests/unit/component-link-target.test.js
+++ b/tests/unit/component-link-target.test.js
@@ -1,0 +1,120 @@
+/**
+ * Component Template File URL Tests
+ *
+ * Tests the logic that derives the GitLab project URL for a component's template file. Mirrors
+ * templateFileUrlForResolved() in src/utils/templateFileUrl.ts.
+ */
+
+const assert = require('assert');
+
+console.log('=== Component Template File URL Tests ===');
+
+function ref(version) {
+  return version && version !== 'main' ? encodeURIComponent(version) : 'main';
+}
+
+function pathForTemplate(templatePath, encodedRef) {
+  const segments = templatePath.split('/');
+  if (segments.length <= 2) {
+    return `/-/blob/${encodedRef}/${templatePath}`;
+  }
+  return `/-/tree/${encodedRef}/${segments.slice(0, -1).join('/')}`;
+}
+
+function templateFileUrlForResolved(input) {
+  return `https://${input.gitlabInstance}/${input.projectPath}${pathForTemplate(input.templatePath, ref(input.version))}`;
+}
+
+const resolvedCases = [
+  {
+    name: 'Resolved single-file template',
+    input: {
+      gitlabInstance: 'gitlab.com',
+      projectPath: 'yu-life/infrastructure/yulife-devops-shared-config',
+      version: 'install-yu-ci-tools-2',
+      templatePath: 'templates/install-yu-ci-tools.yml',
+    },
+    expected: 'https://gitlab.com/yu-life/infrastructure/yulife-devops-shared-config/-/blob/install-yu-ci-tools-2/templates/install-yu-ci-tools.yml',
+  },
+  {
+    name: 'Resolved directory-form template links to the parent directory',
+    input: {
+      gitlabInstance: 'gitlab.com',
+      projectPath: 'components/opentofu',
+      version: '2.9.0',
+      templatePath: 'templates/full-pipeline/template.yml',
+    },
+    expected: 'https://gitlab.com/components/opentofu/-/tree/2.9.0/templates/full-pipeline',
+  },
+  {
+    name: 'Resolved directory-form matches the screenshot scenario',
+    input: {
+      gitlabInstance: 'gitlab.com',
+      projectPath: 'yu-life/infrastructure/yulife-devops-shared-config',
+      version: 'install-yu-ci-tools-2',
+      templatePath: 'templates/install-yu-ci-tools/template.yml',
+    },
+    expected: 'https://gitlab.com/yu-life/infrastructure/yulife-devops-shared-config/-/tree/install-yu-ci-tools-2/templates/install-yu-ci-tools',
+  },
+  {
+    name: 'Resolved template with no version defaults to main',
+    input: {
+      gitlabInstance: 'gitlab.example.com',
+      projectPath: 'group/project',
+      version: undefined,
+      templatePath: 'templates/my-component.yml',
+    },
+    expected: 'https://gitlab.example.com/group/project/-/blob/main/templates/my-component.yml',
+  },
+  {
+    name: 'Resolved with non-default templateRoots (directory form)',
+    input: {
+      gitlabInstance: 'gitlab.example.com',
+      projectPath: 'team/repo',
+      version: 'v1',
+      templatePath: 'ci-templates/foo/template.yaml',
+    },
+    expected: 'https://gitlab.example.com/team/repo/-/tree/v1/ci-templates/foo',
+  },
+  {
+    name: 'Resolved ref with slash is URL-encoded',
+    input: {
+      gitlabInstance: 'gitlab.internal.example.com',
+      projectPath: 'team/repo',
+      version: 'feature/branch-name',
+      templatePath: 'templates/comp.yml',
+    },
+    expected: 'https://gitlab.internal.example.com/team/repo/-/blob/feature%2Fbranch-name/templates/comp.yml',
+  },
+];
+
+let passed = 0;
+let failed = 0;
+
+resolvedCases.forEach((tc, i) => {
+  const actual = templateFileUrlForResolved(tc.input);
+  console.log(`\nResolved Test ${i + 1}: ${tc.name}`);
+  console.log(`  Expected: ${tc.expected}`);
+  console.log(`  Actual:   ${actual}`);
+  try {
+    assert.strictEqual(actual, tc.expected);
+    console.log('  Result: PASS');
+    passed++;
+  } catch (e) {
+    console.log('  Result: FAIL');
+    failed++;
+  }
+});
+
+console.log(`\n=== Component Template File URL Summary ===`);
+console.log(`Total: ${resolvedCases.length}`);
+console.log(`Passed: ${passed}`);
+console.log(`Failed: ${failed}`);
+
+if (failed > 0) {
+  console.log('FAIL: some template file URL cases did not match expectation.');
+  process.exit(1);
+}
+
+console.log('All template file URL tests passed.');
+process.exit(0);


### PR DESCRIPTION
## Summary
- Registers a `DocumentLinkProvider` for `component:` URLs in GitLab CI files so the URL is underlined and cmd-clickable — including when the URL uses GitLab variables like `$CI_SERVER_FQDN`, which VS Code's built-in URL detection ignores.
- Routes link generation through a shared `templateFileUrl` helper that uses the *resolved* template path recorded by the fetcher. The URL shape depends on the on-repo layout: single-file form (`templates/<name>.yml`) → `/-/blob/<ref>/<path>`; directory form (`templates/<name>/template.yml`) → `/-/tree/<ref>/templates/<name>`.
- Extends the cache schema with `templatePath` and persists it from every fetch path (catalog discovery, per-URL dynamic fetch, and the catalog branch of `fetchComponentMetadata`). Bumps cache version to `1.1.0` so caches written by older versions are discarded on load and repopulated on next refresh — preferred over field-level backfill heuristics because a single schema-version check is much less surface to maintain as fields are added over time.
- Replaces the Component Browser's hardcoded single-file `templates/<name>.yml` heuristic and the hover card's "Source" link (which previously pointed at the project root) with the same shared helper, so the inline editor link, the Component Browser's "Template File" link, and the hover's "Source" link all agree.
- Drops the misleading `URL: <component-url>` line from the "Component not in cache" fallback hover — the URL was rendered as a clickable link that 404'd, and it duplicated information the user just typed.
- Link related issue(s): Fixes #130

## Change Type
- [ ] feat
- [x] fix
- [ ] refactor
- [ ] docs
- [ ] test
- [ ] chore

## Context
### User-facing impact
- `component:` URLs are now underlined and cmd-clickable in `.gitlab-ci.yml` files, including the `$CI_SERVER_FQDN/...` variable form.
- Cmd-click navigates to the actual template location on GitLab — the directory for directory-form repos, the file for single-file repos — instead of VS Code's default behaviour of cmd-clicking the literal `component:` string, which is a catalog identifier (not a real web URL) and 404s on GitLab.
- Component Browser's "Template File" row and the hover card's "Source" link now both agree with the inline link.
- For components not in the cache, the fallback hover no longer shows a clickable (broken) URL line — just the failure reason and the suggestion to refresh.
- If a component's URL is for a project that isn't in the user's configured `componentSources`, no link is produced. The same applies in the brief window before the first cache refresh completes after extension activation.
- First run after upgrade: a one-time `Cache schema upgrade (1.0.0 -> 1.1.0)` line appears in the GitLab Component Helper output channel; the cache is discarded and repopulates on next refresh.

### GitLab scope
- [ ] gitlab.com
- [ ] self-managed GitLab
- [x] both

### Affected areas
- [x] Component Browser
- [x] Hover provider
- [ ] Completion provider
- [ ] Validation provider
- [x] Cache and refresh behavior
- [x] GitLab API calls/auth/token storage
- [ ] Docs only

Other areas touched (not listed above):
- New `DocumentLinkProvider` registered against `language: 'yaml'` and `language: 'gitlab-ci'`.
- New shared helper `src/utils/templateFileUrl.ts`.
- Component Browser webview-side JS no longer duplicates the routing logic — the server precomputes the template-file URL and passes it through the message payload.
- Fetcher (`componentFetcher.ts`) always probes the template via `fetchTemplate` in the catalog branch of `fetchComponentMetadata` to learn the on-repo path — one extra HTTP call per catalog-hit metadata fetch, gated to that branch.

## Validation
### Local checks
- [x] `npm run compile`
- [x] `npm test` or targeted tests
- [x] Manual verification in VS Code Extension Host

### Manual test notes
Tested in the Extension Development Host with a `.gitlab-ci.yml` containing both URL forms:

```yaml
include:
  - component: $CI_SERVER_FQDN/my-group/shared-ci/my-component@v1.2.0
    inputs:
      job_name: "TODO: set value1"
  - component: https://gitlab.com/my-group/shared-ci/my-component@v1.2.0
    inputs:
      job_name: "TODO: set value2"
```

- Both lines now show an underlined link.
- Cmd-click on either lands on `https://gitlab.com/my-group/shared-ci/-/tree/v1.2.0/templates/my-component` — the actual template directory, matching the repo's directory-form layout.
- Component Browser detail view's "Template File" link matches; hover card's "Source" link matches.
- Hovering over a component not in the cache shows the fallback hover with no URL line (previously a clickable, broken URL).
- Verified the schema-version invalidation: with an existing pre-upgrade cache on disk, reloading the extension logs `[ComponentCache] Cache schema upgrade (1.0.0 -> 1.1.0)`, discards the cache, repopulates via the next refresh, and links appear correctly. Direct cache resets behave the same way.

Unit tests: 6 cases in `tests/unit/component-link-target.test.js` covering single-file form, directory form (multiple project paths), absent version (default-branch fallback), non-default `templateRoots`, and refs containing slashes. Full suite passes (14/14).

## Breaking Changes
- [x] No breaking changes
- [ ] Breaking changes (describe below)

The cache version bump invalidates existing on-disk caches, which then repopulate transparently on next refresh. No settings changes, no user action required.

## Risk and Rollback
- **Main risks:**
  - Cache invalidation is one-time and affects all users on first launch after the upgrade. If the refresh fails (network, auth), users may see "Component not in cache" messaging until repopulation succeeds — the same surface as today's behaviour when the cache is empty for any other reason, just affecting everyone at once. Chose this over field-level backfill because one schema-version check is far less code to maintain as the schema evolves.
  - Components from projects not listed in `componentSources` produce no link (intentional — no resolved path means no link). If anyone was relying on VS Code's broken default URL underline as a navigation aid for unconfigured projects, that goes away. Acceptable trade-off: the previous behaviour landed on 404s anyway, since GitLab component URLs aren't real navigable web URLs.
  - VS Code's built-in URL detection still fires on `https://...` substrings; extension-contributed links take precedence in the link picker so cmd-click hits the new provider's link, but the underline rendering may overlap visually in some themes.
- **Rollback strategy:** revert the commit. The cache version goes back to `1.0.0`; users who upgraded then rolled back see one more cache invalidation as the new version is treated as a downgrade. No data loss.

## Release Notes Draft
- Fix: `component:` URLs in GitLab CI files are now underlined and cmd-clickable, including when they use `$CI_SERVER_FQDN` or other GitLab variables. The link points at the actual template file or directory on the source GitLab project, matching the repo's layout.

## Checklist
- [x] Branch is up to date with target branch
- [x] Commit messages follow conventional commits
- [ ] Added/updated docs for behavior or settings changes
- [x] Added/updated tests for new behavior
- [x] No secrets or tokens in code, logs, screenshots, or test fixtures
