### PR TITLE
ci: fix double-scoped dependabot commit prefixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,9 @@ updates:
     assignees:
       - "eFAILution"
     commit-message:
-      prefix: "chore(deps)"
+      # prefix has no scope: `include: scope` appends (deps)/(deps-dev). A scoped
+      # prefix here would double-scope (e.g. chore(deps)(deps-dev)).
+      prefix: "chore"
       include: "scope"
     labels:
       - "dependencies"
@@ -47,7 +49,6 @@ updates:
       - "eFAILution"
     commit-message:
       prefix: "chore(ci)"
-      include: "scope"
     labels:
       - "dependencies"
       - "github-actions"
@@ -65,7 +66,6 @@ updates:
       - "eFAILution"
     commit-message:
       prefix: "chore(pre-commit)"
-      include: "scope"
     labels:
       - "dependencies"
       - "pre-commit"


### PR DESCRIPTION
Dependabot was emitting double-scoped commit titles (`chore(deps)(deps-dev)`, `chore(ci)(deps)`) because each ecosystem set a scoped `prefix` **and** `include: scope` (which appends `(deps)`/`(deps-dev)`).

Fix:
- **npm**: `prefix: "chore"` + `include: scope` -> `chore(deps)` (prod) / `chore(deps-dev)` (dev)
- **github-actions**: keep `prefix: "chore(ci)"`, drop `include: scope` -> `chore(ci)`
- **pip / pre-commit**: keep `prefix: "chore(pre-commit)"`, drop `include: scope` -> `chore(pre-commit)`

Note: Dependabot reads its config from the **default branch (main)**, so this takes effect once it lands on main via the 0.12.0 integration (#124). The already-open dependabot PRs had their titles corrected manually.