### PR TITLE
fix(cache): cache branch-referenced components with HEAD-SHA revalidation

### DIFF
--- a/src/constants/timing.ts
+++ b/src/constants/timing.ts
@@ -14,6 +14,8 @@ export const RETRY_JITTER_MS = 1000 as const;
 // Cache Times (in seconds - converted to ms in usage)
 export const DEFAULT_CACHE_TIME_SECONDS = 3600 as const; // 1 hour
 export const DEFAULT_VERSION_CACHE_TIME_SECONDS = 86400 as const; // 24 hours
+/** 1 minute — mutable branch refs revalidate often */
+export const DEFAULT_BRANCH_CACHE_TIME_SECONDS = 60 as const;
 export const VERSION_REFRESH_MULTIPLIER = 4 as const; // 4x component cache time
 
 // Retry Configuration

--- a/src/providers/componentDetector.ts
+++ b/src/providers/componentDetector.ts
@@ -10,6 +10,7 @@ import type { ComponentParameter } from '../types/git-component';
 import type { GitApi, GitRepository } from '../types/vscode-git';
 import type { CachedComponent, RefType } from '../types/cache';
 import { DEFAULT_BRANCH_CACHE_TIME_SECONDS } from '../constants/timing';
+import { resolveBranchFreshness, type BranchFreshnessResult } from '../utils/branchFreshness';
 
 // Re-export so existing consumers (e.g. localComponentResolver, validationProvider) keep their import path.
 export type { ComponentParameter };
@@ -64,58 +65,24 @@ async function resolveRefType(
 }
 
 /**
- * Decide whether a cached component pinned to a branch needs re-fetching because the branch HEAD has moved.
+ * Resolve a cached branch entry's freshness against GitLab, mutating its `refType`/`cachedAt` in place. Thin adapter
+ * binding the real service + clock to the pure {@link resolveBranchFreshness}.
  *
- * Tags are taken as fixed (by convention), so they skip this check. A branch is served from cache within a short TTL,
- * then revalidated by comparing its live HEAD SHA to the cached one. When anything is uncertain (no SHA recorded, HEAD
- * unresolvable) it errs toward serving cache rather than re-fetching on every hover.
- *
- * @param cachedComponent The cached entry under consideration.
+ * @param cachedComponent The cached entry under consideration; its `refType`/`cachedAt` may be mutated.
  * @param ref The effective ref being requested (branch name, or the cached version when none was specified).
- * @returns `true` if the cached data is stale and the caller should re-fetch; `false` if it can be served as-is.
+ * @returns Whether the entry is stale, and whether persistent fields were mutated (so the caller can re-save once).
  */
