### PR TITLE
chore: eslint fix phase 4

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,10 +4,33 @@ import { HoverProvider } from './providers/hoverProvider';
 import { CompletionProvider } from './providers/completionProvider';
 import { ComponentDocumentLinkProvider } from './providers/documentLinkProvider';
 import { ComponentBrowserProvider } from './providers/componentBrowserProvider';
-import { detectIncludeComponent } from './providers/componentDetector';
+import { detectIncludeComponent, Component } from './providers/componentDetector';
 import { getComponentCacheManager, ComponentCacheManager } from './services/cache/componentCacheManager';
 import { Logger } from './utils/logger';
 import { ValidationProvider } from './providers/validationProvider';
+import type { CachedComponent } from './types/cache';
+import type { GitLabYamlFragment } from './types/gitlab-catalog';
+import type { HoverContext } from './providers/hoverContentBuilder';
+
+/** Component payload passed to the `detachHover` command. Adds the hover-builder's location context. */
+type DetachableComponent = Component & { _hoverContext?: HoverContext };
+
+/**
+ * Type-guard narrowing a `Component`-shaped value to one that also satisfies `CachedComponent`.
+ *
+ * @param component  A `Component` (typically `activeComponent` in the detach-hover panel) that may
+ *                   or may not have been enriched with cache details.
+ * @returns          `true` if all `CachedComponent` required fields are present and string-typed,
+ *                   narrowing `component` to `Component & CachedComponent` in the truthy branch.
+ *                   `false` if any field is missing.
+ */
+function isCachedComponentShape(component: Component): component is Component & CachedComponent {
+  return typeof component.source === 'string'
+    && typeof component.sourcePath === 'string'
+    && typeof component.gitlabInstance === 'string'
+    && typeof component.version === 'string'
+    && typeof component.url === 'string';
+}
 import { getPerformanceMonitor } from './utils/performanceMonitor';
 import { isGitLabCIFile, invalidateFileGlobsCache } from './utils/gitlabCiFileMatcher';
 
