### PR TITLE
ci: bump Argus reusable hardening workflow to v1.3.0

### DIFF
--- a/.github/workflows/security-hardening.yml
+++ b/.github/workflows/security-hardening.yml
@@ -19,8 +19,8 @@ permissions:
 jobs:
   argus-hardening:
     name: Argus Reusable Hardening
-    # Pinned to the commit for Argus v0.6.8 for supply-chain safety.
-    uses: huntridge-labs/argus/.github/workflows/reusable-security-hardening.yml@0e74137817fbf4be257f76a976c04b7f730de4dc
+    # Pinned to the commit for Argus v1.3.0 for supply-chain safety.
+    uses: huntridge-labs/argus/.github/workflows/reusable-security-hardening.yml@989ea80e0f10fe792884f53a1e1daa84312e4999
     with:
       scanners: codeql,gitleaks,osv,dependency-review
       enable_code_security: true


### PR DESCRIPTION
Bumps the Argus reusable security-hardening workflow pin from **v0.6.8** (`0e74137`) to **v1.3.0** (`989ea80e0f10fe792884f53a1e1daa84312e4999`), kept SHA-pinned.

v1.3.0 fixes the v1.2.x reusable-workflow regressions (install argus + invalid `needs` context, huntridge-labs/argus#214) that kept us pinned to 0.6.8. All inputs we pass (`scanners`, `enable_code_security`, `allow_failure`, `severity_threshold`, `post_pr_comment`, `secrets: inherit`) remain optional and accepted in v1.3.0. Beta CI exercises the new reusable workflow.

Closes #144