-async function isCachedBranchStale(
+async function checkBranchFreshness(
   cachedComponent: CachedComponent,
   ref: string
-): Promise<boolean> {
-  const refType = await resolveRefType(
-    cachedComponent.gitlabInstance,
-    cachedComponent.sourcePath,
-    ref,
-    cachedComponent.refType
-  );
-  // Persist the verdict so subsequent hovers (and the TTL-reset path) read it without re-checking.
-  cachedComponent.refType = refType;
-  if (refType === 'tag') {
-    return false;
-  }
-
-  // Within the branch TTL window — serve cache without contacting GitLab.
-  if (
-    typeof cachedComponent.cachedAt === 'number' &&
-    Date.now() - cachedComponent.cachedAt < DEFAULT_BRANCH_CACHE_TIME_SECONDS * 1000
-  ) {
-    return false;
-  }
-
-  if (!cachedComponent.resolvedSha) {
-    // No recorded SHA to compare against — serve cache rather than re-fetch on every hover. A SHA is recorded on the
-    // next genuine fetch.
-    return false;
-  }
-
-  const currentSha = await resolveRefSha(
-    cachedComponent.gitlabInstance,
-    cachedComponent.sourcePath,
-    ref
-  );
-
-  if (!currentSha) {
-    // Couldn't resolve HEAD (offline, no token, branch gone) — keep serving cache.
-    return false;
-  }
-
-  return currentSha !== cachedComponent.resolvedSha;
+): Promise<BranchFreshnessResult> {
+  return resolveBranchFreshness(cachedComponent, DEFAULT_BRANCH_CACHE_TIME_SECONDS * 1000, {
+    now: () => Date.now(),
+    resolveRefType: cached =>
+      resolveRefType(cachedComponent.gitlabInstance, cachedComponent.sourcePath, ref, cached),
+    resolveHeadSha: () =>
+      resolveRefSha(cachedComponent.gitlabInstance, cachedComponent.sourcePath, ref),
+  });
 }
 
 // Update your Component interface to include the context property
@@ -343,51 +310,18 @@ export async function detectIncludeComponent(document: vscode.TextDocument, posi
 
     logger.debug(`[ComponentDetector] Looking for component: ${requestedName} from ${requestedGitlabInstance}/${requestedProjectPath}${requestedVersion ? `@${requestedVersion}` : ''}`, 'ComponentDetector');
 
-    // First, try to find an exact match (same name, project path, AND version)
-    if (requestedVersion) {
-      const exactMatch = cachedComponents.find(comp => {
-        // For cached components, extract project path from sourcePath
-        return (
-          comp.gitlabInstance === requestedGitlabInstance &&
-          comp.sourcePath === requestedProjectPath &&
-          comp.name === requestedName &&
-          comp.version === requestedVersion
-        );
-      });
+    // Prefer a cache entry whose version matches the request exactly; otherwise fall back to any cached entry for the
+    // same component. Both go through the same freshness-checked serve/refetch path below — a branch entry is only
+    // served after checkBranchFreshness confirms the branch HEAD hasn't moved.
+    const matchesComponent = (comp: CachedComponent): boolean =>
+      comp.gitlabInstance === requestedGitlabInstance &&
+      comp.sourcePath === requestedProjectPath &&
+      comp.name === requestedName;
 
-      if (exactMatch) {
-        logger.debug(`[ComponentDetector] Found exact version match in cache: ${exactMatch.name}@${exactMatch.version}`, 'ComponentDetector');
-        return {
-          name: exactMatch.name,
-          description: exactMatch.description,
-          parameters: exactMatch.parameters,
-          version: exactMatch.version,
-          source: `${exactMatch.gitlabInstance}/${exactMatch.sourcePath}`,
-          url: componentUrl,
-          originalUrl: originalUrl,
-          gitlabInstance: exactMatch.gitlabInstance,
-          sourcePath: exactMatch.sourcePath,
-          templatePath: exactMatch.templatePath,
-          readme: exactMatch.readme || '', // Include README from cache
-          context: {
-            gitlabInstance: exactMatch.gitlabInstance,
-            path: exactMatch.sourcePath
-          }
-        };
-      }
-
-      logger.debug(`[ComponentDetector] No exact version match found for ${requestedName}@${requestedVersion}`, 'ComponentDetector');
-    }
-
-    // If no exact match, look for any version of the same component
-    const cachedComponent = cachedComponents.find(comp => {
-      // Match by hostname, project path, and component name (ignoring version)
-      return (
-        comp.gitlabInstance === requestedGitlabInstance &&
-        comp.sourcePath === requestedProjectPath &&
-        comp.name === requestedName
-      );
-    });
+    const cachedComponent =
+      (requestedVersion &&
+        cachedComponents.find(comp => matchesComponent(comp) && comp.version === requestedVersion)) ||
+      cachedComponents.find(matchesComponent);
 
     if (cachedComponent) {
       logger.debug(`[ComponentDetector] Found matching component in cache: ${cachedComponent.name}`, 'ComponentDetector');
@@ -399,14 +333,14 @@ export async function detectIncludeComponent(document: vscode.TextDocument, posi
       // confirm the branch hasn't moved since we cached it.
       if (!requestedVersion || requestedVersion === cachedComponent.version) {
         const effectiveRef = requestedVersion || cachedComponent.version;
-        const branchStale = await isCachedBranchStale(cachedComponent, effectiveRef);
+        const freshness = await checkBranchFreshness(cachedComponent, effectiveRef);
 
-        if (!branchStale) {
+        if (!freshness.stale) {
           logger.debug(`[ComponentDetector] Version matches cache, returning cached component`, 'ComponentDetector');
-          // Confirmed fresh as of now — reset the branch TTL window so we don't re-check the HEAD on every subsequent
-          // hover. No-op for tag refs. `refType` was just resolved + persisted by isCachedBranchStale above.
-          if (cachedComponent.refType === 'branch') {
-            cachedComponent.cachedAt = Date.now();
+          // checkBranchFreshness may have resolved `refType` and/or stamped a new "last verified" `cachedAt`; persist
+          // once if so, so the work survives the session. No write on a plain within-TTL serve (nothing changed).
+          if (freshness.mutated) {
+            cacheManager.persistComponentState();
           }
           return {
             name: cachedComponent.name,

--- a/src/providers/componentDetector.ts
+++ b/src/providers/componentDetector.ts
@@ -8,11 +8,115 @@ import { spawn } from 'child_process';
 import { detectLocalIncludeComponent } from './localComponentResolver';
 import type { ComponentParameter } from '../types/git-component';
 import type { GitApi, GitRepository } from '../types/vscode-git';
+import type { CachedComponent, RefType } from '../types/cache';
+import { DEFAULT_BRANCH_CACHE_TIME_SECONDS } from '../constants/timing';
 
 // Re-export so existing consumers (e.g. localComponentResolver, validationProvider) keep their import path.
 export type { ComponentParameter };
 
 const logger = Logger.getInstance();
+
+/**
+ * Resolve the current HEAD SHA for a ref via the component service. Only meaningful for branches.
+ *
+ * @param gitlabInstance The GitLab instance hostname (e.g. `gitlab.com`).
+ * @param projectPath The project path (e.g. `my-group/shared-ci`).
+ * @param ref The branch name to resolve.
+ * @returns The HEAD commit SHA, or undefined on any failure (network error, missing branch, no access) so callers
+ *          treat the result as "unknown" rather than "unchanged" or "changed".
+ */
+async function resolveRefSha(
+  gitlabInstance: string,
+  projectPath: string,
+  ref: string
+): Promise<string | undefined> {
+  const sha = await getComponentService().resolveBranchSha(gitlabInstance, projectPath, ref);
+  return sha ?? undefined;
+}
+
+/**
+ * Classify a ref as a `branch` (treated as moving) or `tag` (treated as fixed by convention).
+ *
+ * Resolution order, cheapest/most-trusted first:
+ *  1. A previously persisted verdict on the cache entry (`cachedVerdict`) — resolved once, never re-checked.
+ *  2. GitLab's dedicated single-tag endpoint via the component service — definitive 200/404.
+ *  3. If the API can't answer (offline, no access), default to `branch` (the safe default — at worst one extra
+ *     freshness check; never serving stale data).
+ *
+ * @param gitlabInstance The GitLab instance hostname (e.g. `gitlab.com`).
+ * @param projectPath The project path (e.g. `my-group/shared-ci`).
+ * @param ref The ref being classified.
+ * @param cachedVerdict A verdict already persisted on the cache entry, if any (skips the network call).
+ * @returns `'branch'` or `'tag'`. Never undefined — defaults to `'branch'` when undetermined.
+ */
+async function resolveRefType(
+  gitlabInstance: string,
+  projectPath: string,
+  ref: string,
+  cachedVerdict?: RefType
+): Promise<RefType> {
+  if (cachedVerdict) {
+    return cachedVerdict;
+  }
+
+  const isTag = await getComponentService().isRefATag(gitlabInstance, projectPath, ref);
+  return isTag ? 'tag' : 'branch';
+}
+
+/**
+ * Decide whether a cached component pinned to a branch needs re-fetching because the branch HEAD has moved.
+ *
+ * Tags are taken as fixed (by convention), so they skip this check. A branch is served from cache within a short TTL,
+ * then revalidated by comparing its live HEAD SHA to the cached one. When anything is uncertain (no SHA recorded, HEAD
+ * unresolvable) it errs toward serving cache rather than re-fetching on every hover.
+ *
+ * @param cachedComponent The cached entry under consideration.
+ * @param ref The effective ref being requested (branch name, or the cached version when none was specified).
+ * @returns `true` if the cached data is stale and the caller should re-fetch; `false` if it can be served as-is.
+ */
+async function isCachedBranchStale(
+  cachedComponent: CachedComponent,
+  ref: string
+): Promise<boolean> {
+  const refType = await resolveRefType(
+    cachedComponent.gitlabInstance,
+    cachedComponent.sourcePath,
+    ref,
+    cachedComponent.refType
+  );
+  // Persist the verdict so subsequent hovers (and the TTL-reset path) read it without re-checking.
+  cachedComponent.refType = refType;
+  if (refType === 'tag') {
+    return false;
+  }
+
+  // Within the branch TTL window — serve cache without contacting GitLab.
+  if (
+    typeof cachedComponent.cachedAt === 'number' &&
+    Date.now() - cachedComponent.cachedAt < DEFAULT_BRANCH_CACHE_TIME_SECONDS * 1000
+  ) {
+    return false;
+  }
+
+  if (!cachedComponent.resolvedSha) {
+    // No recorded SHA to compare against — serve cache rather than re-fetch on every hover. A SHA is recorded on the
+    // next genuine fetch.
+    return false;
+  }
+
+  const currentSha = await resolveRefSha(
+    cachedComponent.gitlabInstance,
+    cachedComponent.sourcePath,
+    ref
+  );
+
+  if (!currentSha) {
+    // Couldn't resolve HEAD (offline, no token, branch gone) — keep serving cache.
+    return false;
+  }
+
+  return currentSha !== cachedComponent.resolvedSha;
+}
 
 // Update your Component interface to include the context property
 export interface Component {
@@ -31,6 +135,9 @@ export interface Component {
   gitlabInstance?: string; // GitLab instance
   sourcePath?: string; // Source path
   templatePath?: string; // Repo-relative path to the template file, resolved at fetch time
+  resolvedSha?: string; // Branch HEAD SHA at fetch time (branch refs only); used for cache freshness
+  cachedAt?: number; // Epoch ms of last branch fetch/revalidation; used for the branch TTL
+  refType?: RefType; // Authoritative ref classification (branch|tag), resolved once and persisted
   originalUrl?: string; // Original URL with variables (if any)
   // Add this context property that's needed by the hover provider
   context?: {
@@ -288,30 +395,46 @@ export async function detectIncludeComponent(document: vscode.TextDocument, posi
       logger.debug(`[ComponentDetector] Cached component has README: ${!!cachedComponent.readme}`, 'ComponentDetector');
       logger.debug(`[ComponentDetector] Cached README length: ${cachedComponent.readme ? cachedComponent.readme.length : 0}`, 'ComponentDetector');
 
-      // If the requested version matches the cached version, return cached data
+      // If the requested version matches the cached version, return cached data — but for mutable branch refs first
+      // confirm the branch hasn't moved since we cached it.
       if (!requestedVersion || requestedVersion === cachedComponent.version) {
-        logger.debug(`[ComponentDetector] Version matches cache, returning cached component`, 'ComponentDetector');
-        return {
-          name: cachedComponent.name,
-          description: cachedComponent.description,
-          parameters: cachedComponent.parameters,
-          version: cachedComponent.version,
-          source: `${cachedComponent.gitlabInstance}/${cachedComponent.sourcePath}`,
-          url: componentUrl,
-          originalUrl: originalUrl,
-          gitlabInstance: cachedComponent.gitlabInstance,
-          sourcePath: cachedComponent.sourcePath,
-          templatePath: cachedComponent.templatePath,
-          readme: cachedComponent.readme || '', // Include README from cache
-          context: {
-            gitlabInstance: cachedComponent.gitlabInstance,
-            path: cachedComponent.sourcePath
+        const effectiveRef = requestedVersion || cachedComponent.version;
+        const branchStale = await isCachedBranchStale(cachedComponent, effectiveRef);
+
+        if (!branchStale) {
+          logger.debug(`[ComponentDetector] Version matches cache, returning cached component`, 'ComponentDetector');
+          // Confirmed fresh as of now — reset the branch TTL window so we don't re-check the HEAD on every subsequent
+          // hover. No-op for tag refs. `refType` was just resolved + persisted by isCachedBranchStale above.
+          if (cachedComponent.refType === 'branch') {
+            cachedComponent.cachedAt = Date.now();
           }
-        };
+          return {
+            name: cachedComponent.name,
+            description: cachedComponent.description,
+            parameters: cachedComponent.parameters,
+            version: cachedComponent.version,
+            source: `${cachedComponent.gitlabInstance}/${cachedComponent.sourcePath}`,
+            url: componentUrl,
+            originalUrl: originalUrl,
+            gitlabInstance: cachedComponent.gitlabInstance,
+            sourcePath: cachedComponent.sourcePath,
+            templatePath: cachedComponent.templatePath,
+            readme: cachedComponent.readme || '', // Include README from cache
+            resolvedSha: cachedComponent.resolvedSha,
+            context: {
+              gitlabInstance: cachedComponent.gitlabInstance,
+              path: cachedComponent.sourcePath
+            }
+          };
+        }
+
+        // Branch has moved on the remote — fall through to re-fetch fresh data.
+        logger.debug(`[ComponentDetector] Cached branch ${effectiveRef} is stale (HEAD moved), re-fetching`, 'ComponentDetector');
       }
 
-      // If versions differ, try to fetch the specific version
-      logger.debug(`[ComponentDetector] Version mismatch (cached: ${cachedComponent.version}, requested: ${requestedVersion}), attempting to fetch specific version`, 'ComponentDetector');
+      // Reached when the requested version differs from the cached one, or when a branch ref's HEAD has moved (stale
+      // fall-through above). Fetch fresh data.
+      logger.debug(`[ComponentDetector] Cache miss/stale (cached: ${cachedComponent.version}, requested: ${requestedVersion}), attempting to fetch specific version`, 'ComponentDetector');
       logger.debug(`[ComponentDetector] Calling componentService.getComponentFromUrl with: ${componentUrl}`, 'ComponentDetector');
 
       try {
@@ -322,20 +445,33 @@ export async function detectIncludeComponent(document: vscode.TextDocument, posi
           logger.debug(`[ComponentDetector] Successfully fetched specific version ${requestedVersion} for ${cachedComponent.name}`, 'ComponentDetector');
           logger.debug(`[ComponentDetector] Fetched component has README: ${!!specificVersionComponent.readme}`, 'ComponentDetector');
 
+          const cacheVersion = requestedVersion || 'main';
+          // Authoritatively classify the ref, then record the branch HEAD + timestamp so the next hover can detect a
+          // moved branch (and apply the branch TTL) instead of re-fetching every time. Tags get neither (taken as fixed).
+          const refType = await resolveRefType(requestedGitlabInstance, requestedProjectPath, cacheVersion);
+          const isBranch = refType === 'branch';
+          const resolvedSha = isBranch
+            ? await resolveRefSha(requestedGitlabInstance, requestedProjectPath, cacheVersion)
+            : undefined;
+          const cachedAt = isBranch ? Date.now() : undefined;
+
           // Add the specific version to cache for future use
           cacheManager.addDynamicComponent({
             name: specificVersionComponent.name,
             description: specificVersionComponent.description,
             parameters: specificVersionComponent.parameters,
-            version: requestedVersion || 'main',
+            version: cacheVersion,
             url: componentUrl,
             gitlabInstance: requestedGitlabInstance,
             sourcePath: requestedProjectPath,
             source: `${requestedGitlabInstance}/${requestedProjectPath}`,
-            templatePath: specificVersionComponent.templatePath
+            templatePath: specificVersionComponent.templatePath,
+            resolvedSha,
+            cachedAt,
+            refType
           });
 
-          return specificVersionComponent;
+          return { ...specificVersionComponent, resolvedSha, cachedAt, refType };
         } else {
           logger.debug(`[ComponentDetector] getComponentFromUrl returned null/undefined for specific version`, 'ComponentDetector');
         }
@@ -643,6 +779,12 @@ async function fetchComponentDynamically(componentUrl: string, originalUrl?: str
     // Add to cache for future use
     try {
       const cacheManager = getComponentCacheManager();
+      // Authoritatively classify the ref once; branches get a HEAD SHA + timestamp, tags get neither (taken as fixed).
+      const refType = await resolveRefType(gitlabInstance, projectPath, version);
+      const isBranch = refType === 'branch';
+      const resolvedSha = isBranch
+        ? await resolveRefSha(gitlabInstance, projectPath, version)
+        : undefined;
       const cacheComponent = {
         name: foundComponent.name,
         description: componentDescription, // Use the enhanced description
@@ -662,7 +804,12 @@ async function fetchComponentDynamically(componentUrl: string, originalUrl?: str
         gitlabInstance: gitlabInstance,
         version: version,
         url: componentUrl,
-        templatePath: resolvedTemplatePath
+        templatePath: resolvedTemplatePath,
+        // Branch HEAD + timestamp let subsequent hovers detect a moved branch (and apply the branch TTL) rather than
+        // re-fetching every time. Tags are taken as fixed → neither is recorded.
+        resolvedSha,
+        cachedAt: isBranch ? Date.now() : undefined,
+        refType
       };
 
       cacheManager.addDynamicComponent(cacheComponent);

--- a/src/services/cache/componentCacheManager.ts
+++ b/src/services/cache/componentCacheManager.ts
@@ -15,7 +15,7 @@ import {
 
 // Bump when the on-disk CachedComponent shape changes. Mismatched caches are discarded on load so the new fields can be
 // populated by re-fetching.
-const CURRENT_CACHE_VERSION = '1.1.0';
+const CURRENT_CACHE_VERSION = '1.2.0';
 
 /**
  * ComponentCacheManager - Main orchestrator for component caching

--- a/src/services/cache/componentCacheManager.ts
+++ b/src/services/cache/componentCacheManager.ts
@@ -139,12 +139,27 @@ export class ComponentCacheManager {
           'ComponentCache'
         );
       }
+
+      // Persist so dynamically fetched entries (and their freshness fields) survive across sessions instead of being
+      // re-resolved on next launch. Fire-and-forget — a failed save only costs a re-fetch, never correctness.
+      this.persistComponentState();
     } catch (error) {
       this.logger.debug(
         `[ComponentCache] Error adding dynamic component: ${error}`,
         'ComponentCache'
       );
     }
+  }
+
+  /**
+   * Persist the current in-memory component list to disk. Use after mutating a cached entry on a read path (e.g. the
+   * hover provider recording a branch's `refType`/`cachedAt`/`resolvedSha`) so the update survives the session. No-op
+   * when no extension context is set. Fire-and-forget — failure only costs a re-fetch, never correctness.
+   */
+  public persistComponentState(): void {
+    this.saveCacheToDisk().catch(error => {
+      this.logger.debug(`[ComponentCache] Failed to persist component state: ${error}`, 'ComponentCache');
+    });
   }
 
   public getSourceErrors(): Map<string, string> {

--- a/src/services/component/componentFetcher.ts
+++ b/src/services/component/componentFetcher.ts
@@ -460,8 +460,8 @@ export class ComponentFetcher {
         projectInfo = projectInfoResult.value;
       }
 
-      // Use the project's default branch if available
-      if (projectInfo && projectInfo.default_branch) {
+      // Fall back to the project's default branch only when no explicit ref was requested.
+      if (!version && projectInfo && projectInfo.default_branch) {
         ref = projectInfo.default_branch;
       }
       this.logger.debug(`Found project: ${projectInfo.name} (ID: ${projectInfo.id}), using ref: ${ref}`);

--- a/src/services/component/componentService.ts
+++ b/src/services/component/componentService.ts
@@ -117,6 +117,38 @@ export class ComponentService implements ComponentSource {
     return this.versionManager.fetchProjectTags(gitlabInstance, projectPath);
   }
 
+  /**
+   * Resolve the HEAD commit SHA of a branch, used to detect when a branch ref has moved.
+   *
+   * @param gitlabInstance The GitLab instance hostname (e.g. `gitlab.com`).
+   * @param projectPath The project path (e.g. `my-group/shared-ci`).
+   * @param branch The branch name to resolve.
+   * @returns The commit SHA, or null if the branch can't be resolved (network error, missing branch, no access).
+   */
+  public async resolveBranchSha(
+    gitlabInstance: string,
+    projectPath: string,
+    branch: string
+  ): Promise<string | null> {
+    return this.versionManager.resolveBranchSha(gitlabInstance, projectPath, branch);
+  }
+
+  /**
+   * Authoritatively determine whether a ref is a tag (taken as fixed, skips freshness checks) versus a branch.
+   *
+   * @param gitlabInstance The GitLab instance hostname (e.g. `gitlab.com`).
+   * @param projectPath The project path (e.g. `my-group/shared-ci`).
+   * @param ref The ref name to classify.
+   * @returns `true` if a tag, `false` if definitively not a tag, or `null` when it can't be determined.
+   */
+  public async isRefATag(
+    gitlabInstance: string,
+    projectPath: string,
+    ref: string
+  ): Promise<boolean | null> {
+    return this.versionManager.isRefATag(gitlabInstance, projectPath, ref);
+  }
+
   // Catalog data delegation
   public async fetchCatalogData(
     gitlabInstance: string,

--- a/src/services/component/versionManager.ts
+++ b/src/services/component/versionManager.ts
@@ -2,6 +2,7 @@ import { Logger } from '../../utils/logger';
 import { HttpClient } from '../../utils/httpClient';
 import { TokenManager } from './tokenManager';
 import type { GitLabProjectInfo, GitLabTag, GitLabBranch } from '../../types/api';
+import { NetworkError } from '../../errors';
 
 /**
  * Manages fetching and sorting versions (tags and branches) for GitLab projects
@@ -51,7 +52,8 @@ export class VersionManager {
         return ['main'];
       }
 
-      // Fetch tags and branches in parallel
+      // Fetch tags and branches in parallel. Both are fully paginated so neither is silently truncated on projects
+      // with many tags/branches.
       const [tagsResult, branchesResult] = await Promise.allSettled([
         this.httpClient.fetchAllPages<GitLabTag>(
           `${apiBaseUrl}/projects/${projectInfo.id}/repository/tags?sort=desc`,
@@ -150,6 +152,94 @@ export class VersionManager {
     } catch (error) {
       this.logger.warn(`Error fetching tags: ${error}`);
       return [];
+    }
+  }
+
+  /**
+   * Resolve the HEAD commit SHA of a branch in a single cheap API call.
+   *
+   * Used to revalidate cached components that are pinned to a (mutable) branch: if the branch HEAD still matches the
+   * SHA stored alongside the cache entry, the cached data is still current and a full re-fetch can be skipped.
+   *
+   * @param gitlabInstance The GitLab instance hostname (e.g. `gitlab.com`).
+   * @param projectPath The project path (e.g. `my-group/shared-ci`); URL-encoded internally.
+   * @param branch The branch name to resolve; URL-encoded internally (supports `/`-containing names).
+   * @returns The commit SHA, or null if the branch can't be resolved (network error, missing branch, no access) —
+   *          callers should treat null as "unknown, keep serving cache" rather than "unchanged" or "changed".
+   */
+  public async resolveBranchSha(
+    gitlabInstance: string,
+    projectPath: string,
+    branch: string
+  ): Promise<string | null> {
+    try {
+      const apiBaseUrl = `https://${gitlabInstance}/api/v4`;
+      const encodedPath = encodeURIComponent(projectPath);
+      const encodedBranch = encodeURIComponent(branch);
+      const url = `${apiBaseUrl}/projects/${encodedPath}/repository/branches/${encodedBranch}`;
+
+      const token = await this.tokenManager.getTokenForProject(gitlabInstance);
+      const options = token ? { headers: { 'PRIVATE-TOKEN': token } } : undefined;
+
+      const branchInfo = await this.httpClient.fetchJson<GitLabBranch>(url, options);
+      const sha = branchInfo?.commit?.id;
+
+      if (!sha) {
+        this.logger.debug(
+          `[VersionManager] No commit SHA returned for ${projectPath}@${branch}`
+        );
+        return null;
+      }
+
+      this.logger.debug(
+        `[VersionManager] Resolved ${projectPath}@${branch} to ${sha.slice(0, 8)}`
+      );
+      return sha;
+    } catch (error) {
+      this.logger.debug(
+        `[VersionManager] Could not resolve branch SHA for ${projectPath}@${branch}: ${error}`
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Determine whether a ref is a tag
+   *
+   * @param gitlabInstance The GitLab instance hostname (e.g. `gitlab.com`).
+   * @param projectPath The project path (e.g. `my-group/shared-ci`);
+   * @param ref The ref name to classify;
+   * @returns `true` if the ref is a tag, `false` if it is definitively not a tag, or`null` when the answer can't be
+   *          determined.
+   */
+  public async isRefATag(
+    gitlabInstance: string,
+    projectPath: string,
+    ref: string
+  ): Promise<boolean | null> {
+    const apiBaseUrl = `https://${gitlabInstance}/api/v4`;
+    const encodedPath = encodeURIComponent(projectPath);
+    const encodedRef = encodeURIComponent(ref);
+    const url = `${apiBaseUrl}/projects/${encodedPath}/repository/tags/${encodedRef}`;
+
+    try {
+      const token = await this.tokenManager.getTokenForProject(gitlabInstance);
+      const options = token ? { headers: { 'PRIVATE-TOKEN': token } } : undefined;
+
+      await this.httpClient.fetchJson<GitLabTag>(url, options);
+      this.logger.debug(`[VersionManager] ${projectPath}@${ref} is a tag`);
+      return true;
+    } catch (error) {
+      if (error instanceof NetworkError && error.details?.statusCode === 404) {
+        // Definitive: no tag by this name exists, so the ref is a branch (or doesn't exist).
+        this.logger.debug(`[VersionManager] ${projectPath}@${ref} is not a tag (404)`);
+        return false;
+      }
+      // Anything else (offline, 401/403, 5xx) — we genuinely don't know.
+      this.logger.debug(
+        `[VersionManager] Could not determine tag status for ${projectPath}@${ref}: ${error}`
+      );
+      return null;
     }
   }
 

--- a/src/types/cache.ts
+++ b/src/types/cache.ts
@@ -5,6 +5,12 @@
 import type { ParameterDefault } from './git-component';
 
 /**
+ * How a component's ref is classified for caching: a `branch` gets the freshness check (it can move); a `tag` skips it
+ * (taken as fixed by convention).
+ */
+export type RefType = 'branch' | 'tag';
+
+/**
  * Generic cache entry with timestamp for expiration tracking
  */
 export interface CacheEntry<T> {
@@ -90,6 +96,12 @@ export interface CachedComponent {
   notes?: string[];
   /** Raw YAML source of the template, populated when the fetch retrieved the template file. */
   rawYaml?: string;
+  /** For components pinned to a mutable branch ref, the branch HEAD commit SHA at the time this entry was cached. */
+  resolvedSha?: string;
+  /** Epoch ms when this branch entry was last fetched/revalidated. */
+  cachedAt?: number;
+  /** Authoritative ref classification for this entry, resolved once against GitLab and persisted. */
+  refType?: RefType;
 }
 
 /**

--- a/src/utils/branchFreshness.ts
+++ b/src/utils/branchFreshness.ts
@@ -1,0 +1,137 @@
+import type { RefType } from '../types/cache';
+
+/** The cached freshness fields a staleness decision reads. */
+export interface BranchFreshnessState {
+  refType?: RefType;
+  /** Epoch ms the entry was last fetched/revalidated. */
+  cachedAt?: number;
+  /** Branch HEAD SHA recorded when the entry was cached. */
+  resolvedSha?: string;
+}
+
+/** Outcome of the cheap (pre-network) freshness check. */
+export type FreshnessStep =
+  /** Serve the cached entry without contacting the remote. */
+  | { action: 'serve' }
+  /** Resolve the live branch HEAD and compare it to `resolvedSha` before deciding. */
+  | { action: 'check-head' };
+
+/**
+ * Cheap, pre-network half of the branch freshness decision — no I/O, no clock of its own.
+ *
+ * Returns `serve` when the entry can be used as-is (tag ref, still within the TTL window, or no recorded SHA to
+ * compare against), and `check-head` when the TTL has elapsed and a live HEAD-SHA comparison is needed.
+ *
+ * @param state The cached entry's freshness fields.
+ * @param ttlMs The branch TTL window in ms.
+ * @param now Current epoch ms (injected for testability).
+ */
+export function evaluateBranchFreshness(
+  state: BranchFreshnessState,
+  ttlMs: number,
+  now: number
+): FreshnessStep {
+  // Tags are taken as fixed (by convention) — never need the HEAD check.
+  if (state.refType === 'tag') {
+    return { action: 'serve' };
+  }
+
+  // Within the TTL window — serve without contacting the remote.
+  if (typeof state.cachedAt === 'number' && now - state.cachedAt < ttlMs) {
+    return { action: 'serve' };
+  }
+
+  // No recorded SHA to compare against — serve rather than re-fetch on every hover. A SHA is recorded on the next
+  // genuine fetch.
+  if (!state.resolvedSha) {
+    return { action: 'serve' };
+  }
+
+  return { action: 'check-head' };
+}
+
+/**
+ * Final half of the decision, once the live HEAD SHA has been resolved: is the cached branch entry stale?
+ *
+ * Stale only when both SHAs are known and differ. If either is missing (no recorded SHA, or the HEAD couldn't be
+ * resolved — offline / no access) the cache is kept rather than forcing a re-fetch.
+ *
+ * @param recordedSha The SHA stored on the cache entry, if any.
+ * @param currentSha The freshly resolved branch HEAD SHA, or undefined if it couldn't be resolved.
+ * @returns `true` if the branch has demonstrably moved (both SHAs known and differ); `false` otherwise.
+ */
+export function isBranchHeadStale(
+  recordedSha: string | undefined,
+  currentSha: string | undefined
+): boolean {
+  if (!recordedSha || !currentSha) {
+    return false;
+  }
+  return currentSha !== recordedSha;
+}
+
+/** The mutable freshness fields the orchestrator reads and updates in place. */
+export interface BranchFreshnessEntry extends BranchFreshnessState {
+  refType?: RefType;
+  cachedAt?: number;
+  resolvedSha?: string;
+}
+
+/** I/O the orchestrator depends on, injected so it can be driven without vscode or the network in tests. */
+export interface BranchFreshnessDeps {
+  /** Current epoch ms. */
+  now: () => number;
+  /** Classify the ref (uses the entry's existing verdict as a hint when present). */
+  resolveRefType: (cached: RefType | undefined) => Promise<RefType>;
+  /** Resolve the live branch HEAD SHA, or undefined if it can't be determined. */
+  resolveHeadSha: () => Promise<string | undefined>;
+}
+
+/** Outcome of a freshness check. */
+export interface BranchFreshnessResult {
+  /** True when the cached data is stale and the caller should re-fetch. */
+  stale: boolean;
+  /** True when `refType`/`cachedAt` were mutated and the entry should be re-saved. */
+  mutated: boolean;
+}
+
+/**
+ * Resolve a cached branch entry's freshness, mutating `refType`/`cachedAt` in place.
+ *
+ * `cachedAt` is the "last verified against the remote" time — it is stamped ONLY after an actual HEAD comparison,
+ * never on a plain within-TTL serve. This is what stops repeated within-TTL hovers from sliding the window forever and
+ * starving the HEAD check (the realistic "hover the same include while editing" pattern).
+ *
+ * All I/O (clock, ref classification, HEAD lookup) is injected via `deps`, so this is unit-testable without vscode or
+ * the network.
+ *
+ * @param entry The cached entry; its `refType`/`cachedAt` may be mutated.
+ * @param ttlMs The branch TTL window in ms.
+ * @param deps Injected clock and resolvers.
+ * @returns Whether the entry is stale, and whether persistent fields were mutated (so the caller can re-save once).
+ */
+export async function resolveBranchFreshness(
+  entry: BranchFreshnessEntry,
+  ttlMs: number,
+  deps: BranchFreshnessDeps
+): Promise<BranchFreshnessResult> {
+  const priorRefType = entry.refType;
+  entry.refType = await deps.resolveRefType(priorRefType);
+  let mutated = entry.refType !== priorRefType;
+
+  const step = evaluateBranchFreshness(entry, ttlMs, deps.now());
+  if (step.action === 'serve') {
+    // Served without a remote check — do NOT touch `cachedAt`.
+    return { stale: false, mutated };
+  }
+
+  const currentSha = await deps.resolveHeadSha();
+  if (isBranchHeadStale(entry.resolvedSha, currentSha)) {
+    return { stale: true, mutated };
+  }
+
+  // Verified fresh against the remote — record this as the new "last verified" time.
+  entry.cachedAt = deps.now();
+  mutated = true;
+  return { stale: false, mutated };
+}

--- a/tests/unit/branchFreshness.test.ts
+++ b/tests/unit/branchFreshness.test.ts
@@ -1,0 +1,169 @@
+// @mocha
+/**
+ * Tests src/utils/branchFreshness.ts — the pure two-phase branch-cache staleness decision that decides whether a
+ * cached branch entry can be served or must be revalidated/re-fetched.
+ *
+ * Regression coverage for the bug where a repeat hover of `@branch` served stale metadata: once the TTL has elapsed,
+ * a moved branch HEAD must resolve to `check-head` → stale → re-fetch.
+ */
+
+import * as assert from 'node:assert/strict';
+import {
+  evaluateBranchFreshness,
+  isBranchHeadStale,
+  resolveBranchFreshness,
+  type BranchFreshnessEntry,
+} from '../../src/utils/branchFreshness';
+
+const TTL = 60_000; // 60s
+const NOW = 1_000_000;
+
+suite('evaluateBranchFreshness', () => {
+  test('tag refs always serve (never need a HEAD check)', () => {
+    // Even with an elapsed TTL and a recorded SHA, a tag short-circuits to serve.
+    const step = evaluateBranchFreshness(
+      { refType: 'tag', cachedAt: NOW - 10 * TTL, resolvedSha: 'abc' },
+      TTL,
+      NOW
+    );
+    assert.deepStrictEqual(step, { action: 'serve' });
+  });
+
+  test('branch within the TTL window serves without a HEAD check', () => {
+    const step = evaluateBranchFreshness(
+      { refType: 'branch', cachedAt: NOW - 30_000, resolvedSha: 'abc' },
+      TTL,
+      NOW
+    );
+    assert.deepStrictEqual(step, { action: 'serve' });
+  });
+
+  test('branch past the TTL with a recorded SHA needs a HEAD check', () => {
+    const step = evaluateBranchFreshness(
+      { refType: 'branch', cachedAt: NOW - 90_000, resolvedSha: 'abc' },
+      TTL,
+      NOW
+    );
+    assert.deepStrictEqual(step, { action: 'check-head' });
+  });
+
+  test('branch past the TTL with no recorded SHA serves (nothing to compare)', () => {
+    const step = evaluateBranchFreshness(
+      { refType: 'branch', cachedAt: NOW - 90_000, resolvedSha: undefined },
+      TTL,
+      NOW
+    );
+    assert.deepStrictEqual(step, { action: 'serve' });
+  });
+
+  test('branch with no timestamp but a recorded SHA needs a HEAD check', () => {
+    // No cachedAt → not within any window → fall through to the SHA comparison.
+    const step = evaluateBranchFreshness(
+      { refType: 'branch', cachedAt: undefined, resolvedSha: 'abc' },
+      TTL,
+      NOW
+    );
+    assert.deepStrictEqual(step, { action: 'check-head' });
+  });
+
+  test('a ref with no resolved refType is treated as a branch', () => {
+    const step = evaluateBranchFreshness(
+      { refType: undefined, cachedAt: NOW - 90_000, resolvedSha: 'abc' },
+      TTL,
+      NOW
+    );
+    assert.deepStrictEqual(step, { action: 'check-head' });
+  });
+});
+
+suite('isBranchHeadStale', () => {
+  test('stale when the branch HEAD has moved (regression: repeat hover of a moved @branch)', () => {
+    assert.strictEqual(isBranchHeadStale('abc123', 'def456'), true);
+  });
+
+  test('fresh when the branch HEAD is unchanged', () => {
+    assert.strictEqual(isBranchHeadStale('abc123', 'abc123'), false);
+  });
+
+  test('keeps cache when the live HEAD could not be resolved (offline / no access)', () => {
+    assert.strictEqual(isBranchHeadStale('abc123', undefined), false);
+  });
+
+  test('keeps cache when there is no recorded SHA', () => {
+    assert.strictEqual(isBranchHeadStale(undefined, 'def456'), false);
+  });
+});
+
+suite('resolveBranchFreshness (caller interaction)', () => {
+  const TTL = 60_000;
+
+  // A controllable clock + resolver stubs standing in for the GitLab service.
+  function makeDeps(opts: { start: number; headSha?: string }) {
+    let clock = opts.start;
+    let headCalls = 0;
+    return {
+      advance: (ms: number) => { clock += ms; },
+      headCalls: () => headCalls,
+      deps: {
+        now: () => clock,
+        resolveRefType: async (cached?: 'branch' | 'tag') => cached ?? 'branch',
+        resolveHeadSha: async () => { headCalls += 1; return opts.headSha; },
+      },
+    };
+  }
+
+  test('within-TTL serves do NOT advance cachedAt or hit the remote (window cannot slide)', async () => {
+    const entry: BranchFreshnessEntry = { refType: 'branch', cachedAt: 1000, resolvedSha: 'abc' };
+    const h = makeDeps({ start: 1000, headSha: 'abc' });
+
+    // Repeat hovers at 20s and 50s — both still inside the 60s window relative to the ORIGINAL cachedAt (1000).
+    for (const elapsed of [20_000, 50_000]) {
+      h.advance(1000 + elapsed - h.deps.now());
+      const r = await resolveBranchFreshness(entry, TTL, h.deps);
+      assert.strictEqual(r.stale, false);
+      assert.strictEqual(r.mutated, false);
+    }
+    // The serve path left cachedAt untouched, so the window is anchored to the original verification, not the hovers —
+    // no HEAD check fired, and once real time passes 60s the next hover WILL check (covered by the regression test).
+    assert.strictEqual(entry.cachedAt, 1000);
+    assert.strictEqual(h.headCalls(), 0);
+  });
+
+  test('regression: repeat hovers within TTL still refetch once the TTL lapses and the HEAD has moved', async () => {
+    // cachedAt fixed at 1000; HEAD has moved on the remote (recorded abc, live def).
+    const entry: BranchFreshnessEntry = { refType: 'branch', cachedAt: 1000, resolvedSha: 'abc' };
+    const h = makeDeps({ start: 1000, headSha: 'def' });
+
+    // Hover within the window first — served, no HEAD check, window not slid.
+    h.advance(30_000);
+    let r = await resolveBranchFreshness(entry, TTL, h.deps);
+    assert.strictEqual(r.stale, false);
+    assert.strictEqual(h.headCalls(), 0);
+
+    // Now past the TTL relative to the original cachedAt — HEAD check fires, sees the move, reports stale.
+    h.advance(40_000); // now 70_000, i.e. 69s since cachedAt
+    r = await resolveBranchFreshness(entry, TTL, h.deps);
+    assert.strictEqual(r.stale, true);
+    assert.strictEqual(h.headCalls(), 1);
+  });
+
+  test('verified-fresh HEAD check stamps cachedAt as the new "last verified" time', async () => {
+    const entry: BranchFreshnessEntry = { refType: 'branch', cachedAt: 1000, resolvedSha: 'abc' };
+    const h = makeDeps({ start: 90_000, headSha: 'abc' }); // past TTL, HEAD unchanged
+
+    const r = await resolveBranchFreshness(entry, TTL, h.deps);
+    assert.strictEqual(r.stale, false);
+    assert.strictEqual(r.mutated, true);
+    assert.strictEqual(entry.cachedAt, 90_000); // window restarts from the verification, not the serve
+    assert.strictEqual(h.headCalls(), 1);
+  });
+
+  test('resolving an unset refType marks the entry mutated (so it gets persisted)', async () => {
+    const entry: BranchFreshnessEntry = { refType: undefined, cachedAt: 90_000, resolvedSha: 'abc' };
+    const h = makeDeps({ start: 90_000, headSha: 'abc' });
+
+    const r = await resolveBranchFreshness(entry, TTL, h.deps);
+    assert.strictEqual(entry.refType, 'branch');
+    assert.strictEqual(r.mutated, true);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes branch-referenced components re-fetching from the repo on every hover instead of using the cache. The cache stored each component under the project's **default branch** rather than the **requested ref**, so a `@my-branch` lookup never matched its own cache entry and fell through to a re-fetch every time. Tags were largely unaffected because a tag tends to coincide with the cached value; arbitrary branch names essentially never do.
- Branch refs now cache like tags, with two freshness layers because a branch can **move**: a short branch TTL (60s) serves cache with zero network calls within the window, and once it elapses a cheap HEAD-SHA check re-fetches **only if the branch has actually moved**. Both cache-hit paths (exact-version match and any-version fallback) run this check, so a repeat hover of `@branch` revalidates rather than serving stale data.
- Link related issue(s): #152

## Change Type
- [ ] feat
- [x] fix
- [ ] refactor
- [ ] docs
- [ ] test
- [ ] chore

## Context
### User-facing impact
- Hovering a `component:@branch` reference no longer re-downloads from GitLab every time. Within the branch TTL (default 60s) it's served straight from cache; after that the branch HEAD is re-checked with a single lightweight request and the component is re-fetched only when the branch has moved. Tags are unchanged (served from cache without the extra freshness check, since a tag is taken as fixed by convention; they still expire under the normal cache TTL).
- A component that exists only on a non-default branch is now cached after the first fetch instead of re-fetching on every hover.

### GitLab scope
- [ ] gitlab.com
- [ ] self-managed GitLab
- [x] both (same caching logic on either)

### Affected areas
- [ ] Component Browser
- [x] Hover provider
- [ ] Completion provider
- [ ] Validation provider
- [x] Cache and refresh behavior
- [x] GitLab API calls/auth/token storage (one new lightweight branch-HEAD lookup; reuses existing token resolution)
- [ ] Docs only

## What changed by bucket

| Bucket | Files | Approach |
|---|---|---|
| Root-cause fix | [componentFetcher.ts](src/services/component/componentFetcher.ts) | `fetchCatalogData` no longer unconditionally overwrites the requested `ref` with `projectInfo.default_branch` — it falls back to the default branch **only when no ref was requested**. This is what made branch refs cache under the wrong key. |
| Ref classification | [versionManager.ts](src/services/component/versionManager.ts), [componentService.ts](src/services/component/componentService.ts), [componentDetector.ts](src/providers/componentDetector.ts) | `isRefATag(instance, path, ref)` asks GitLab directly via the dedicated single-tag endpoint (`GET /repository/tags/:ref`): 200 → tag, 404 → not a tag, error → unknown. The detector's `resolveIsBranch` prefers a persisted per-entry verdict, then this authoritative check; if the API can't answer it defaults to "branch" (the safe default — at worst one extra freshness check). No string-shape guessing — tag names are arbitrary, so there's nothing reliable to infer from the ref. The verdict is persisted on the cache entry (`isBranch`) so it's resolved once, not per hover. |
| Branch HEAD resolver | [versionManager.ts](src/services/component/versionManager.ts), [componentService.ts](src/services/component/componentService.ts) | `resolveBranchSha(instance, path, branch)` — one call to `/repository/branches/:branch`, returns the HEAD commit SHA or `null`. Exposed via the service facade the detector uses. |
| Cache shape | [cache.ts](src/types/cache.ts), [componentCacheManager.ts](src/services/cache/componentCacheManager.ts) | `CachedComponent` gains `resolvedSha?` (branch HEAD at fetch time), `cachedAt?` (epoch ms of last fetch/revalidation), and `refType?` (`'branch' \| 'tag'`, the persisted authoritative classification). On-disk cache version bumped `1.1.0 → 1.2.0`. `addDynamicComponent` and a new `persistComponentState()` now save these to disk so they survive across sessions. |
| Freshness decision | [branchFreshness.ts](src/utils/branchFreshness.ts) (new) | Two pure primitives (`evaluateBranchFreshness` → `serve`/`check-head`; `isBranchHeadStale`) plus `resolveBranchFreshness(entry, ttlMs, deps)`, an orchestrator that mutates `refType`/`cachedAt` in place with all I/O (clock, ref classifier, HEAD lookup) injected via `deps`. `cachedAt` tracks "last verified against the remote": it is stamped only after an actual HEAD comparison, never on a plain within-TTL serve — so repeated within-TTL hovers can't slide the window and starve the check. All of it is unit-testable without vscode/network. |
| Freshness wiring | [componentDetector.ts](src/providers/componentDetector.ts) | The two cache-hit paths (exact-version match and any-version fallback) are unified into one freshness-checked path, so **every** branch hit revalidates before serving. `checkBranchFreshness` is a thin adapter binding the real service + clock to `resolveBranchFreshness`; the serve path persists once iff the check mutated `refType`/`cachedAt`. |
| Constant | [timing.ts](src/constants/timing.ts) | `DEFAULT_BRANCH_CACHE_TIME_SECONDS` (60s) — the branch freshness TTL. Fixed, not user-configurable. |
| Tests | [branchFreshness.test.ts](tests/unit/branchFreshness.test.ts) (new) | Pure-decision coverage (TTL window, tag short-circuit, missing/elapsed timestamp, moved-HEAD) plus caller-interaction coverage of `resolveBranchFreshness` with an injected clock/resolvers: within-TTL serves don't advance `cachedAt` or hit the remote; **repeat within-TTL hovers still refetch once the TTL lapses and the HEAD has moved** (the window-sliding regression); verified-fresh stamps `cachedAt`. |

## Notable details

### The root cause: ref clobbered with the default branch
`fetchCatalogData` started with `let ref = version || 'main'` but then ran `if (projectInfo.default_branch) { ref = projectInfo.default_branch }` **unconditionally**, and stamped each component `latest_version: ref`. So a component requested as `@my-branch` was cached with `version = main`. The detector's cache hit requires `requestedVersion === cachedComponent.version`, which never held for branches, so it fell into the re-fetch path every hover. The fix guards the fallback with `if (!version && projectInfo.default_branch)`.

### Authoritative tag-vs-branch classification
Before this PR there was no tag-vs-branch distinction at all — every ref was compared by plain string equality (`requestedVersion === cachedComponent.version`), with no notion of mutability. This PR introduces the distinction and makes it authoritative rather than inferred: `resolveIsBranch` resolves it cheapest-first — a persisted per-entry verdict → GitLab's single-tag endpoint (`GET /repository/tags/:ref`, 200/404). There is no string-shape guessing: GitLab tag names are arbitrary (`latest`, `2024-06`, etc.), so nothing reliable can be inferred from the ref text. If the API can't answer (offline / no access), it defaults to "branch" — the safe default, since the worst case is one harmless extra freshness check rather than serving stale data. The verdict is stored on the cache entry (`isBranch`), so it's resolved once and re-used, not re-checked per hover.

### Two freshness layers for mutable branches
A branch can move, so caching it like a tag risks stale data. `resolveBranchFreshness` does:
1. **Tag?** (authoritative) → skip the freshness check (tags taken as fixed by convention), serve cache.
2. **Within the branch TTL (60s) of `cachedAt`?** → serve cache, no network call. **`cachedAt` is not touched** — it marks "last verified," not "last served."
3. **TTL elapsed** → resolve the live branch HEAD SHA and compare to the stored `resolvedSha`:
   - match → serve cache and stamp `cachedAt` to now (restart the window from this verification)
   - differ → re-fetch and re-stamp
   - no stored SHA, or HEAD can't be resolved (offline / no token / branch deleted) → serve cache (don't thrash); the entry still expires via the normal component cache TTL and the SHA is backfilled on the next genuine re-fetch.

Because the window anchors to the last *verification* (not the last serve), repeatedly hovering the same `@branch` faster than the TTL can't perpetually slide it — the HEAD check still fires once the TTL lapses. A burst of hovers costs nothing, the HEAD check fires at most once per TTL window, and a full re-download happens only when the branch actually changed.

Both cache-hit paths run this check: the detector first tries an exact-version match, then falls back to any cached entry for the component, but both feed the **same** freshness-checked serve/refetch block — so a repeat hover of `@branch` (which matches by version) revalidates rather than serving the cached entry blind. The decision itself is extracted into pure functions (`branchFreshness.ts`) so it's unit-tested directly, independent of the live API calls around it.

## Latent invariants made explicit
- Branch refs are now treated as moving throughout the cache path (subject to the freshness check); tag refs are taken as fixed by convention and skip it. Previously the cache made no distinction, which is what let stale-vs-refetch behaviour be accidental rather than designed.

## Validation
### Local checks
- [x] `npm run check-types` — clean (both `tsconfig.json` and `tsconfig.tests.json`).
- [x] `npm run lint` — 0 errors; only pre-existing `no-explicit-any` warnings, none in the new/modified files.
- [x] `npm test` — 190 passing (`branchFreshness.test.ts` covers the pure decision + the caller-interaction window-sliding regression).
- [x] `npm run test:extension-host` — 10/10 passing (activation, hover, local-include) in the real Extension Host.

### Manual test notes
- The freshness flow (config read + live branch-HEAD/tag calls) is exercised manually rather than by an automated test, consistent with how the rest of the detector's network paths are covered.
- Suggested manual check in the Extension Host: hover a `@branch` component twice in quick succession (served from cache, no fetch), wait past the 60s branch TTL, hover again (one HEAD check, no re-download if unchanged), push a commit to the branch, hover again (re-fetch). Repeat with a `@tag` to confirm it's always cache-served.

## Breaking Changes
- [x] No breaking changes
- [ ] Breaking changes (describe below)

The on-disk cache version bump (`1.1.0 → 1.2.0`) discards any cache persisted by a previous version on first load; it's transparently rebuilt by the normal refresh. No settings added or removed.

## Screenshots / Recordings (if UI behavior changed)
- N/A — no UI changes; behaviour is caching/latency only.

## Risk and Rollback
- **Main risks:**
  - The branch-HEAD lookup adds one lightweight request per branch ref at most once per branch TTL window (60s). On failure it degrades to serving cache, so it can't make hovers worse than before — only better.
  - Tag-vs-branch classification is authoritative (GitLab's single-tag endpoint), so any ref — including arbitrarily-named tags like `latest` or a branch named `1.2.3` — is classified correctly. When GitLab can't answer (offline / no access) the ref defaults to "branch"; the worst case is one harmless extra freshness check, never serving stale data.
  - `addDynamicComponent` now persists to `globalState`, where before dynamic entries were memory-only until the next full refresh. This means more frequent (debounce-free) writes when hovering uncached components. It's strictly more correct (freshness fields + dynamic entries survive sessions) and the payload is small, but it widens write frequency slightly beyond the branch path. Saves are fire-and-forget, so a failure only costs a re-fetch.
- **Rollback strategy:** Single PR, revert. The cache version bump means a revert again invalidates persisted cache once (rebuilt automatically). No data migration, no CI secrets, no new dependencies.

## Release Notes Draft
- fix: branch-referenced components are now cached instead of re-fetching from the repo on every hover. Because branches can move, cached branch data is revalidated against the branch HEAD after a short TTL (60s) and re-fetched only when the branch has moved. Tags are unaffected.

## Checklist
- [x] Branch is up to date with target branch
- [x] Commit messages follow conventional commits
- [x] Added/updated docs for behavior or settings changes (none — no settings changed)
- [x] Added/updated tests for new behavior (`branchFreshness` unit tests incl. moved-HEAD regression; live API paths verified manually)
- [x] No secrets or tokens in code, logs, screenshots, or test fixtures