@@ -256,8 +279,8 @@ export function activate(context: vscode.ExtensionContext) {
         logger.info(`[Extension] Total source errors: ${errors.size}`, 'Extension');
 
         // Group components by source
-        const componentsBySource = new Map<string, any[]>();
-        components.forEach((comp: any) => {
+        const componentsBySource = new Map<string, CachedComponent[]>();
+        components.forEach(comp => {
           const key = comp.source;
           let bucket = componentsBySource.get(key);
           if (!bucket) {
@@ -268,9 +291,9 @@ export function activate(context: vscode.ExtensionContext) {
         });
 
         logger.info(`[Extension] Components grouped by source:`, 'Extension');
-        componentsBySource.forEach((comps: any[], source: string) => {
+        componentsBySource.forEach((comps, source) => {
           logger.info(`[Extension]   ${source}: ${comps.length} components`, 'Extension');
-          comps.forEach((comp: any) => {
+          comps.forEach(comp => {
             logger.debug(`[Extension]     - ${comp.name} (${comp.gitlabInstance}/${comp.sourcePath})`, 'Extension');
           });
         });
@@ -287,7 +310,7 @@ export function activate(context: vscode.ExtensionContext) {
     // Register command to detach hover window as a dedicated panel
     logger.debug('[Extension] Registering detachHover command...', 'Extension');
     context.subscriptions.push(
-      vscode.commands.registerCommand('gitlab-component-helper.detachHover', async (component: any) => {
+      vscode.commands.registerCommand('gitlab-component-helper.detachHover', async (component: DetachableComponent) => {
         logger.info(`[Extension] Detaching hover for component: ${component?.name}`, 'Extension');
 
         if (!component) {
@@ -354,7 +377,7 @@ export function activate(context: vscode.ExtensionContext) {
                   true,
                   targetVersion
                 );
-                const fragment = catalogData?.fragments?.find((frag: any) => frag.name === resolvedName);
+                const fragment = catalogData?.fragments?.find((frag: GitLabYamlFragment) => frag.name === resolvedName);
                 if (fragment) {
                   activeComponent = {
                     ...component,
@@ -422,6 +445,10 @@ export function activate(context: vscode.ExtensionContext) {
 
                 // Update component version if specified
                 if (version && version !== activeComponent.version) {
+                  if (!activeComponent.sourcePath || !activeComponent.gitlabInstance) {
+                    vscode.window.showErrorMessage(`Cannot fetch version: component is missing source path or GitLab instance.`);
+                    return;
+                  }
                   const updatedComponent = await cacheManager.fetchSpecificVersion(
                     activeComponent.name,
                     activeComponent.sourcePath,
@@ -474,6 +501,9 @@ export function activate(context: vscode.ExtensionContext) {
               break;
             case 'fetchVersions':
               try {
+                if (!isCachedComponentShape(activeComponent)) {
+                  throw new Error('Component is missing required fields (source, sourcePath, gitlabInstance, version) for version lookup.');
+                }
                 const versions = await cacheManager.fetchComponentVersions(activeComponent);
                 panel.webview.postMessage({
                   command: 'versionsLoaded',
@@ -490,6 +520,10 @@ export function activate(context: vscode.ExtensionContext) {
             case 'versionChanged':
               try {
                 const { selectedVersion } = message;
+                if (!activeComponent.sourcePath || !activeComponent.gitlabInstance) {
+                  vscode.window.showErrorMessage(`Cannot change version: component is missing source path or GitLab instance.`);
+                  return;
+                }
                 const updatedComponent = await cacheManager.fetchSpecificVersion(
                   activeComponent.name,
                   activeComponent.sourcePath,

--- a/src/providers/completionProvider.ts
+++ b/src/providers/completionProvider.ts
@@ -5,6 +5,9 @@ import { getVariableCompletions, containsGitLabVariables, expandComponentUrl } f
 import { Logger } from '../utils/logger';
 import { isGitLabCIFile } from '../utils/gitlabCiFileMatcher';
 import { resolveLocalComponent } from './localComponentResolver';
+import { parseYaml, isYamlNode } from '../utils/yamlParser';
+import type { ComponentParameter } from '../types/git-component';
+import type { CachedComponent } from '../types/cache';
 
 export class CompletionProvider implements vscode.CompletionItemProvider {
   private logger = Logger.getInstance();
@@ -293,7 +296,7 @@ export class CompletionProvider implements vscode.CompletionItemProvider {
     return availableVersions[0];
   }
 
-  private provideParameterCompletions(parameters: any[]): vscode.CompletionItem[] {
+  private provideParameterCompletions(parameters: ComponentParameter[]): vscode.CompletionItem[] {
     return parameters.map(param => {
       const item = new vscode.CompletionItem(param.name, vscode.CompletionItemKind.Property);
       item.documentation = new vscode.MarkdownString(param.description);
@@ -359,10 +362,9 @@ export class CompletionProvider implements vscode.CompletionItemProvider {
   ): Promise<vscode.CompletionItem[] | null> {
     try {
       const text = document.getText();
-      const { parseYaml } = await import('../utils/yamlParser');
       const parsedYaml = parseYaml(text);
 
-      if (!parsedYaml || !parsedYaml.include) {
+      if (!isYamlNode(parsedYaml) || !parsedYaml.include) {
         return null;
       }
 
@@ -488,14 +490,14 @@ export class CompletionProvider implements vscode.CompletionItemProvider {
         this.logger.debug(`[CompletionProvider] Existing inputs: ${Object.keys(existingInputs).join(', ') || 'none'}`, 'CompletionProvider');
 
         // Filter out already provided inputs
-        const missingInputs = component.parameters.filter((param: any) =>
+        const missingInputs = component.parameters.filter((param: ComponentParameter) =>
           !Object.prototype.hasOwnProperty.call(existingInputs, param.name)
         );
 
-        this.logger.debug(`[CompletionProvider] Found ${missingInputs.length} missing inputs for completion: ${missingInputs.map((p: any) => p.name).join(', ')}`, 'CompletionProvider');
+        this.logger.debug(`[CompletionProvider] Found ${missingInputs.length} missing inputs for completion: ${missingInputs.map(p => p.name).join(', ')}`, 'CompletionProvider');
 
         // Create completion items for missing inputs
-        return missingInputs.map((param: any) => {
+        return missingInputs.map((param: ComponentParameter & { enum?: unknown[] }) => {
           const item = new vscode.CompletionItem(param.name, vscode.CompletionItemKind.Property);
 
           // Enhanced documentation
@@ -537,7 +539,7 @@ export class CompletionProvider implements vscode.CompletionItemProvider {
               default:
                 // Check if there are enum values
                 if (param.enum && Array.isArray(param.enum)) {
-                  const enumValues = param.enum.map((val: any) => `"${val}"`).join(',');
+                  const enumValues = param.enum.map((val: unknown) => `"${String(val)}"`).join(',');
                   insertValue = `\${1|${enumValues}|}`;
                 } else {
                   insertValue = param.required ? '${1:"TODO: set value"}' : '${1:""}';
@@ -567,7 +569,7 @@ export class CompletionProvider implements vscode.CompletionItemProvider {
   // Helper method to find component in cache (similar to validation provider).
   // `forUri` is the active document's URI — used so variable expansion picks
   // the GitLab host matching the file's containing repo, not workspace[0].
-  private async findComponentInCache(componentUrl: string, forUri?: vscode.Uri): Promise<any | null> {
+  private async findComponentInCache(componentUrl: string, forUri?: vscode.Uri): Promise<CachedComponent | null> {
     try {
       const cacheManager = getComponentCacheManager();
       const components = await cacheManager.getComponents();

--- a/src/providers/hoverInputContext.ts
+++ b/src/providers/hoverInputContext.ts
@@ -4,7 +4,7 @@
  * parameter it names.
  */
 
-import { parseYaml } from '../utils/yamlParser';
+import { parseYaml, isYamlNode } from '../utils/yamlParser';
 
 /**
  * The component-input slot a YAML cursor position resolves to.
@@ -46,13 +46,13 @@ export function findInputContextAtLine(text: string, lineIndex: number): InputCo
 
   // Need a parsed `include:` array to know which includes are in scope; if YAML doesn't parse, bail.
   const parsed = parseYaml(text);
-  if (!parsed || !parsed.include) return null;
+  if (!isYamlNode(parsed) || !parsed.include) return null;
   const includes = Array.isArray(parsed.include) ? parsed.include : [parsed.include];
 
   // Each include is either a remote `component:` URL or a `local:` path — both behave the same here.
   const candidates: IncludeCandidate[] = [];
   for (const include of includes) {
-    if (!include) continue;
+    if (!isYamlNode(include)) continue;
     if (typeof include.component === 'string') {
       candidates.push({ value: include.component, key: 'component' });
     } else if (typeof include.local === 'string') {

--- a/src/providers/validationProvider.ts
+++ b/src/providers/validationProvider.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { getComponentService } from '../services/component';
 import { getComponentCacheManager } from '../services/cache/componentCacheManager';
-import { parseYaml } from '../utils/yamlParser';
+import { parseYaml, isYamlNode } from '../utils/yamlParser';
 import { Component, ComponentParameter } from '../types/git-component';
 import { Logger } from '../utils/logger';
 import { expandComponentUrl, containsGitLabVariables } from '../utils/gitlabVariables';
@@ -104,7 +104,7 @@ export class ValidationProvider implements vscode.CodeActionProvider {
         const diagnosticKeys = new Set<string>(); // Track unique diagnostics to prevent duplicates
         const parsedYaml = parseYaml(text);
 
-        if (!parsedYaml || !parsedYaml.include) {
+        if (!isYamlNode(parsedYaml) || !parsedYaml.include) {
             this.diagnosticCollection.set(document.uri, diagnostics);
             return;
         }

--- a/src/templates/detachedComponent.ts
+++ b/src/templates/detachedComponent.ts
@@ -1,5 +1,7 @@
 import { HtmlBuilder } from './helpers/htmlBuilder';
 import { StyleBuilder } from './helpers/styleBuilder';
+import type { Component } from '../providers/componentDetector';
+import type { ComponentParameter } from '../types/git-component';
 
 /**
  * Template class for generating HTML for the detached component view.
@@ -12,7 +14,7 @@ export class DetachedComponentTemplate {
    * @param existingInputs - Array of input parameter names already present in the file
    * @returns Complete HTML string ready for webview display
    */
-  static render(component: any, existingInputs: string[] = []): string {
+  static render(component: Component, existingInputs: string[] = []): string {
     return `
       <!DOCTYPE html>
       <html lang="en">
@@ -31,7 +33,7 @@ export class DetachedComponentTemplate {
   /**
    * Builds the HTML head section with title and styles.
    */
-  private static buildHead(component: any): string {
+  private static buildHead(component: Component): string {
     return `
       <head>
         <meta charset="UTF-8">
@@ -47,7 +49,7 @@ export class DetachedComponentTemplate {
   /**
    * Builds the header section with component name and metadata.
    */
-  private static buildHeader(component: any): string {
+  private static buildHeader(component: Component): string {
     const metadataItems: string[] = [];
 
     // Add source metadata
@@ -87,7 +89,7 @@ export class DetachedComponentTemplate {
   /**
    * Builds the description section.
    */
-  private static buildDescription(component: any): string {
+  private static buildDescription(component: Component): string {
     if (component.description) {
       return `
         <div class="description">
@@ -107,7 +109,7 @@ export class DetachedComponentTemplate {
   /**
    * Builds the parameters section with individual parameter cards.
    */
-  private static buildParameters(component: any, existingInputs: string[]): string {
+  private static buildParameters(component: Component, existingInputs: string[]): string {
     const parameters = component.parameters || [];
     const hasParameters = parameters.length > 0;
 
@@ -126,7 +128,7 @@ export class DetachedComponentTemplate {
 
     const parametersContent = hasParameters
       ? `<div class="parameters">
-          ${parameters.map((param: any) => this.buildParameter(param, existingInputs)).join('')}
+          ${parameters.map((param: ComponentParameter) => this.buildParameter(param, existingInputs)).join('')}
         </div>`
       : '<div class="no-content">No parameters documented for this component.</div>';
 
@@ -147,7 +149,7 @@ export class DetachedComponentTemplate {
   /**
    * Builds a single parameter card.
    */
-  private static buildParameter(param: any, existingInputs: string[]): string {
+  private static buildParameter(param: ComponentParameter, existingInputs: string[]): string {
     const isExisting = existingInputs.includes(param.name);
     const checkboxClass = isExisting ? 'parameter-checkbox existing' : 'parameter-checkbox';
     const checkboxLabel = isExisting ? 'Already Present' : 'Insert';
@@ -186,7 +188,7 @@ export class DetachedComponentTemplate {
   /**
    * Builds the insert options section with action buttons.
    */
-  private static buildInsertOptions(component: any, existingInputs: string[]): string {
+  private static buildInsertOptions(component: Component, existingInputs: string[]): string {
     const isEditMode = existingInputs.length > 0;
     const heading = isEditMode ? 'Edit Component' : 'Insert Component';
     const buttonText = isEditMode ? 'Update Component' : 'Insert Component';

--- a/src/utils/performanceMonitor.ts
+++ b/src/utils/performanceMonitor.ts
@@ -12,7 +12,7 @@ interface OperationMetric {
   name: string;
   duration: number;
   timestamp: number;
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 }
 
 interface OperationStats {
@@ -39,7 +39,7 @@ export class PerformanceMonitor {
   async track<T>(
     name: string,
     fn: () => Promise<T>,
-    metadata?: Record<string, any>
+    metadata?: Record<string, unknown>
   ): Promise<T> {
     const startTime = Date.now();
 
@@ -77,7 +77,7 @@ export class PerformanceMonitor {
   trackSync<T>(
     name: string,
     fn: () => T,
-    metadata?: Record<string, any>
+    metadata?: Record<string, unknown>
   ): T {
     const startTime = Date.now();
 
@@ -114,7 +114,7 @@ export class PerformanceMonitor {
   private recordMetric(
     name: string,
     duration: number,
-    metadata?: Record<string, any>
+    metadata?: Record<string, unknown>
   ): void {
     let metrics = this.metrics.get(name);
     if (!metrics) {

--- a/src/utils/yamlParser.ts
+++ b/src/utils/yamlParser.ts
@@ -1,11 +1,19 @@
 import * as yaml from 'js-yaml';
 import type * as vscode from 'vscode';
 
+/** Loose object shape returned by `js-yaml`. Callers narrow via property checks before reading fields. */
+export type YamlNode = Record<string, unknown>;
+
+/** Type-guard: a parsed YAML value is a non-null object (i.e. a mapping). Use to narrow `unknown` results. */
+export function isYamlNode(value: unknown): value is YamlNode {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 // Cache for parsed YAML documents to avoid re-parsing
-const parseCache = new Map<string, { content: string; parsed: any; timestamp: number }>();
+const parseCache = new Map<string, { content: string; parsed: unknown; timestamp: number }>();
 const CACHE_TTL = 5000; // 5 seconds TTL for parse cache
 
-export function parseYaml(text: string): any {
+export function parseYaml(text: string): unknown {
   try {
     // Generate a simple hash of the content for caching
     const contentHash = text.length + text.substring(0, 100) + text.substring(text.length - 100);
@@ -42,7 +50,7 @@ function cleanParseCache(currentTime: number): void {
   }
 }
 
-export function getYamlNodeAtPosition(document: vscode.TextDocument, _position: vscode.Position): any {
+export function getYamlNodeAtPosition(document: vscode.TextDocument, _position: vscode.Position): unknown {
   const text = document.getText();
   const parsed = parseYaml(text);
 
@@ -51,7 +59,7 @@ export function getYamlNodeAtPosition(document: vscode.TextDocument, _position: 
   return parsed;
 }
 
-export function findInputNode(document: vscode.TextDocument, componentNode: any, inputName: string): any {
+export function findInputNode(document: vscode.TextDocument, componentNode: YamlNode | null | undefined, inputName: string): { line: number; column: number } | null {
     if (!componentNode || !componentNode.inputs) {
         return null;
     }
@@ -61,6 +69,9 @@ export function findInputNode(document: vscode.TextDocument, componentNode: any,
 
     // More precise component line finding
     const componentUrl = componentNode.component;
+    if (typeof componentUrl !== 'string') {
+        return null;
+    }
     let componentLine = -1;
 
     // Find the line that contains the component URL with proper YAML structure


### PR DESCRIPTION
## Summary
- Phase 4 of the ESLint `@typescript-eslint/no-explicit-any` cleanup. This PR tackles the template + completion + extension entry layer: `detachedComponent.ts`, `completionProvider.ts`, `extension.ts`, `yamlParser.ts`, `performanceMonitor.ts`. Substitutes the loose `component: any` / `param: any` / `Record<string, any>` annotations for `Component`, `ComponentParameter`, `CachedComponent`, `Record<string, unknown>`. `parseYaml` now returns `unknown` and callers narrow explicitly.
- 29 warnings removed (**129 → 100**). Two latent invariants surfaced and now have explicit runtime guards.
- Link related issue(s): n/a

## Change Type
- [ ] feat
- [ ] fix
- [ ] refactor
- [ ] docs
- [ ] test
- [x] chore

## Context
### User-facing impact
- None expected. All edits are type tightening at warning sites. Two runtime guards added to message handlers in `extension.ts` make latent invariants explicit (a missing `sourcePath`/`gitlabInstance` now shows a clear error message instead of failing further downstream).

### GitLab scope
- [ ] gitlab.com
- [ ] self-managed GitLab
- [x] both (no behavioural change to either)

### Affected areas
- [ ] Component Browser
- [ ] Hover provider
- [x] Completion provider (typing only — no logic change)
- [ ] Validation provider
- [ ] Cache and refresh behavior
- [ ] GitLab API calls/auth/token storage
- [ ] Docs only

## What changed by bucket

| Bucket | Files | Warnings cleared | Approach |
|---|---|---|---|
| Component / parameter model | [detachedComponent.ts](src/templates/detachedComponent.ts), [completionProvider.ts](src/providers/completionProvider.ts) | 14 | All `component: any` → `Component` (from `componentDetector`), all `param: any` → `ComponentParameter` (from `types/git-component`). `findComponentInCache` return tightened to `Promise<CachedComponent \| null>`. One legacy `param.enum` access uses an inline `ComponentParameter & { enum?: unknown[] }` intersection so the canonical model isn't widened. |
| Extension entry data flow | [extension.ts](src/extension.ts) | 6 | Cache-debug buckets typed as `Map<string, CachedComponent[]>`. New `DetachableComponent = Component & { _hoverContext?: HoverContext }` type for the `detachHover` command payload. `(frag: any)` in the catalog-fragments path typed as `GitLabYamlFragment`. |
| YAML parser surface | [yamlParser.ts](src/utils/yamlParser.ts) | 5 | `parseYaml` and `getYamlNodeAtPosition` now return `unknown`; exported `YamlNode = Record<string, unknown>` and `isYamlNode(value): value is YamlNode` type-guard for callers; `findInputNode` accepts `YamlNode \| null \| undefined` and gained a runtime `typeof componentUrl === 'string'` guard at the use site. |
| Perf monitor metadata bags | [performanceMonitor.ts](src/utils/performanceMonitor.ts) | 4 | `Record<string, any>` → `Record<string, unknown>` on every `metadata?` parameter. |

Total: **29 warnings removed**.

## Notable details

### `parseYaml` return type tightened to `unknown` + shared `isYamlNode` guard
`parseYaml(text): any` becomes `parseYaml(text): unknown`. To narrow at call sites without resorting to `as` assertions, `yamlParser.ts` also exports a `isYamlNode(value): value is YamlNode` type-guard. Callers follow this pattern:
```ts
const parsed = parseYaml(text);
if (!isYamlNode(parsed) || !parsed.include) return null;
const includes = Array.isArray(parsed.include) ? parsed.include : [parsed.include];
```
TypeScript narrows `parsed` via the guard's `value is YamlNode` return type — no unchecked claims, the runtime check and the static narrow are the same statement. Inner iterations (e.g. each item in `includes`) use the same guard rather than a blanket array cast.

Affected callers updated: [hoverInputContext.ts](src/providers/hoverInputContext.ts), [completionProvider.ts](src/providers/completionProvider.ts), [validationProvider.ts](src/providers/validationProvider.ts). The validationProvider edit is a single-line narrowing adjacent to (but separate from) Phase 5's diagnostic-metadata work — it doesn't claim any of Phase 5's warnings.

### `DetachableComponent` for the `detachHover` command
The hover provider attaches `_hoverContext` (cursor + document location) to component data before serialising into the detach-command URL. The receiving handler in `extension.ts` was typed `component: any`; it's now typed as `DetachableComponent = Component & { _hoverContext?: HoverContext }`. `HoverContext` is re-exported from `hoverContentBuilder.ts` where it was already defined.

### `param.enum` is a latent extension field
The completion provider has a `default:` branch that reads `param.enum` for snippet-as-enum-picker rendering — but `enum` isn't part of the canonical `ComponentParameter` model. Rather than silently dropping the branch or widening the canonical type, the one access site uses an inline `ComponentParameter & { enum?: unknown[] }` intersection. Behaviour is preserved; the un-modelled field is now explicit at the only place that reads it.

## Latent invariants made explicit

### `detachHover` message handler — version fetch
The webview's "Update Component" action requires the active component to have `sourcePath` and `gitlabInstance` set. The runtime previously crashed with `Cannot read properties of undefined` if either was missing; it now surfaces a user-friendly `vscode.window.showErrorMessage(...)` and returns early.

### `detachHover` message handler — `fetchVersions`
Same as above for the `fetchVersions` message. The `cacheManager.fetchComponentVersions(component)` call requires a `CachedComponent` shape; a new `isCachedComponentShape` type-guard validates the required fields are present and throws a descriptive error if not (caught by the existing `try`/`catch`, which posts a `versionsError` message back to the webview).

Both guards encode invariants that were *already implicit* in the gatekeeper at line 333 (component enrichment only succeeds if those fields are resolvable). The old `any` typing masked that the invariant wasn't actually propagated to the message handler's scope.

## Validation
### Local checks
- [x] `npm run check-types` — clean (both `tsconfig.json` and `tsconfig.tests.json`).
- [x] `npm run lint` — **129 → 100 `no-explicit-any` warnings**, zero new warnings of any rule.
- [x] `npm test` — 20/20 assertions passing across 2 test files.
- [x] Manual verification in VS Code Extension Host — `env -u ELECTRON_RUN_AS_NODE npm run test:extension-host` 10/10 passing.

### Manual test notes
- The 29 cleared warnings span the hover detach panel, parameter completion, YAML include parsing, and perf metadata. Exercised in extension host: the local-include hover + completion paths exercise `parseYaml` narrowing; the extension activation tests exercise the new typed cache-debug command; the catch-and-log paths in fetch error scenarios exercise the `Logger` paths typed in earlier phases.
- The two new runtime guards in `extension.ts` were not directly exercised by the test suite — they cover error paths that require a component to be missing required fields. Behaviour preserved for the happy path.

## Breaking Changes
- [x] No breaking changes
- [ ] Breaking changes (describe below)

`parseYaml` and `getYamlNodeAtPosition` return types narrow from `any` to `unknown`. Three in-repo callers were updated in this PR; no external consumers exist.

## Screenshots / Recordings (if UI behavior changed)
- N/A — no UI changes.

## Risk and Rollback
- **Main risks:**
  - `parseYaml: unknown` will surface as a lint failure in any future code that reads `.foo` on the result without narrowing. This is the *intended* behaviour — callers should narrow at the parse boundary. Existing in-repo callers all updated.
  - The two `extension.ts` runtime guards add new early-return paths in message handlers. Previously the runtime would crash or silently fail when fields were missing; it now logs a clean error message. Net safer; user sees a notification instead of a stack trace in the dev console.
- **Rollback strategy:** Single PR, revert. No settings changes, no data migration, no CI secrets touched, no new dependencies.

## Release Notes Draft
- chore: tighten types across the detach-hover panel, parameter completion, YAML include parsing, and perf monitoring. `parseYaml` now returns `unknown` with caller-side narrowing. Two latent runtime invariants in the detach-hover message handlers now have explicit guards.

## Checklist
- [x] Branch is up to date with target branch
- [x] Commit messages follow conventional commits
- [x] Added/updated docs for behavior or settings changes (none required)
- [x] Added/updated tests for new behavior (none required — pure typing)
- [x] No secrets or tokens in code, logs, screenshots, or test fixtures
