### PR TITLE
Chore: eslint quick wins

### DIFF
--- a/package.json
+++ b/package.json
@@ -312,7 +312,7 @@
     "test:unit": "node tests/run-tests.js unit",
     "test:integration": "node tests/run-tests.js integration",
     "test:all": "node tests/run-tests.js && npm run test:extension-host",
-    "pretest:extension-host": "npm run compile && tsc --project tsconfig.test.json",
+    "pretest:extension-host": "rm -rf out-test && npm run compile && tsc --project tsconfig.test.json",
     "test:extension-host": "node out-test/runTest.js",
     "release": "release-it",
     "release:beta": "release-it --config .release-it.beta.json",

--- a/src/errors/handler.ts
+++ b/src/errors/handler.ts
@@ -169,13 +169,13 @@ export class ErrorHandler {
         error.userMessage,
         ...actions
       );
-      await this.handleAction(selection, error);
+      await this.handleAction(selection);
     } else {
       const selection = await vscode.window.showErrorMessage(
         error.userMessage,
         ...actions
       );
-      await this.handleAction(selection, error);
+      await this.handleAction(selection);
     }
   }
 
@@ -217,10 +217,7 @@ export class ErrorHandler {
   /**
    * Handle user action selection
    */
-  private async handleAction(
-    action: string | undefined,
-    error: GitLabComponentError
-  ): Promise<void> {
+  private async handleAction(action: string | undefined): Promise<void> {
     if (!action) {
       return;
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,8 +7,6 @@ import { detectIncludeComponent } from './providers/componentDetector';
 import { getComponentCacheManager, ComponentCacheManager } from './services/cache/componentCacheManager';
 import { Logger } from './utils/logger';
 import { ValidationProvider } from './providers/validationProvider';
-import { parseYaml } from './utils/yamlParser';
-import { DetachedComponentTemplate } from './templates';
 import { getPerformanceMonitor } from './utils/performanceMonitor';
 import { isGitLabCIFile, invalidateFileGlobsCache } from './utils/gitlabCiFileMatcher';
 
@@ -247,10 +245,12 @@ export function activate(context: vscode.ExtensionContext) {
         const componentsBySource = new Map<string, any[]>();
         components.forEach((comp: any) => {
           const key = comp.source;
-          if (!componentsBySource.has(key)) {
-            componentsBySource.set(key, []);
+          let bucket = componentsBySource.get(key);
+          if (!bucket) {
+            bucket = [];
+            componentsBySource.set(key, bucket);
           }
-          componentsBySource.get(key)!.push(comp);
+          bucket.push(comp);
         });
 
         logger.info(`[Extension] Components grouped by source:`, 'Extension');
@@ -625,101 +625,5 @@ export function activate(context: vscode.ExtensionContext) {
   }
 }
 
-/**
- * Helper function to generate HTML for detached component details.
- * Detects existing inputs and delegates to the template for rendering.
- */
-async function getDetachedComponentHtml(component: any): Promise<string> {
-  const existingInputs = await detectExistingInputs(component);
-  return DetachedComponentTemplate.render(component, existingInputs);
-}
-
-/**
- * Detects existing input parameters for a component in the active editor.
- * Returns an array of input parameter names already present in the file.
- */
-async function detectExistingInputs(component: any): Promise<string[]> {
-  const parameters = component.parameters || [];
-  const existingInputs: string[] = [];
-  const editor = vscode.window.activeTextEditor;
-
-  if (!editor || parameters.length === 0) {
-    return existingInputs;
-  }
-
-  if (editor && parameters.length > 0) {
-    try {
-      const document = editor.document;
-      const text = document.getText();
-
-      // Parse the YAML to find component includes and their inputs
-      const parsedYaml = parseYaml(text);
-      if (parsedYaml && parsedYaml.include) {
-        const includes = Array.isArray(parsedYaml.include) ? parsedYaml.include : [parsedYaml.include];
-
-        for (const include of includes) {
-          if (include.component && include.inputs) {
-            // Check if this include is for the current component
-            const componentUrl = include.component;
-            if (componentUrl.includes(component.name)) {
-              // Extract input parameter names from this component's inputs
-              for (const inputName in include.inputs) {
-                if (parameters.some((p: any) => p.name === inputName)) {
-                  existingInputs.push(inputName);
-                }
-              }
-            }
-          }
-        }
-      }
-    } catch (error) {
-      // Silently ignore parsing errors and fall back to regex-based detection
-      try {
-        const document = editor.document;
-        const text = document.getText();
-
-        // Simple regex-based detection of component inputs as fallback
-        const componentUrlPattern = component.name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-        const componentRegex = new RegExp(`component:\\s*[^\\n]*${componentUrlPattern}[^\\n]*`, 'g');
-        const match = componentRegex.exec(text);
-
-        if (match) {
-          // Find the inputs section for this component
-          const startIndex = match.index + match[0].length;
-          const remainingText = text.substring(startIndex);
-
-          // Look for inputs: section
-          const inputsMatch = remainingText.match(/^\s*inputs:\s*$/m);
-          if (inputsMatch) {
-            const inputsStartIndex = startIndex + inputsMatch.index! + inputsMatch[0].length;
-            const afterInputsText = text.substring(inputsStartIndex);
-
-            // Extract input parameter names
-            const inputLines = afterInputsText.split('\n');
-            for (const line of inputLines) {
-              // Stop at next job or section
-              if (line.match(/^\S/) && !line.trim().startsWith('#')) {
-                break;
-              }
-
-              // Match input parameter lines (indented with parameter name)
-              const paramMatch = line.match(/^\s{2,}([a-zA-Z][a-zA-Z0-9_-]*)\s*:/);
-              if (paramMatch) {
-                const paramName = paramMatch[1];
-                if (parameters.some((p: any) => p.name === paramName)) {
-                  existingInputs.push(paramName);
-                }
-              }
-            }
-          }
-        }
-      } catch (fallbackError) {
-        // Silently ignore errors
-      }
-    }
-  }
-
-  return existingInputs;
-}
 
 export function deactivate() {}

--- a/src/parsers/specParser.ts
+++ b/src/parsers/specParser.ts
@@ -1,9 +1,8 @@
 import { SPEC_INPUTS_SECTION_REGEX } from '../constants/regex';
 import { Logger } from '../utils/logger';
-import { ParseError, ErrorCode, getErrorHandler } from '../errors';
+import { ParseError } from '../errors';
 
 const logger = Logger.getInstance();
-const errorHandler = getErrorHandler();
 
 export interface ComponentVariable {
   name: string;

--- a/src/providers/completionProvider.ts
+++ b/src/providers/completionProvider.ts
@@ -1,9 +1,7 @@
 import * as vscode from 'vscode';
 import { getComponentUnderCursor, getGitRepositoryContext } from './componentDetector';
-import { getComponentService } from '../services/component';
-import { GitLabCatalogComponent, GitLabCatalogVariable } from '../types/gitlab-catalog';
 import { getComponentCacheManager } from '../services/cache/componentCacheManager';
-import { getVariableCompletions, GITLAB_PREDEFINED_VARIABLES, containsGitLabVariables, expandComponentUrl } from '../utils/gitlabVariables';
+import { getVariableCompletions, containsGitLabVariables, expandComponentUrl } from '../utils/gitlabVariables';
 import { Logger } from '../utils/logger';
 import { isGitLabCIFile } from '../utils/gitlabCiFileMatcher';
 
@@ -214,21 +212,6 @@ export class CompletionProvider implements vscode.CompletionItemProvider {
       }
 
       item.documentation = new vscode.MarkdownString(documentation);
-
-      // Check user preferences for default version
-      const config = vscode.workspace.getConfiguration('gitlabComponentHelper');
-      const defaultVersions = config.get<Record<string, string>>('defaultVersions', {});
-      const alwaysLatest = config.get<string[]>('alwaysUseLatest', []);
-
-      let versionToUse = bestVersion;
-
-      if (alwaysLatest.includes(component.name)) {
-        // User wants to always use latest for this component
-        versionToUse = bestVersion; // bestVersion is already the latest
-      } else if (defaultVersions[component.name]) {
-        // User has set a specific default version for this component
-        versionToUse = defaultVersions[component.name];
-      }
 
       // For now, suggest the URL with the best version - user can change the version later
       if (componentUrl.includes('@')) {
@@ -503,7 +486,7 @@ export class CompletionProvider implements vscode.CompletionItemProvider {
 
         // Filter out already provided inputs
         const missingInputs = component.parameters.filter((param: any) =>
-          !existingInputs.hasOwnProperty(param.name)
+          !Object.prototype.hasOwnProperty.call(existingInputs, param.name)
         );
 
         this.logger.debug(`[CompletionProvider] Found ${missingInputs.length} missing inputs for completion: ${missingInputs.map((p: any) => p.name).join(', ')}`, 'CompletionProvider');
@@ -523,7 +506,7 @@ export class CompletionProvider implements vscode.CompletionItemProvider {
           item.documentation = new vscode.MarkdownString(documentation);
 
           // Smart insert text based on parameter type and default value
-          let insertValue = '';
+          let insertValue: string;
           if (param.default !== undefined) {
             if (typeof param.default === 'string') {
               insertValue = `"${param.default}"`;

--- a/src/providers/componentBrowserProvider.ts
+++ b/src/providers/componentBrowserProvider.ts
@@ -2,8 +2,8 @@ import * as vscode from 'vscode';
 import { getComponentService } from '../services/component';
 import { ComponentCacheManager } from '../services/cache/componentCacheManager';
 import { GitLabCatalogComponent, GitLabCatalogVariable } from '../types/gitlab-catalog';
-import { Component, ComponentParameter } from './componentDetector';
-import { containsGitLabVariables, expandGitLabVariables } from '../utils/gitlabVariables';
+import { ComponentParameter } from './componentDetector';
+import { containsGitLabVariables } from '../utils/gitlabVariables';
 import { Logger } from '../utils/logger';
 
 // Constants for timing delays
@@ -95,10 +95,10 @@ export class ComponentBrowserProvider {
             await this.fetchAndCacheVersion(message.componentName, message.sourcePath, message.gitlabInstance, message.version);
             return;
           case 'setDefaultVersion':
-            await this.setDefaultVersion(message.componentName, message.version, message.projectId);
+            await this.setDefaultVersion(message.componentName, message.version);
             return;
           case 'setAlwaysUseLatest':
-            await this.setAlwaysUseLatest(message.componentName, message.projectId);
+            await this.setAlwaysUseLatest(message.componentName);
             return;
           case 'expandComponent':
             await this.handleComponentExpand(message.componentName, message.projectId);
@@ -2258,37 +2258,38 @@ ${sourceErrors.size > 0 ? '\nErrors:\n' + Array.from(sourceErrors.entries()).map
       }
 
       // Initialize main source if not exists
-      if (!hierarchy.has(mainSource)) {
-        hierarchy.set(mainSource, {
+      let sourceGroup = hierarchy.get(mainSource);
+      if (!sourceGroup) {
+        sourceGroup = {
           source: mainSource,
           type: 'source',
           isExpanded: true, // Sources start expanded
           projects: new Map<string, any>(),
           totalComponents: 0,
           totalVersions: 0
-        });
+        };
+        hierarchy.set(mainSource, sourceGroup);
       }
-
-      const sourceGroup = hierarchy.get(mainSource)!;
 
       // Initialize project if not exists
       const projectKey = `${projectPath}@${comp.gitlabInstance}`;
-      if (!sourceGroup.projects.has(projectKey)) {
-        sourceGroup.projects.set(projectKey, {
+      let projectGroup = sourceGroup.projects.get(projectKey);
+      if (!projectGroup) {
+        projectGroup = {
           name: projectName,
           path: projectPath,
           gitlabInstance: comp.gitlabInstance,
           type: 'project',
           isExpanded: false, // Projects start collapsed
           components: new Map<string, any>() // Map by component name to group versions
-        });
+        };
+        sourceGroup.projects.set(projectKey, projectGroup);
       }
 
-      const projectGroup = sourceGroup.projects.get(projectKey)!;
-
       // Group components by name to handle multiple versions
-      if (!projectGroup.components.has(comp.name)) {
-        projectGroup.components.set(comp.name, {
+      let componentGroup = projectGroup.components.get(comp.name);
+      if (!componentGroup) {
+        componentGroup = {
           name: comp.name,
           description: comp.description || 'No description available',
           summary: comp.summary,
@@ -2303,16 +2304,14 @@ ${sourceErrors.size > 0 ? '\nErrors:\n' + Array.from(sourceErrors.entries()).map
           versions: new Map<string, any>(),
           defaultVersion: comp.version || 'latest',
           availableVersions: comp.availableVersions || []
-        });
+        };
+        projectGroup.components.set(comp.name, componentGroup);
         sourceGroup.totalComponents++;
       } else if (comp.availableVersions) {
         // Merge availableVersions from subsequent cache entries
-        const existing = projectGroup.components.get(comp.name)!;
-        const merged = new Set([...existing.availableVersions, ...comp.availableVersions]);
-        existing.availableVersions = Array.from(merged);
+        const merged = new Set([...componentGroup.availableVersions, ...comp.availableVersions]);
+        componentGroup.availableVersions = Array.from(merged);
       }
-
-      const componentGroup = projectGroup.components.get(comp.name)!;
 
       // Add this version to the component
       componentGroup.versions.set(comp.version || 'latest', {
@@ -2543,7 +2542,7 @@ ${sourceErrors.size > 0 ? '\nErrors:\n' + Array.from(sourceErrors.entries()).map
     }
   }
 
-  private async setDefaultVersion(componentName: string, version: string, projectId: string) {
+  private async setDefaultVersion(componentName: string, version: string) {
     try {
       // Store user preference for this component's default version
       const config = vscode.workspace.getConfiguration('gitlabComponentHelper');
@@ -2560,7 +2559,7 @@ ${sourceErrors.size > 0 ? '\nErrors:\n' + Array.from(sourceErrors.entries()).map
     }
   }
 
-  private async setAlwaysUseLatest(componentName: string, projectId: string) {
+  private async setAlwaysUseLatest(componentName: string) {
     try {
       // Store user preference to always use latest for this component
       const config = vscode.workspace.getConfiguration('gitlabComponentHelper');

--- a/src/providers/componentDetector.ts
+++ b/src/providers/componentDetector.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { getComponentService } from '../services/component';
 import { getComponentCacheManager } from '../services/cache/componentCacheManager';
 import { GitLabCatalogComponent, GitLabCatalogVariable } from '../types/gitlab-catalog';
-import { expandGitLabVariables, containsGitLabVariables, detectGitLabVariables, expandComponentUrl } from '../utils/gitlabVariables';
+import { containsGitLabVariables, detectGitLabVariables, expandComponentUrl } from '../utils/gitlabVariables';
 import { Logger } from '../utils/logger';
 import { spawn } from 'child_process';
 
@@ -97,7 +97,7 @@ export async function detectIncludeComponent(document: vscode.TextDocument, posi
     // Try to get Git repository context first, scoped to the active file so
     // multi-repo workspaces resolve to the correct GitLab host.
     const gitContext = await getGitRepositoryContext(document.uri);
-    let expandedUrl = componentUrl;
+    let expandedUrl: string;
 
     if (gitContext.gitlabInstance && gitContext.projectPath) {
       logger.debug(`[ComponentDetector] Using Git repository context: ${gitContext.gitlabInstance}/${gitContext.projectPath}`, 'ComponentDetector');

--- a/src/providers/hoverProvider.ts
+++ b/src/providers/hoverProvider.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { getComponentUnderCursor, Component, ComponentParameter, detectIncludeComponent } from './componentDetector';
+import { Component, ComponentParameter, detectIncludeComponent } from './componentDetector';
 import { Logger } from '../utils/logger';
 import { getVariableInfo } from '../utils/gitlabVariables';
 import { parseYaml } from '../utils/yamlParser';
@@ -19,7 +19,6 @@ export class HoverProvider implements vscode.HoverProvider {
     this.logger.debug(`[HoverProvider] Hover requested at line ${position.line + 1}, character ${position.character}`, 'HoverProvider');
     this.logger.debug(`[HoverProvider] File: ${document.fileName} (language: ${document.languageId})`, 'HoverProvider');
 
-    const line = document.lineAt(position.line).text;
     const wordRange = document.getWordRangeAtPosition(position);
 
     // Check if we're hovering over a component input parameter first
@@ -206,7 +205,6 @@ export class HoverProvider implements vscode.HoverProvider {
       this.logger.debug(`[HoverProvider] Found closest component: ${closestComponent.componentUrl}`, 'HoverProvider');
 
       // Verify we're in the inputs section of this component
-      const include = closestComponent.include;
       const componentLineIndex = closestComponent.componentLineIndex;
 
       // Look for inputs: section between component and current line

--- a/src/providers/validationProvider.ts
+++ b/src/providers/validationProvider.ts
@@ -365,7 +365,7 @@ export class ValidationProvider implements vscode.CodeActionProvider {
                     }
 
                     for (const componentInput of componentInputs) {
-                        if (componentInput.required && !providedInputs.hasOwnProperty(componentInput.name)) {
+                        if (componentInput.required && !Object.prototype.hasOwnProperty.call(providedInputs, componentInput.name)) {
                             const line = this.findLineForComponent(document, include);
                             const range = new vscode.Range(line, 0, line, document.lineAt(line).text.length);
                             const diagnostic = new vscode.Diagnostic(
@@ -608,7 +608,6 @@ export class ValidationProvider implements vscode.CodeActionProvider {
             }
             else if (diagnostic.code === 'unresolved-variables' && (diagnostic as any).metadata) {
                 const metadata = (diagnostic as any).metadata;
-                const componentUrl = metadata.componentUrl as string;
                 const isNonGitlabRepo = metadata.isNonGitlabRepo as boolean;
 
                 // Different suggestions based on repository type
@@ -710,7 +709,7 @@ export class ValidationProvider implements vscode.CodeActionProvider {
                     const componentLine = diagnostic.range.start.line;
                     const insertInfo = this.findInputsInsertPosition(document, componentLine);
 
-                    let insertText = '';
+                    let insertText: string;
                     if (insertInfo.needsInputsSection) {
                         // Add inputs section
                         insertText = `${insertInfo.indentation}inputs:\n${insertInfo.indentation}  ${missingInput}: `;
@@ -1082,7 +1081,7 @@ export class ValidationProvider implements vscode.CodeActionProvider {
 
         quickPick.onDidAccept(async () => {
             const document = await vscode.workspace.openTextDocument(vscode.Uri.parse(args.documentUri));
-            const editor = await vscode.window.showTextDocument(document);
+            await vscode.window.showTextDocument(document);
 
             if (args.type === 'replace' && quickPick.selectedItems.length === 1) {
                 // Replace the unknown input with the selected one
@@ -1394,7 +1393,7 @@ export class ValidationProvider implements vscode.CodeActionProvider {
     /**
      * Fallback method to get git info using git commands
      */
-    private async getGitInfoFromCommand(workspacePath: string): Promise<{
+    private async getGitInfoFromCommand(_workspacePath: string): Promise<{
         gitlabInstance?: string;
         projectPath?: string;
         commitSha?: string;

--- a/src/services/cache/groupCache.ts
+++ b/src/services/cache/groupCache.ts
@@ -1,4 +1,3 @@
-import * as vscode from 'vscode';
 import { getComponentService } from '../component';
 import { Logger } from '../../utils/logger';
 import { CachedComponent } from '../../types/cache';

--- a/src/services/cache/projectCache.ts
+++ b/src/services/cache/projectCache.ts
@@ -1,4 +1,3 @@
-import * as vscode from 'vscode';
 import { getComponentService } from '../component';
 import { Logger } from '../../utils/logger';
 import { CachedComponent } from '../../types/cache';

--- a/src/services/cache/versionCache.ts
+++ b/src/services/cache/versionCache.ts
@@ -1,4 +1,3 @@
-import * as vscode from 'vscode';
 import { getComponentService } from '../component';
 import { Logger } from '../../utils/logger';
 import { CachedComponent } from '../../types/cache';

--- a/src/services/component/commands.ts
+++ b/src/services/component/commands.ts
@@ -27,7 +27,7 @@ export function registerAddProjectTokenCommand(
         // Remove leading/trailing slashes and join path
         projectPath = parsed.pathname.replace(/^\/+|\/+$/g, '');
         if (!gitlabInstance || !projectPath) throw new Error('Invalid URL');
-      } catch (e) {
+      } catch {
         vscode.window.showErrorMessage('Invalid GitLab URL. Please enter a valid project or group URL.');
         return;
       }
@@ -106,7 +106,7 @@ export function registerAddProjectTokenCommand(
           if (!service['tokenManager']) {
             service.setSecretStorage(context.secrets);
           }
-          await service.setTokenForProject(gitlabInstance, projectPath, token.trim());
+          await service.setTokenForProject(gitlabInstance, token.trim());
           vscode.window.showInformationMessage(
             `Component source "${displayName}" added successfully with token for ${gitlabInstance}!`
           );

--- a/src/services/component/componentFetcher.ts
+++ b/src/services/component/componentFetcher.ts
@@ -25,8 +25,7 @@ interface GitLabTreeItem {
 async function promptForTokenIfNeeded(
   context: vscode.ExtensionContext | undefined,
   tokenManager: TokenManager,
-  gitlabInstance: string,
-  projectPath: string
+  gitlabInstance: string
 ): Promise<string | undefined> {
   const tokenPrompt = `This project/group requires a GitLab personal access token for ${gitlabInstance}. Please enter one to continue.`;
   const token = await vscode.window.showInputBox({
@@ -35,7 +34,7 @@ async function promptForTokenIfNeeded(
     ignoreFocusOut: true
   });
   if (token && token.trim()) {
-    await tokenManager.setTokenForProject(gitlabInstance, projectPath, token.trim());
+    await tokenManager.setTokenForProject(gitlabInstance, token.trim());
     vscode.window.showInformationMessage(`Token saved for ${gitlabInstance}`);
     return token.trim();
   } else if (token === '') {
@@ -128,7 +127,7 @@ export class ComponentFetcher {
           namespaceProject
         )}`;
 
-        const token = await this.tokenManager.getTokenForProject(gitlabInstance, projectPath);
+        const token = await this.tokenManager.getTokenForProject(gitlabInstance);
         const catalogFetchOptions = token ? { headers: { 'PRIVATE-TOKEN': token } } : undefined;
 
         this.logger.debug(`Trying to fetch from GitLab Catalog API: ${catalogApiUrl}`);
@@ -215,7 +214,7 @@ export class ComponentFetcher {
 
       this.logger.debug(`Fetching project info from: ${projectApiUrl}`);
 
-      let token = await this.tokenManager.getTokenForProject(gitlabInstance, projectPath);
+      let token = await this.tokenManager.getTokenForProject(gitlabInstance);
       let fetchOptions = token ? { headers: { 'PRIVATE-TOKEN': token } } : undefined;
 
       this.logger.debug(`Using token for ${gitlabInstance}: ${token ? 'YES' : 'NO'}`);
@@ -231,7 +230,7 @@ export class ComponentFetcher {
       } catch (err: any) {
         if (err && (err.status === 401 || err.status === 403)) {
           // Prompt for token and retry
-          token = await promptForTokenIfNeeded(context, this.tokenManager, gitlabInstance, projectPath);
+          token = await promptForTokenIfNeeded(context, this.tokenManager, gitlabInstance);
           if (token) {
             fetchOptions = { headers: { 'PRIVATE-TOKEN': token } };
             [projectInfo, templateResult] = await Promise.allSettled([
@@ -402,11 +401,11 @@ export class ComponentFetcher {
     try {
       const apiBaseUrl = `https://${cleanGitlabInstance}/api/v4`;
       let ref = version || 'main';
-      let token = await this.tokenManager.getTokenForProject(cleanGitlabInstance, projectPath);
+      let token = await this.tokenManager.getTokenForProject(cleanGitlabInstance);
       let fetchOptions = token ? { headers: { 'PRIVATE-TOKEN': token } } : undefined;
 
       // **PARALLEL OPTIMIZATION with GRACEFUL DEGRADATION** - Fetch project info and templates in parallel
-      const [projectInfoResult, templatesResult] = await Promise.allSettled([
+      const [projectInfoResult] = await Promise.allSettled([
         this.httpClient.fetchJson(
           `${apiBaseUrl}/projects/${encodeURIComponent(projectPath)}`,
           fetchOptions
@@ -420,17 +419,16 @@ export class ComponentFetcher {
       ]);
 
       let projectInfo: any;
-      let templates: any;
 
       // Handle authentication errors and retry if needed
       if (projectInfoResult.status === 'rejected') {
         const err = projectInfoResult.reason;
         if (err && (err.status === 401 || err.status === 403)) {
           // Prompt for token and retry
-          token = await promptForTokenIfNeeded(context, this.tokenManager, cleanGitlabInstance, projectPath);
+          token = await promptForTokenIfNeeded(context, this.tokenManager, cleanGitlabInstance);
           if (token) {
             fetchOptions = { headers: { 'PRIVATE-TOKEN': token } };
-            const [retryProjectInfo, retryTemplates] = await Promise.allSettled([
+            const [retryProjectInfo] = await Promise.allSettled([
               this.httpClient.fetchJson(
                 `${apiBaseUrl}/projects/${encodeURIComponent(projectPath)}`,
                 fetchOptions
@@ -448,7 +446,6 @@ export class ComponentFetcher {
             }
 
             projectInfo = retryProjectInfo.value;
-            templates = retryTemplates.status === 'fulfilled' ? retryTemplates.value : [] as GitLabTreeItem[];
           } else {
             throw err;
           }
@@ -457,7 +454,6 @@ export class ComponentFetcher {
         }
       } else {
         projectInfo = projectInfoResult.value;
-        templates = templatesResult.status === 'fulfilled' ? templatesResult.value : [] as GitLabTreeItem[];
       }
 
       // Use the project's default branch if available
@@ -498,8 +494,8 @@ export class ComponentFetcher {
             fetchOptions
           );
 
-          let description = '';
-          let variables: ComponentVariable[] = [];
+          let description: string;
+          let variables: ComponentVariable[];
 
           // Process template content - skip files that don't have a spec section
           if (templateResult) {
@@ -627,7 +623,7 @@ export class ComponentFetcher {
     projectPath: string
   ): Promise<any> {
     const apiBaseUrl = `https://${gitlabInstance}/api/v4`;
-    const token = await this.tokenManager.getTokenForProject(gitlabInstance, projectPath);
+    const token = await this.tokenManager.getTokenForProject(gitlabInstance);
     const fetchOptions = token ? { headers: { 'PRIVATE-TOKEN': token } } : undefined;
 
     return this.httpClient.fetchJson(

--- a/src/services/component/componentService.ts
+++ b/src/services/component/componentService.ts
@@ -21,7 +21,6 @@ interface CacheEntry {
 }
 
 const sourceCache = new Map<string, CacheEntry>();
-const backgroundUpdateInProgress = false;
 
 /**
  * Main component service that orchestrates fetching and managing GitLab components
@@ -55,19 +54,12 @@ export class ComponentService implements ComponentSource {
     this.tokenManager.setSecretStorage(secretStorage);
   }
 
-  public async getTokenForProject(
-    gitlabInstance: string,
-    projectPath: string
-  ): Promise<string | undefined> {
-    return this.tokenManager.getTokenForProject(gitlabInstance, projectPath);
+  public async getTokenForProject(gitlabInstance: string): Promise<string | undefined> {
+    return this.tokenManager.getTokenForProject(gitlabInstance);
   }
 
-  public async setTokenForProject(
-    gitlabInstance: string,
-    projectPath: string,
-    token: string
-  ): Promise<void> {
-    return this.tokenManager.setTokenForProject(gitlabInstance, projectPath, token);
+  public async setTokenForProject(gitlabInstance: string, token: string): Promise<void> {
+    return this.tokenManager.setTokenForProject(gitlabInstance, token);
   }
 
   public async getTokenForInstance(gitlabInstance: string): Promise<string | undefined> {

--- a/src/services/component/tokenManager.ts
+++ b/src/services/component/tokenManager.ts
@@ -15,14 +15,10 @@ export class TokenManager {
   }
 
   /**
-   * Get token for a specific GitLab project
+   * Get token for a specific GitLab instance
    * @param gitlabInstance The GitLab instance hostname (e.g., 'gitlab.com')
-   * @param projectPath The project path (not currently used, but kept for API compatibility)
    */
-  public async getTokenForProject(
-    gitlabInstance: string,
-    projectPath: string
-  ): Promise<string | undefined> {
+  public async getTokenForProject(gitlabInstance: string): Promise<string | undefined> {
     if (!this.secretStorage) {
       this.logger.debug(`No secretStorage available for ${gitlabInstance}`);
       return undefined;
@@ -35,16 +31,11 @@ export class TokenManager {
   }
 
   /**
-   * Store token for a specific GitLab project
+   * Store token for a specific GitLab instance
    * @param gitlabInstance The GitLab instance hostname
-   * @param projectPath The project path (not currently used, but kept for API compatibility)
    * @param token The personal access token to store
    */
-  public async setTokenForProject(
-    gitlabInstance: string,
-    projectPath: string,
-    token: string
-  ): Promise<void> {
+  public async setTokenForProject(gitlabInstance: string, token: string): Promise<void> {
     if (!this.secretStorage) {
       throw new Error('SecretStorage not available');
     }

--- a/src/services/component/versionManager.ts
+++ b/src/services/component/versionManager.ts
@@ -7,10 +7,6 @@ interface GitLabTag {
   commit: any;
 }
 
-interface GitLabBranch {
-  name: string;
-}
-
 /**
  * Manages fetching and sorting versions (tags and branches) for GitLab projects
  */
@@ -43,7 +39,7 @@ export class VersionManager {
       this.logger.info(`Fetching versions for ${gitlabInstance}/${projectPath}`);
 
       // Try to get a token for this project/instance
-      const token = await this.tokenManager.getTokenForProject(gitlabInstance, projectPath);
+      const token = await this.tokenManager.getTokenForProject(gitlabInstance);
       const fetchOptions = token ? { headers: { 'PRIVATE-TOKEN': token } } : undefined;
 
       this.logger.debug(`Using token for versions fetch: ${token ? 'YES' : 'NO'}`);
@@ -144,7 +140,7 @@ export class VersionManager {
         projectPath
       )}/repository/tags?per_page=100&order_by=updated&sort=desc`;
 
-      const token = await this.tokenManager.getTokenForProject(gitlabInstance, projectPath);
+      const token = await this.tokenManager.getTokenForProject(gitlabInstance);
       const options = token ? { headers: { 'PRIVATE-TOKEN': token } } : undefined;
       const tags = await this.httpClient.fetchJson(apiUrl, options);
 

--- a/src/utils/performanceMonitor.ts
+++ b/src/utils/performanceMonitor.ts
@@ -116,11 +116,12 @@ export class PerformanceMonitor {
     duration: number,
     metadata?: Record<string, any>
   ): void {
-    if (!this.metrics.has(name)) {
-      this.metrics.set(name, []);
+    let metrics = this.metrics.get(name);
+    if (!metrics) {
+      metrics = [];
+      this.metrics.set(name, metrics);
     }
 
-    const metrics = this.metrics.get(name)!;
     metrics.push({
       name,
       duration,

--- a/src/utils/yamlParser.ts
+++ b/src/utils/yamlParser.ts
@@ -42,7 +42,7 @@ function cleanParseCache(currentTime: number): void {
   }
 }
 
-export function getYamlNodeAtPosition(document: vscode.TextDocument, position: vscode.Position): any {
+export function getYamlNodeAtPosition(document: vscode.TextDocument, _position: vscode.Position): any {
   const text = document.getText();
   const parsed = parseYaml(text);
 


### PR DESCRIPTION
## Summary
- Mechanical lint cleanup. `npm run lint` was emitting **218 warnings** — enough noise that real new findings would get lost. This PR clears every non-`any` warning class (50 sites) so the remaining 168 warnings are exclusively `@typescript-eslint/no-explicit-any` and the output becomes meaningful again.
- Link related issue(s): n/a

## Change Type
- [ ] feat
- [ ] fix
- [ ] refactor
- [ ] docs
- [ ] test
- [x] chore

## Context
### User-facing impact
- None. The extension binary is unchanged in behaviour. All edits are inside the warning sites only; no surrounding refactoring, no new abstractions, no new dependencies.

### GitLab scope
- [ ] gitlab.com
- [ ] self-managed GitLab
- [x] both (no behavioural change to either)

### Affected areas
- [ ] Component Browser
- [ ] Hover provider
- [ ] Completion provider
- [ ] Validation provider
- [ ] Cache and refresh behavior
- [ ] GitLab API calls/auth/token storage
- [ ] Docs only

(Touches files across every provider/service, but only at warning sites — no behavioural change in any of them.)

## What changed by rule

| Rule | Count | Approach |
|---|---|---|
| `@typescript-eslint/no-unused-vars` | 29 | Deleted dead imports/vars; renamed unused params with `_` only where the param represents a genuine future-work placeholder (2 sites). For the rest, dropped the parameter entirely and propagated to callers. |
| `@typescript-eslint/no-non-null-assertion` | 7 | Refactored the `map.set(k,v); … map.get(k)!` pattern to hoist the entry into a local variable before storing it — `push`/use the local instead of round-tripping through the map. |
| `no-useless-assignment` | 5 | Removed the dead initial write (`let x = ''` immediately overwritten in every branch becomes `let x: string`). |
| `no-prototype-builtins` | 2 | Replaced `obj.hasOwnProperty(k)` with `Object.prototype.hasOwnProperty.call(obj, k)`. |

### Notable cascades from "delete dead code completely" (per project convention)
- **`getDetachedComponentHtml` + `detectExistingInputs` removed entirely** ([extension.ts](src/extension.ts)). The first was flagged as unused; the second was its only caller. Removing both also let me drop the now-unused `parseYaml` and `DetachedComponentTemplate` imports.
- **`versionToUse` block removed** ([completionProvider.ts](src/providers/completionProvider.ts)) — the assigned variable was never read, so the surrounding `defaultVersions` / `alwaysLatest` config reads went with it.
- **`projectPath` dropped from `TokenManager.getTokenForProject` and `setTokenForProject`** ([tokenManager.ts](src/services/component/tokenManager.ts)) — the body uses `gitlab-token-${gitlabInstance}` as the key; `projectPath` was historic dead weight kept "for API compatibility" per the old JSDoc. Updated all 10 callers + the `componentService.ts` re-export + `promptForTokenIfNeeded` (which only existed to pass the value through). Public method signature changes, but no external consumers.

### What stayed
- Two `_`-prefixed params kept as **genuine future-work placeholders**, where the body has a TODO and the param represents the input the real implementation would need:
  - [validationProvider.ts:1396](src/providers/validationProvider.ts#L1396) `_workspacePath` — "in a real implementation you might want to execute git commands"
  - [yamlParser.ts:45](src/utils/yamlParser.ts#L45) `_position` — "TODO: Implement actual position-based node finding"

## Drive-by: `pretest:extension-host` clean step
While verifying this PR I discovered `out-test/` is gitignored build output but `pretest:extension-host` never pruned it. Switching from another branch left an orphan behind, which the test loader (which globs `**/*.test.js`) kept loading even though the source no longer existed on the current branch — producing 5 phantom failures that looked like regressions until traced. Fix: prepend `rm -rf out-test` to `pretest:extension-host` so the directory is rebuilt from scratch every run.

## Validation
### Local checks
- [x] `npm run compile` — bundle still builds (`out/extension.js`).
- [x] `npm test` — 14/14 passing.
- [x] Manual verification in VS Code Extension Host — `env -u ELECTRON_RUN_AS_NODE npm run test:extension-host` 5/5 passing on a freshly-built `out-test/` (after the pretest clean fix).
- [x] `npm run lint` — **218 → 168 warnings.** All 168 remaining are `@typescript-eslint/no-explicit-any`. Zero in-scope warnings remain.
- [x] `npm run check-types` — clean.

### Manual test notes
- Spot-checked the `map.set` → local-variable refactors in [componentBrowserProvider.ts:2260-2310](src/providers/componentBrowserProvider.ts#L2260-L2310): the hierarchy → projects → components nesting still constructs the same shape; `totalComponents++` still runs exactly once per new component (moved inside the "not seen" branch where it always was, just reachable via the local instead of via `map.get(...)!`).
- Spot-checked the `templates` cleanup in [componentFetcher.ts](src/services/component/componentFetcher.ts#L408-L460): the `Promise.allSettled` parallel fetches still happen (preserving any rate-limit / cache-warming side effects); only the unused destructure slot was dropped.

## Breaking Changes
- [x] No breaking changes
- [ ] Breaking changes (describe below)

Public method signatures on `TokenManager` and `ComponentService` (`getTokenForProject`, `setTokenForProject`) lose their `projectPath` parameter. These types aren't exported as a public extension API — they're internal classes consumed only within this repo. All in-repo callers updated.

## Screenshots / Recordings (if UI behavior changed)
- N/A — no UI changes.

## Risk and Rollback
- **Main risks:**
  - The non-null-assertion refactors change *how* the code retrieves a just-stored map entry but not *what* it retrieves. If any of them masked an ordering bug (concurrent mutation between `set` and `get`), the refactor surfaces it as a real reference instead of a silent get/!. None of the touched sites mutate the map between the set and the read, so the risk is theoretical.
  - Dropping `projectPath` from `TokenManager.getTokenForProject` is observable to anyone calling those methods externally — but they're internal classes with no external consumers in the marketplace API.
- **Rollback strategy:** Single PR — revert. No settings changes, no data migration, no CI secrets touched, no new dependencies.

## Release Notes Draft
- chore: clear 50 mechanical eslint warnings (unused vars, useless assignments, prototype-builtins, non-null assertions); lint output now exclusively flags `no-explicit-any`. Also: `pretest:extension-host` now prunes stale build output so branch switches don't leave traps.

## Checklist
- [x] Branch is up to date with target branch
- [x] Commit messages follow conventional commits
- [x] Added/updated docs for behavior or settings changes (none required)
- [x] Added/updated tests for new behavior (none required — pure cleanup)
- [x] No secrets or tokens in code, logs, screenshots, or test fixtures
