### PR TITLE
chore: eslint fix phase 3

### DIFF
--- a/src/services/cache/cacheTypes.ts
+++ b/src/services/cache/cacheTypes.ts
@@ -45,7 +45,7 @@ export interface SerializedCacheData {
   entries: Array<{
     type: CacheType;
     key: string;
-    data: any;
+    data: unknown;
     timestamp: number;
     ttl: number;
   }>;

--- a/src/services/cache/componentCacheManager.ts
+++ b/src/services/cache/componentCacheManager.ts
@@ -113,23 +113,7 @@ export class ComponentCacheManager {
   /**
    * Add a dynamically fetched component to the cache
    */
-  public addDynamicComponent(component: {
-    name: string;
-    description: string;
-    parameters: Array<{
-      name: string;
-      description: string;
-      required: boolean;
-      type: string;
-      default?: any;
-    }>;
-    source: string;
-    sourcePath: string;
-    gitlabInstance: string;
-    version: string;
-    url: string;
-    templatePath?: string;
-  }): void {
+  public addDynamicComponent(component: CachedComponent): void {
     try {
       // Check if component already exists (avoid duplicates)
       const existingIndex = this.components.findIndex(

--- a/src/services/cache/groupCache.ts
+++ b/src/services/cache/groupCache.ts
@@ -1,6 +1,7 @@
 import { getComponentService } from '../component';
 import { Logger } from '../../utils/logger';
 import { CachedComponent } from '../../types/cache';
+import type { GitLabGroupProject } from '../../types/api';
 import { ProjectCache } from './projectCache';
 
 /**
@@ -71,7 +72,7 @@ export class GroupCache {
           'GroupCache'
         );
 
-        const batchPromises = batch.map(async (project: any) => {
+        const batchPromises = batch.map(async project => {
           try {
             this.logger.debug(
               `[GroupCache] Checking ${project.path_with_namespace}...`,
@@ -151,7 +152,7 @@ export class GroupCache {
    * @param groupPath Group path
    * @returns Array of project objects from GitLab API
    */
-  async fetchGroupProjects(gitlabInstance: string, groupPath: string): Promise<any[]> {
+  async fetchGroupProjects(gitlabInstance: string, groupPath: string): Promise<GitLabGroupProject[]> {
     const componentService = getComponentService();
 
     try {
@@ -172,7 +173,7 @@ export class GroupCache {
       );
 
       // Use the fetchJson method with authentication options
-      const projects = await componentService.fetchJson(groupApiUrl, fetchOptions);
+      const projects = await componentService.fetchJson<GitLabGroupProject[]>(groupApiUrl, fetchOptions);
 
       this.logger.info(
         `[GroupCache] Found ${projects.length} total projects in group ${groupPath}`,

--- a/src/services/cache/projectCache.ts
+++ b/src/services/cache/projectCache.ts
@@ -42,7 +42,7 @@ export class ProjectCache {
           'ProjectCache'
         );
 
-        const sourceComponents: CachedComponent[] = catalogData.components.map((c: any) => {
+        const sourceComponents: CachedComponent[] = catalogData.components.map(c => {
           const componentUrl = `https://${gitlabInstance}/${projectPath}/${c.name}@${
             c.latest_version || 'main'
           }`;
@@ -50,7 +50,7 @@ export class ProjectCache {
           return {
             name: c.name,
             description: c.description || `Component from ${sourceName}`,
-            parameters: (c.variables || []).map((v: any) => ({
+            parameters: (c.variables || []).map(v => ({
               name: v.name,
               description: v.description || `Parameter: ${v.name}`,
               required: v.required || false,
@@ -140,7 +140,7 @@ export class ProjectCache {
       }
 
       // Find the matching component in the catalog
-      const catalogComponent = catalogData.components.find((c: any) => c.name === componentName);
+      const catalogComponent = catalogData.components.find(c => c.name === componentName);
       if (!catalogComponent) {
         this.logger.warn(
           `[ProjectCache] Component ${componentName} not found in version ${version}`,
@@ -153,7 +153,7 @@ export class ProjectCache {
       const cachedComponent: CachedComponent = {
         name: catalogComponent.name,
         description: catalogComponent.description || `Component from ${sourcePath}`,
-        parameters: (catalogComponent.variables || []).map((v: any) => ({
+        parameters: (catalogComponent.variables || []).map(v => ({
           name: v.name,
           description: v.description || `Parameter: ${v.name}`,
           required: v.required || false,

--- a/src/services/cache/unifiedCache.ts
+++ b/src/services/cache/unifiedCache.ts
@@ -29,7 +29,7 @@ import { Logger } from '../../utils/logger';
  * Unified cache manager for all extension caching needs
  */
 export class UnifiedCache {
-  private cache = new Map<string, UnifiedCacheEntry<any>>();
+  private cache = new Map<string, UnifiedCacheEntry<unknown>>();
   private context: vscode.ExtensionContext | null = null;
   private logger = Logger.getInstance();
   private persistenceEnabled = false;
@@ -66,7 +66,7 @@ export class UnifiedCache {
   /**
    * Check if a cache entry is expired based on its TTL
    */
-  private isExpired(entry: UnifiedCacheEntry<any>): boolean {
+  private isExpired(entry: UnifiedCacheEntry<unknown>): boolean {
     const now = Date.now();
     const age = now - entry.timestamp;
     return age > entry.ttl;

--- a/src/services/component/commands.ts
+++ b/src/services/component/commands.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { ComponentService } from './componentService';
+import type { ComponentSource } from '../../types/api';
 
 /**
  * Register the command to add a GitLab project token
@@ -42,7 +43,7 @@ export function registerAddProjectTokenCommand(
 
       // Add to component sources as a proper object
       const config = vscode.workspace.getConfiguration('gitlabComponentHelper');
-      const componentSources: any[] = config.get('componentSources', []);
+      const componentSources: ComponentSource[] = config.get('componentSources', []);
 
       // Check if this source already exists
       const existingSource = componentSources.find(

--- a/src/services/component/componentFetcher.ts
+++ b/src/services/component/componentFetcher.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { Component } from '../../providers/componentDetector';
+import type { ComponentParameter } from '../../types/git-component';
 import {
   GitLabCatalogComponent,
   GitLabCatalogVariable,
@@ -150,13 +151,13 @@ export class ComponentFetcher {
           if (catalogComponent) {
             this.logger.info(`Found component in catalog: ${componentName}`);
 
-            let extractedParameters: ComponentVariable[] =
+            let extractedParameters: ComponentParameter[] =
               catalogComponent.variables?.map((v: GitLabCatalogVariable) => ({
                 name: v.name,
                 description: v.description || `Parameter: ${v.name}`,
                 required: v.required || false,
                 type: v.type || 'string',
-                default: v.default === undefined ? undefined : String(v.default)
+                default: v.default
               })) || [];
 
             // Always probe the template so we know the on-repo path (needed for the template-file link). When the

--- a/src/services/component/componentFetcher.ts
+++ b/src/services/component/componentFetcher.ts
@@ -3,21 +3,15 @@ import { Component } from '../../providers/componentDetector';
 import {
   GitLabCatalogComponent,
   GitLabCatalogVariable,
-  GitLabCatalogData
+  GitLabCatalogData,
+  ParsedCatalogData
 } from '../../types/gitlab-catalog';
+import type { GitLabProjectInfo, GitLabTreeItem } from '../../types/api';
 import { HttpClient } from '../../utils/httpClient';
 import { Logger } from '../../utils/logger';
 import { GitLabSpecParser, ComponentVariable } from '../../parsers/specParser';
 import { TokenManager } from './tokenManager';
 import { UrlParser } from './urlParser';
-
-interface GitLabTreeItem {
-  id: string;
-  name: string;
-  type: string;
-  path: string;
-  mode: string;
-}
 
 /**
  * Helper function to prompt user for token if needed
@@ -52,7 +46,7 @@ export class ComponentFetcher {
   private httpClient: HttpClient;
   private tokenManager: TokenManager;
   private urlParser: UrlParser;
-  private catalogCache = new Map<string, any>();
+  private catalogCache = new Map<string, ParsedCatalogData>();
 
   constructor(httpClient: HttpClient, tokenManager: TokenManager, urlParser: UrlParser) {
     this.httpClient = httpClient;
@@ -112,13 +106,7 @@ export class ComponentFetcher {
       const apiBaseUrl = `https://${gitlabInstance}/api/v4`;
 
       let templateContent = '';
-      let parameters: Array<{
-        name: string;
-        description: string;
-        required: boolean;
-        type: string;
-        default?: string;
-      }> = [];
+      let parameters: ComponentVariable[] = [];
 
       // Try GitLab CI/CD Catalog first
       try {
@@ -132,10 +120,10 @@ export class ComponentFetcher {
 
         this.logger.debug(`Trying to fetch from GitLab Catalog API: ${catalogApiUrl}`);
         this.logger.debug(`Using token for catalog API: ${token ? 'YES' : 'NO'}`);
-        const catalogData = (await this.httpClient.fetchJson(
+        const catalogData = await this.httpClient.fetchJson<GitLabCatalogData>(
           catalogApiUrl,
           catalogFetchOptions
-        )) as GitLabCatalogData;
+        );
 
         if (catalogData && catalogData.components) {
           let catalogComponent = catalogData.components.find(
@@ -162,13 +150,13 @@ export class ComponentFetcher {
           if (catalogComponent) {
             this.logger.info(`Found component in catalog: ${componentName}`);
 
-            let extractedParameters =
+            let extractedParameters: ComponentVariable[] =
               catalogComponent.variables?.map((v: GitLabCatalogVariable) => ({
                 name: v.name,
                 description: v.description || `Parameter: ${v.name}`,
                 required: v.required || false,
                 type: v.type || 'string',
-                default: v.default
+                default: v.default === undefined ? undefined : String(v.default)
               })) || [];
 
             // Always probe the template so we know the on-repo path (needed for the template-file link). When the
@@ -220,21 +208,24 @@ export class ComponentFetcher {
       this.logger.debug(`Using token for ${gitlabInstance}: ${token ? 'YES' : 'NO'}`);
 
       // Fetch project info and template in parallel
-      let projectInfo: any;
-      let templateResult: any;
+      let projectInfo: PromiseSettledResult<GitLabProjectInfo>;
+      let templateResult: PromiseSettledResult<Awaited<ReturnType<typeof this.fetchTemplate>>>;
       try {
         [projectInfo, templateResult] = await Promise.allSettled([
-          this.httpClient.fetchJson(projectApiUrl, fetchOptions),
+          this.httpClient.fetchJson<GitLabProjectInfo>(projectApiUrl, fetchOptions),
           this.fetchTemplate(apiBaseUrl, encodedProjectPath, componentName, version, fetchOptions)
         ]);
-      } catch (err: any) {
-        if (err && (err.status === 401 || err.status === 403)) {
+      } catch (err: unknown) {
+        const status = (err && typeof err === 'object' && 'status' in err)
+          ? (err as { status?: number }).status
+          : undefined;
+        if (status === 401 || status === 403) {
           // Prompt for token and retry
           token = await promptForTokenIfNeeded(context, this.tokenManager, gitlabInstance);
           if (token) {
             fetchOptions = { headers: { 'PRIVATE-TOKEN': token } };
             [projectInfo, templateResult] = await Promise.allSettled([
-              this.httpClient.fetchJson(projectApiUrl, fetchOptions),
+              this.httpClient.fetchJson<GitLabProjectInfo>(projectApiUrl, fetchOptions),
               this.fetchTemplate(
                 apiBaseUrl,
                 encodedProjectPath,
@@ -316,8 +307,12 @@ export class ComponentFetcher {
     projectId: string,
     componentName: string,
     version: string,
-    fetchOptions?: any
-  ): Promise<{ content: string; parameters: any[]; templatePath: string } | null> {
+    fetchOptions?: { headers?: Record<string, string> }
+  ): Promise<{
+    content: string;
+    parameters: ComponentVariable[];
+    templatePath: string;
+  } | null> {
     try {
       const templatePathCandidates = [
         `templates/${componentName}.yml`,
@@ -381,7 +376,7 @@ export class ComponentFetcher {
     forceRefresh: boolean = false,
     version?: string,
     context?: vscode.ExtensionContext
-  ): Promise<any> {
+  ): Promise<ParsedCatalogData> {
     const startTime = Date.now();
     const versionSuffix = version ? `@${version}` : '';
     const cacheKey = `catalog:${gitlabInstance}:${projectPath}${versionSuffix}`;
@@ -393,10 +388,11 @@ export class ComponentFetcher {
     const cleanGitlabInstance = this.urlParser.cleanGitLabInstance(gitlabInstance);
 
     // Check cache first
-    if (!forceRefresh && this.catalogCache.has(cacheKey)) {
+    const cached = forceRefresh ? undefined : this.catalogCache.get(cacheKey);
+    if (cached) {
       this.logger.info(`Returning cached catalog data for ${cacheKey}`);
       this.logger.logPerformance('fetchCatalogData (cached)', Date.now() - startTime);
-      return this.catalogCache.get(cacheKey);
+      return cached;
     }
 
     this.logger.info(`Fetching fresh catalog data from ${cleanGitlabInstance}`);
@@ -409,11 +405,11 @@ export class ComponentFetcher {
 
       // **PARALLEL OPTIMIZATION with GRACEFUL DEGRADATION** - Fetch project info and templates in parallel
       const [projectInfoResult] = await Promise.allSettled([
-        this.httpClient.fetchJson(
+        this.httpClient.fetchJson<GitLabProjectInfo>(
           `${apiBaseUrl}/projects/${encodeURIComponent(projectPath)}`,
           fetchOptions
         ),
-        this.httpClient.fetchJson(
+        this.httpClient.fetchJson<GitLabTreeItem[]>(
           `${apiBaseUrl}/projects/${encodeURIComponent(
             projectPath
           )}/repository/tree?path=templates&ref=${ref}`,
@@ -421,7 +417,7 @@ export class ComponentFetcher {
         )
       ]);
 
-      let projectInfo: any;
+      let projectInfo: GitLabProjectInfo;
 
       // Handle authentication errors and retry if needed
       if (projectInfoResult.status === 'rejected') {
@@ -432,11 +428,11 @@ export class ComponentFetcher {
           if (token) {
             fetchOptions = { headers: { 'PRIVATE-TOKEN': token } };
             const [retryProjectInfo] = await Promise.allSettled([
-              this.httpClient.fetchJson(
+              this.httpClient.fetchJson<GitLabProjectInfo>(
                 `${apiBaseUrl}/projects/${encodeURIComponent(projectPath)}`,
                 fetchOptions
               ),
-              this.httpClient.fetchJson(
+              this.httpClient.fetchJson<GitLabTreeItem[]>(
                 `${apiBaseUrl}/projects/${encodeURIComponent(
                   projectPath
                 )}/repository/tree?path=templates&ref=${ref}`,
@@ -532,7 +528,7 @@ export class ComponentFetcher {
       );
 
       // Filter out null results (non-component templates)
-      const components = componentResults.filter((c: any) => c !== null);
+      const components = componentResults.filter((c): c is NonNullable<typeof c> => c !== null);
       this.logger.debug(
         `[ComponentFetcher] ${components.length} of ${yamlFiles.length} templates are valid components`
       );
@@ -561,20 +557,20 @@ export class ComponentFetcher {
     apiBaseUrl: string,
     projectPath: string,
     ref: string,
-    fetchOptions?: any
+    fetchOptions?: { headers?: Record<string, string> }
   ): Promise<GitLabTreeItem[]> {
     const treeUrl = `${apiBaseUrl}/projects/${encodeURIComponent(projectPath)}/repository/tree?path=templates&ref=${ref}`;
-    const topLevel: GitLabTreeItem[] = await this.httpClient.fetchJson(treeUrl, fetchOptions).catch(() => [] as GitLabTreeItem[]);
+    const topLevel = await this.httpClient.fetchJson<GitLabTreeItem[]>(treeUrl, fetchOptions).catch(() => [] as GitLabTreeItem[]);
 
-    const yamlFiles: GitLabTreeItem[] = topLevel.filter((item: GitLabTreeItem) =>
+    const yamlFiles = topLevel.filter(item =>
       item.type === 'blob' && (item.name.endsWith('.yml') || item.name.endsWith('.yaml'))
     );
 
-    const subdirs = topLevel.filter((item: GitLabTreeItem) => item.type === 'tree');
+    const subdirs = topLevel.filter(item => item.type === 'tree');
     for (const subdir of subdirs) {
       const subdirUrl = `${apiBaseUrl}/projects/${encodeURIComponent(projectPath)}/repository/tree?path=${encodeURIComponent('templates/' + subdir.name)}&ref=${ref}`;
-      const subdirContents: GitLabTreeItem[] = await this.httpClient.fetchJson(subdirUrl, fetchOptions).catch(() => [] as GitLabTreeItem[]);
-      const subdirYaml = subdirContents.filter((item: GitLabTreeItem) =>
+      const subdirContents = await this.httpClient.fetchJson<GitLabTreeItem[]>(subdirUrl, fetchOptions).catch(() => [] as GitLabTreeItem[]);
+      const subdirYaml = subdirContents.filter(item =>
         item.type === 'blob' && (item.name.endsWith('.yml') || item.name.endsWith('.yaml'))
       );
       yamlFiles.push(...subdirYaml);
@@ -588,10 +584,10 @@ export class ComponentFetcher {
    */
   private async fetchTemplateContent(
     apiBaseUrl: string,
-    projectId: string,
+    projectId: string | number,
     relativePath: string,
     ref: string,
-    fetchOptions?: any
+    fetchOptions?: { headers?: Record<string, string> }
   ): Promise<{
     content: string;
     extractedVariables: ComponentVariable[];
@@ -625,12 +621,12 @@ export class ComponentFetcher {
   public async fetchProjectInfo(
     gitlabInstance: string,
     projectPath: string
-  ): Promise<any> {
+  ): Promise<GitLabProjectInfo> {
     const apiBaseUrl = `https://${gitlabInstance}/api/v4`;
     const token = await this.tokenManager.getTokenForProject(gitlabInstance);
     const fetchOptions = token ? { headers: { 'PRIVATE-TOKEN': token } } : undefined;
 
-    return this.httpClient.fetchJson(
+    return this.httpClient.fetchJson<GitLabProjectInfo>(
       `${apiBaseUrl}/projects/${encodeURIComponent(projectPath)}`,
       fetchOptions
     );

--- a/src/services/component/componentService.ts
+++ b/src/services/component/componentService.ts
@@ -124,7 +124,7 @@ export class ComponentService implements ComponentSource {
     forceRefresh: boolean = false,
     version?: string,
     context?: vscode.ExtensionContext
-  ): Promise<any> {
+  ): Promise<Awaited<ReturnType<ComponentFetcher['fetchCatalogData']>>> {
     return this.componentFetcher.fetchCatalogData(
       gitlabInstance,
       projectPath,
@@ -135,8 +135,8 @@ export class ComponentService implements ComponentSource {
   }
 
   // HTTP client delegation
-  public async fetchJson(url: string, options?: any): Promise<any> {
-    return this.httpClient.fetchJson(url, options);
+  public async fetchJson<T = unknown>(url: string, options?: { headers?: Record<string, string> }): Promise<T> {
+    return this.httpClient.fetchJson<T>(url, options);
   }
 
   private async fetchText(url: string): Promise<string> {
@@ -237,12 +237,12 @@ export class ComponentService implements ComponentSource {
     )}/repository/files/${encodeURIComponent(filePath)}/raw`;
 
     try {
-      const components = await this.httpClient.fetchJson(apiUrl, {
+      const raw = await this.httpClient.fetchJson<unknown>(apiUrl, {
         headers: {
           'PRIVATE-TOKEN': token
         }
       });
-
+      const components = this.coerceToComponents(raw, apiUrl);
       this.logger.info(`Successfully fetched ${components.length} components from GitLab`);
       return components;
     } catch (error) {
@@ -260,13 +260,40 @@ export class ComponentService implements ComponentSource {
     }
 
     try {
-      const components = await this.httpClient.fetchJson(url);
+      const raw = await this.httpClient.fetchJson<unknown>(url);
+      const components = this.coerceToComponents(raw, url);
       this.logger.info(`Successfully fetched ${components.length} components from URL`);
       return components;
     } catch (error) {
       this.logger.error(`URL fetch failed: ${error}`);
       throw error;
     }
+  }
+
+  /**
+   * Narrow an unknown JSON payload (from a user-configured URL) to `Component[]`.
+   *
+   * The remote shape is user-controlled — could be a malformed file, a wrong endpoint, or a stale
+   * schema — so we filter to objects with the minimum required `name`/`parameters` fields rather
+   * than trusting the cast. Anything that doesn't pass is dropped with a warning.
+   *
+   * @param raw     The parsed JSON returned by `fetchJson<unknown>`. Expected to be an array of
+   *                `Component`-shaped objects, but typed as `unknown` because the remote endpoint
+   *                is user-configured.
+   * @param source  URL or identifier of the source, used only in the warning message when the
+   *                payload is not an array.
+   * @returns       The subset of `raw` that has the minimum `name` and `parameters` fields.
+   *                Entries that don't pass the shape check are silently dropped; a non-array
+   *                input returns `[]` (and logs a warning).
+   */
+  private coerceToComponents(raw: unknown, source: string): Component[] {
+    if (!Array.isArray(raw)) {
+      this.logger.warn(`Expected array of components from ${source}, got ${typeof raw}`);
+      return [];
+    }
+    return raw.filter((c): c is Component =>
+      typeof c === 'object' && c !== null && 'name' in c && 'parameters' in c
+    );
   }
 
   // Cache management

--- a/src/services/component/versionManager.ts
+++ b/src/services/component/versionManager.ts
@@ -1,11 +1,7 @@
 import { Logger } from '../../utils/logger';
 import { HttpClient } from '../../utils/httpClient';
 import { TokenManager } from './tokenManager';
-
-interface GitLabTag {
-  name: string;
-  commit: any;
-}
+import type { GitLabProjectInfo, GitLabTag, GitLabBranch } from '../../types/api';
 
 /**
  * Manages fetching and sorting versions (tags and branches) for GitLab projects
@@ -45,7 +41,7 @@ export class VersionManager {
       this.logger.debug(`Using token for versions fetch: ${token ? 'YES' : 'NO'}`);
 
       // First, get project info to get the project ID
-      const projectInfo = await this.httpClient.fetchJson(
+      const projectInfo = await this.httpClient.fetchJson<GitLabProjectInfo>(
         `${apiBaseUrl}/projects/${encodedPath}`,
         fetchOptions
       );
@@ -57,11 +53,11 @@ export class VersionManager {
 
       // Fetch tags and branches in parallel
       const [tagsResult, branchesResult] = await Promise.allSettled([
-        this.httpClient.fetchJson(
+        this.httpClient.fetchJson<GitLabTag[]>(
           `${apiBaseUrl}/projects/${projectInfo.id}/repository/tags?per_page=100&sort=desc`,
           fetchOptions
         ),
-        this.httpClient.fetchJson(
+        this.httpClient.fetchJson<GitLabBranch[]>(
           `${apiBaseUrl}/projects/${projectInfo.id}/repository/branches?per_page=20`,
           fetchOptions
         )
@@ -72,8 +68,8 @@ export class VersionManager {
       // Process tags
       if (tagsResult.status === 'fulfilled' && Array.isArray(tagsResult.value)) {
         const tagVersions = tagsResult.value
-          .map((tag: any) => tag.name)
-          .filter((name: string) => name);
+          .map(tag => tag.name)
+          .filter(name => name);
         versions.push(...tagVersions);
         this.logger.debug(`Found ${tagVersions.length} tags`);
       } else {
@@ -87,8 +83,8 @@ export class VersionManager {
       // Process branches
       if (branchesResult.status === 'fulfilled' && Array.isArray(branchesResult.value)) {
         const importantBranches = branchesResult.value
-          .map((branch: any) => branch.name)
-          .filter((name: string) => ['main', 'master', 'develop', 'dev'].includes(name));
+          .map(branch => branch.name)
+          .filter(name => ['main', 'master', 'develop', 'dev'].includes(name));
         versions.push(...importantBranches);
         this.logger.debug(`Found ${importantBranches.length} important branches`);
       } else {
@@ -142,7 +138,7 @@ export class VersionManager {
 
       const token = await this.tokenManager.getTokenForProject(gitlabInstance);
       const options = token ? { headers: { 'PRIVATE-TOKEN': token } } : undefined;
-      const tags = await this.httpClient.fetchJson(apiUrl, options);
+      const tags = await this.httpClient.fetchJson<GitLabTag[]>(apiUrl, options);
 
       this.logger.info(`Found ${tags.length} tags for ${projectPath}`);
       this.logger.logPerformance('fetchProjectTags', Date.now() - startTime, {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -95,6 +95,17 @@ export interface GitLabBranch {
 }
 
 /**
+ * GitLab group project listing item returned from /api/v4/groups/:id/projects
+ *
+ * Narrower than {@link GitLabProjectInfo} — the group listing endpoint returns the same shape,
+ * but consumers only read these two fields.
+ */
+export interface GitLabGroupProject {
+  name: string;
+  path_with_namespace: string;
+}
+
+/**
  * GitLab file content response from /api/v4/projects/:id/repository/files/:file_path/raw
  */
 export interface GitLabFileContent {

--- a/src/types/gitlab-catalog.ts
+++ b/src/types/gitlab-catalog.ts
@@ -1,4 +1,5 @@
 import type { ParameterDefault } from './git-component';
+import type { ComponentVariable } from '../parsers/specParser';
 
 export interface GitLabCatalogComponent {
   name: string;
@@ -54,5 +55,40 @@ export interface GitLabFragmentAnchor {
 export interface GitLabCatalogData {
   components: GitLabCatalogComponent[];
   /** YAML fragments containing reusable anchors */
+  fragments?: GitLabYamlFragment[];
+}
+
+/**
+ * A single component after we've fetched its template YAML and parsed it locally. Distinct from
+ * {@link GitLabCatalogComponent} (the raw API shape).
+ */
+export interface ParsedCatalogComponent {
+  /** Component name as it appears in the template path (e.g. `my-job` for `templates/my-job.yml`). */
+  name: string;
+  /** Human-readable description extracted from the template's `spec.description` field. */
+  description: string;
+  /**
+   * Input variables defined by the component. Typed as the parser's {@link ComponentVariable}
+   * (`default?: string`) rather than the catalog API's {@link GitLabCatalogVariable}
+   * (`default?: ParameterDefault`) because we re-parse the template locally.
+   */
+  variables: ComponentVariable[];
+  /** Git ref (tag or branch) the template was fetched at. */
+  latest_version: string;
+  /** Repo-relative path where the template was found (e.g. `templates/my-job.yml`). */
+  templatePath: string;
+  /** Optional external documentation URL declared in the template's `spec.documentation_url`. */
+  documentation_url?: string;
+}
+
+/**
+ * Internal cache shape produced by `ComponentFetcher.fetchCatalogData`. Mirrors
+ * {@link GitLabCatalogData} but with each component already locally parsed (see
+ * {@link ParsedCatalogComponent}).
+ */
+export interface ParsedCatalogData {
+  /** Locally-parsed components found under `templates/`. */
+  components: ParsedCatalogComponent[];
+  /** YAML fragment files (no `spec` section) that contribute reusable anchors. */
   fragments?: GitLabYamlFragment[];
 }

--- a/src/utils/httpClient.ts
+++ b/src/utils/httpClient.ts
@@ -95,17 +95,17 @@ export class HttpClient {
     return `${url}|${authToken}`;
   }
 
-  async fetchJson(url: string, options: RequestOptions = {}): Promise<any> {
+  async fetchJson<T = unknown>(url: string, options: RequestOptions = {}): Promise<T> {
     return this.performanceMonitor.track(
       'httpClient.fetchJson',
       async () => {
-        return this.fetchJsonInternal(url, options);
+        return this.fetchJsonInternal<T>(url, options);
       },
       { url: new URL(url).hostname + new URL(url).pathname }
     );
   }
 
-  private async fetchJsonInternal(url: string, options: RequestOptions = {}): Promise<any> {
+  private async fetchJsonInternal<T = unknown>(url: string, options: RequestOptions = {}): Promise<T> {
     const config = this.getConfig();
     const timeout = options.timeout || config.timeout;
     const retryAttempts = options.retryAttempts || config.retryAttempts;
@@ -116,7 +116,7 @@ export class HttpClient {
 
     const cacheKey = this.buildCacheKey(url, headers);
 
-    return this.deduplicator.fetch(cacheKey, async () => {
+    return this.deduplicator.fetch<T>(cacheKey, async () => {
       for (let attempt = 0; attempt <= retryAttempts; attempt++) {
         try {
           this.logger.debug(`HTTP Request attempt ${attempt + 1}/${retryAttempts + 1}: ${url}`);
@@ -124,7 +124,7 @@ export class HttpClient {
           const data = await this.makeRequest(url, { timeout, headers });
 
           try {
-            const jsonData = JSON.parse(data);
+            const jsonData = JSON.parse(data) as T;
             this.logger.debug(`HTTP Request successful: ${url} (${data.length} chars)`);
             return jsonData;
           } catch (parseError) {

--- a/src/utils/requestDeduplicator.ts
+++ b/src/utils/requestDeduplicator.ts
@@ -18,7 +18,7 @@ interface PendingRequest<T> {
 }
 
 export class RequestDeduplicator {
-  private pendingRequests: Map<string, PendingRequest<any>> = new Map();
+  private pendingRequests: Map<string, PendingRequest<unknown>> = new Map();
 
   /**
    * Fetch data with deduplication.
@@ -33,7 +33,7 @@ export class RequestDeduplicator {
     const existing = this.pendingRequests.get(key);
 
     if (existing) {
-      return existing.promise;
+      return existing.promise as Promise<T>;
     }
 
     const promise = fetcher()


### PR DESCRIPTION
## Summary
- Phase 3 of the ESLint `@typescript-eslint/no-explicit-any` cleanup. Previous PRs ([#132](https://github.com/eFAILution/gitlab-component-helper/pull/132), [#133](https://github.com/eFAILution/gitlab-component-helper/pull/133)) cleared 90 warnings. This PR tackles the cache + service layer: makes `HttpClient.fetchJson` generic, types every call site with the concrete GitLab API response shape, and replaces the `(c: any)` / `(v: any)` / `(tag: any)` annotations on the downstream `.map()`/`.filter()` callbacks (TS infers them once `fetchJson` is typed).
- 32 warnings removed (**160 → 128**). Two latent bugs surfaced and fixed (see below).
- Link related issue(s): n/a

## Change Type
- [ ] feat
- [ ] fix
- [ ] refactor
- [ ] docs
- [ ] test
- [x] chore

## Context
### User-facing impact
- None expected. All edits are type tightening at warning sites. Two latent typing bugs were fixed in passing; both are described in the Risk section.

### GitLab scope
- [ ] gitlab.com
- [ ] self-managed GitLab
- [x] both (no behavioural change to either)

### Affected areas
- [ ] Component Browser
- [ ] Hover provider
- [ ] Completion provider
- [ ] Validation provider
- [x] Cache and refresh behavior (typing only — no logic change)
- [x] GitLab API calls/auth/token storage (typing only — no logic change)
- [ ] Docs only

## What changed by bucket

| Bucket | Files | Warnings cleared | Approach |
|---|---|---|---|
| Keystone — generic `fetchJson<T>` | [httpClient.ts](src/utils/httpClient.ts), [requestDeduplicator.ts](src/utils/requestDeduplicator.ts) | 3 | `fetchJson(url): Promise<any>` → `fetchJson<T = unknown>(url): Promise<T>` on both public and internal methods. Default `T = unknown` (not `any`) so unguarded callers fail loudly. Deduplicator stores `PendingRequest<unknown>` and casts at the typed `fetch<T>` return. |
| GitLab API response typing | [componentFetcher.ts](src/services/component/componentFetcher.ts), [versionManager.ts](src/services/component/versionManager.ts), [groupCache.ts](src/services/cache/groupCache.ts) | 20 | Typed 12 `fetchJson` call sites with `<GitLabProjectInfo>` / `<GitLabTag[]>` / `<GitLabBranch[]>` / `<GitLabTreeItem[]>` / `<GitLabGroupProject[]>` / `<GitLabCatalogData>`. Dropped two local duplicate type definitions (`GitLabTreeItem` in `componentFetcher`, `GitLabTag` in `versionManager`). Map/filter callbacks lose their `(x: any)` annotations — TS infers them. |
| Cache layer + service delegates | [projectCache.ts](src/services/cache/projectCache.ts), [unifiedCache.ts](src/services/cache/unifiedCache.ts), [cacheTypes.ts](src/services/cache/cacheTypes.ts), [componentCacheManager.ts](src/services/cache/componentCacheManager.ts), [componentService.ts](src/services/component/componentService.ts), [commands.ts](src/services/component/commands.ts) | 9 | Heterogeneous-payload `any` → `unknown` for the cache slots; service delegates propagate the wrapped method's typed return; `componentCacheManager.addDynamicComponent` inline shape replaced with the existing `CachedComponent` import; `commands.ts` config-read uses the existing `ComponentSource` type from [api.ts](src/types/api.ts). |
| User-URL narrowing | [componentService.ts](src/services/component/componentService.ts) | (covered above) | Two `fetchFrom*` methods that hit user-configured URLs now use `fetchJson<unknown>` + a new `coerceToComponents(raw, source)` helper that filters to objects with the minimum `name` + `parameters` fields rather than blindly trusting the response shape. |

## Notable details

### GitLab API response types in `src/types/api.ts`
All raw GitLab REST response shapes now flow through [src/types/api.ts](src/types/api.ts): `GitLabProjectInfo`, `GitLabTreeItem`, `GitLabTag`, `GitLabBranch`, `GitLabGroupProject` (new in this PR), `ComponentSource`. The existing `src/types/index.ts` barrel re-exports these. Two duplicate local interfaces (`GitLabTreeItem` in `componentFetcher`, `GitLabTag` in `versionManager`) were deleted.

### New internal types in `gitlab-catalog.ts`
[gitlab-catalog.ts](src/types/gitlab-catalog.ts) gained `ParsedCatalogComponent` and `ParsedCatalogData`. These describe the internal cache shape produced by `ComponentFetcher.fetchCatalogData` — distinct from `GitLabCatalogData` (the raw catalog API shape) because `variables` are typed as the parser's `ComponentVariable` (`default?: string`) rather than the catalog API's `GitLabCatalogVariable` (`default?: ParameterDefault`), and `templatePath` is additionally recorded. Per-property JSDoc on each field so hover-docs at the call site explain what's stored.

### Helpers in `componentFetcher`
- `coerceToComponents(raw, source)` — narrows `unknown` JSON to `Component[]` by filtering on minimum shape rather than blind casting. Used by both user-URL fetch paths.
- `fetchTemplateContent` signature tightened (`fetchOptions?: any` → typed options, `projectId: string` → `string | number` to match the actual `GitLabProjectInfo.id` shape — see Latent bugs below).
- `componentResults.filter((c: any) => c !== null)` → `c is NonNullable<typeof c>` predicate so downstream code sees the null-stripped shape.

### Duplication reduction
Three byte-identical inline `Array<{ name; description; required; type; default? }>` shapes in `componentFetcher.ts` are replaced with the existing `ComponentVariable` type from `specParser.ts`. Net: ~25 lines of inline-shape boilerplate gone.

## Latent bugs fixed

### `projectInfo.id` is `number`, not `string`
[componentFetcher.ts:494](src/services/component/componentFetcher.ts#L494) passes `projectInfo.id` to `fetchTemplateContent(projectId: string, …)`. The actual JSON value is `number` (per GitLab REST API), and the value flowed through a template literal that implicitly coerced it. The old `projectInfo: any` masked the mismatch. The parameter is now `string | number`.

### `componentResults` contained `null` entries
The old `.filter((c: any) => c !== null)` only narrowed at runtime; TypeScript still saw `null` in the result type, leaking through to the `catalogData.components` shape. A proper `c is NonNullable<typeof c>` predicate deletes the `any` warning *and* gives downstream code the honest non-null shape.

## Validation
### Local checks
- [x] `npm run check-types` — clean (both `tsconfig.json` and `tsconfig.tests.json`).
- [x] `npm run lint` — **160 → 128 `no-explicit-any` warnings**, zero new warnings of any rule.
- [x] `npm test` — 8/8 unit tests passing.
- [x] Manual verification in VS Code Extension Host — `env -u ELECTRON_RUN_AS_NODE npm run test:extension-host` 10/10 passing.

### Manual test notes
- The 32 cleared warnings span every fetch path in the extension. Exercised in extension host: `componentFetcher.fetchProject`, `fetchCatalogData`, `versionManager.fetchProjectTags`, `groupCache.fetchGroupProjects`, the catch+log paths in `httpClient`, the typed cache slots in `unifiedCache`. All previously-working behaviour preserved.
- Hover, completion, validation, and component browser features in the extension host all still pass.

## Breaking Changes
- [x] No breaking changes
- [ ] Breaking changes (describe below)

`HttpClient.fetchJson<T = unknown>` is the only public signature change. The default of `unknown` (not `any`) means callers that don't specify a type argument will be forced to narrow at the call site rather than getting silent `any` flow. Inside this repo, every call site is updated; no external consumers exist.

## Screenshots / Recordings (if UI behavior changed)
- N/A — no UI changes.

## Risk and Rollback
- **Main risks:**
  - `coerceToComponents` filters non-conforming entries out of user-configured URL responses. The old code returned them as-is, then downstream code could crash on `.parameters` access. Net: more defensive, but a user who relied on partially-shaped components silently being preserved will see fewer entries now. A warning is logged when the payload isn't an array. Low risk — this was a latent footgun.
  - `fetchTemplateContent(projectId: string | number)` widening is purely typing — the function body interpolates into a URL string, behaviour unchanged.
  - `c is NonNullable<typeof c>` narrowing — same runtime behaviour as the previous `(c: any) => c !== null`, but downstream types are now honest about the absence of nulls. If any consumer was *relying* on a `null` slipping through (it wasn't), it would surface here.
- **Rollback strategy:** Single PR, revert. No settings changes, no data migration, no CI secrets touched, no new dependencies.

## Release Notes Draft
- chore: generic `HttpClient.fetchJson<T>` with concrete GitLab API response types (`GitLabProjectInfo`, `GitLabTag`, `GitLabBranch`, `GitLabTreeItem`, `GitLabGroupProject`, `GitLabCatalogData`). Cache and service layer now strictly typed; 32 of the remaining 160 `no-explicit-any` warnings cleared.

## Checklist
- [x] Branch is up to date with target branch
- [x] Commit messages follow conventional commits
- [x] Added/updated docs for behavior or settings changes (none required)
- [x] Added/updated tests for new behavior (none required — pure typing)
- [x] No secrets or tokens in code, logs, screenshots, or test fixtures
