### PR TITLE
chore: eslint fix phase 6

### DIFF
--- a/src/providers/validationMetadata.ts
+++ b/src/providers/validationMetadata.ts
@@ -1,0 +1,115 @@
+/**
+ * Typed diagnostic metadata for the validation provider.
+ *
+ * `vscode.Diagnostic` doesn't carry a typed payload field, so the validation provider attaches a
+ * `metadata` object at runtime. This module declares:
+ *
+ * 1. A discriminated union {@link DiagnosticMetadata} that pairs each `diagnostic.code` value with
+ *    its known metadata shape — so producers and consumers agree on the contract.
+ * 2. A typed wrapper alias {@link DiagnosticWithMetadata} for diagnostics that carry metadata.
+ * 3. A setter ({@link attachDiagnosticMetadata}) and a getter ({@link readDiagnosticMetadata}) so
+ *    the write and read sites use a single, statically-checked API instead of
+ *    `(diagnostic as any).metadata = …`.
+ *
+ * The getter returns a `DiagnosticMetadata` whose `code` literal matches the diagnostic, so callers
+ * can narrow via `if (m?.code === 'unknown-input')` and access variant-specific fields directly.
+ */
+
+import type * as vscode from 'vscode';
+import type { ComponentParameter, ParameterDefault } from '../types/git-component';
+
+/** Shared fields for diagnostics that point at a component reference. */
+interface ComponentRefBase {
+  /** Original component URL as it appears in the document (may contain `${…}` variables). */
+  componentUrl: string;
+  /** URL after GitLab variable expansion (when expansion was attempted). */
+  expandedUrl?: string;
+  /** `inputs:` object provided alongside the include in the source YAML. */
+  includeInputs: Record<string, unknown>;
+}
+
+/** Metadata attached to `code: 'unresolved-variables'` diagnostics. */
+export interface UnresolvedVariablesMetadata extends ComponentRefBase {
+  code: 'unresolved-variables';
+  /** True when the active workspace is not a GitLab repo and variable expansion can't proceed. */
+  isNonGitlabRepo?: boolean;
+}
+
+/** Metadata attached to `code: 'component-fetch-failed'` diagnostics. */
+export interface ComponentFetchFailedMetadata extends ComponentRefBase {
+  code: 'component-fetch-failed';
+}
+
+/** Metadata attached to `code: 'unknown-input'` diagnostics (input name not in the component's spec). */
+export interface UnknownInputMetadata {
+  code: 'unknown-input';
+  componentName: string;
+  componentUrl: string;
+  /** The provided input that isn't recognised. */
+  unknownInput: string;
+  /** Names of every valid input the component declares — used for QuickPick suggestions. */
+  availableInputs: string[];
+  /** Full input declarations from the component spec — used for description/type/default rendering. */
+  componentInputs: ComponentParameter[];
+  /** Marks this as a single-input diagnostic so the code action only replaces this one input. */
+  currentInputOnly: boolean;
+}
+
+/** Metadata attached to `code: 'missing-required-input'` diagnostics. */
+export interface MissingRequiredInputMetadata {
+  code: 'missing-required-input';
+  componentName: string;
+  componentUrl: string;
+  /** Name of the required input that the document is missing. */
+  missingInput: string;
+  /** Description from the component spec, surfaced in QuickFix labels. */
+  inputDescription: string;
+  /** Declared input type (`string`, `boolean`, etc.). */
+  inputType: string;
+  /** Default value declared by the component, if any. */
+  inputDefault?: ParameterDefault;
+  /** Names of inputs the document already provides — context for the "add missing inputs" action. */
+  providedInputs: string[];
+}
+
+/** All diagnostic metadata variants the validation provider attaches. */
+export type DiagnosticMetadata =
+  | UnresolvedVariablesMetadata
+  | ComponentFetchFailedMetadata
+  | UnknownInputMetadata
+  | MissingRequiredInputMetadata;
+
+/**
+ * `vscode.Diagnostic` extended with the (optional) typed metadata payload. Used at write sites so
+ * the producer commits to one of the {@link DiagnosticMetadata} variants.
+ */
+export type DiagnosticWithMetadata = vscode.Diagnostic & { metadata?: DiagnosticMetadata };
+
+/**
+ * Attach typed metadata to a diagnostic. Use this instead of mutating the diagnostic directly so
+ * the shape stays committed to the discriminated union.
+ *
+ * @param diagnostic  The diagnostic being constructed.
+ * @param metadata    The variant matching `diagnostic.code`. Pass the literal — TS verifies the
+ *                    field set is complete for the chosen `code`.
+ */
+export function attachDiagnosticMetadata(
+  diagnostic: vscode.Diagnostic,
+  metadata: DiagnosticMetadata,
+): void {
+  (diagnostic as DiagnosticWithMetadata).metadata = metadata;
+}
+
+/**
+ * Read previously-attached metadata off a diagnostic.
+ *
+ * @param diagnostic  Any diagnostic — typically one from `CodeActionContext.diagnostics`.
+ * @returns           The attached metadata or `undefined` if none was set (or it doesn't carry a
+ *                    `code` field — defensive check against foreign diagnostics in the collection).
+ */
+export function readDiagnosticMetadata(
+  diagnostic: vscode.Diagnostic,
+): DiagnosticMetadata | undefined {
+  const metadata = (diagnostic as DiagnosticWithMetadata).metadata;
+  return metadata && typeof metadata === 'object' && 'code' in metadata ? metadata : undefined;
+}

--- a/src/providers/validationProvider.ts
+++ b/src/providers/validationProvider.ts
@@ -8,6 +8,28 @@ import { expandComponentUrl, containsGitLabVariables } from '../utils/gitlabVari
 import { isGitLabCIFile } from '../utils/gitlabCiFileMatcher';
 import { spawn } from 'child_process';
 import { resolveLocalComponent, isUnsupportedLocalPath } from './localComponentResolver';
+import { attachDiagnosticMetadata, readDiagnosticMetadata } from './validationMetadata';
+import type { MissingRequiredInputMetadata } from './validationMetadata';
+import type { GitApi, GitRepository } from '../types/vscode-git';
+
+/**
+ * A `.gitlab-ci.yml` include entry that this provider validates. Either a remote `component:` URL
+ * or a `local:` path; both branches carry an optional `inputs` mapping. Built by narrowing a parsed
+ * YAML node — fields outside the union (anything else under the include) are intentionally not modelled.
+ */
+type ComponentInclude = { component: string; local?: undefined; inputs?: Record<string, unknown> };
+type LocalInclude = { local: string; component?: undefined; inputs?: Record<string, unknown> };
+type IncludeEntry = ComponentInclude | LocalInclude;
+
+/** Narrow a parsed YAML value to an {@link IncludeEntry} (string-typed `component` or `local`). */
+function isIncludeEntry(value: unknown): value is IncludeEntry {
+    if (!isYamlNode(value)) {
+        return false;
+    }
+    const hasComponent = typeof value.component === 'string';
+    const hasLocal = typeof value.local === 'string';
+    return hasComponent !== hasLocal; // exactly one of the two
+}
 
 export class ValidationProvider implements vscode.CodeActionProvider {
     private diagnosticCollection: vscode.DiagnosticCollection;
@@ -109,7 +131,8 @@ export class ValidationProvider implements vscode.CodeActionProvider {
             return;
         }
 
-        const includes = Array.isArray(parsedYaml.include) ? parsedYaml.include : [parsedYaml.include];
+        const rawIncludes: unknown[] = Array.isArray(parsedYaml.include) ? parsedYaml.include : [parsedYaml.include];
+        const includes: IncludeEntry[] = rawIncludes.filter(isIncludeEntry);
         this.logger.debug(`[ValidationProvider] Found ${includes.length} include entries`, 'ValidationProvider');
 
         for (let includeIndex = 0; includeIndex < includes.length; includeIndex++) {
@@ -162,12 +185,13 @@ export class ValidationProvider implements vscode.CodeActionProvider {
 
                             diagnostic.code = 'unresolved-variables';
                             diagnostic.source = 'gitlab-component-helper';
-                            (diagnostic as any).metadata = {
+                            attachDiagnosticMetadata(diagnostic, {
+                                code: 'unresolved-variables',
                                 componentUrl: componentUrl,
                                 expandedUrl: expandedUrl,
                                 includeInputs: include.inputs || {},
                                 isNonGitlabRepo: true
-                            };
+                            });
 
                             this.logger.debug(`[ValidationProvider] Created unresolved variables diagnostic for non-GitLab repo: ${componentUrl}`, 'ValidationProvider');
                             diagnostics.push(diagnostic);
@@ -195,11 +219,12 @@ export class ValidationProvider implements vscode.CodeActionProvider {
 
                         diagnostic.code = 'unresolved-variables';
                         diagnostic.source = 'gitlab-component-helper';
-                        (diagnostic as any).metadata = {
+                        attachDiagnosticMetadata(diagnostic, {
+                            code: 'unresolved-variables',
                             componentUrl: componentUrl,
                             expandedUrl: expandedUrl,
                             includeInputs: include.inputs || {}
-                        };
+                        });
 
                         this.logger.debug(`[ValidationProvider] Created unresolved variables diagnostic for ${componentUrl}`, 'ValidationProvider');
                         diagnostics.push(diagnostic);
@@ -272,11 +297,12 @@ export class ValidationProvider implements vscode.CodeActionProvider {
 
                     diagnostic.code = 'component-fetch-failed';
                     diagnostic.source = 'gitlab-component-helper';
-                    (diagnostic as any).metadata = {
+                    attachDiagnosticMetadata(diagnostic, {
+                        code: 'component-fetch-failed',
                         componentUrl: componentUrl,
                         expandedUrl: expandedUrl,
                         includeInputs: include.inputs || {}
-                    };
+                    });
 
                     this.logger.debug(`[ValidationProvider] Created component fetch failure diagnostic for ${componentUrl}`, 'ValidationProvider');
                     diagnostics.push(diagnostic);
@@ -317,7 +343,7 @@ export class ValidationProvider implements vscode.CodeActionProvider {
                     }
 
                     for (const providedInput in providedInputs) {
-                        if (!componentInputs.some((p: any) => p.name === providedInput)) {
+                        if (!componentInputs.some(p => p.name === providedInput)) {
                             const line = this.findLineForInput(document, include, providedInput);
 
                             // Create a unique key to prevent duplicate diagnostics for the same input
@@ -354,15 +380,16 @@ export class ValidationProvider implements vscode.CodeActionProvider {
                             // Add metadata for code actions - specific to this input only
                             diagnostic.code = 'unknown-input';
                             diagnostic.source = 'gitlab-component-helper';
-                            (diagnostic as any).metadata = {
+                            attachDiagnosticMetadata(diagnostic, {
+                                code: 'unknown-input',
                                 componentName: component.name,
                                 componentUrl: componentUrl,
                                 unknownInput: providedInput,
-                                availableInputs: componentInputs.map((p: any) => p.name),
+                                availableInputs: componentInputs.map(p => p.name),
                                 componentInputs: componentInputs, // Include full input details for descriptions
                                 // Only include the current unknown input, not all provided inputs
                                 currentInputOnly: true
-                            };
+                            });
 
                             this.logger.debug(`[ValidationProvider] Created diagnostic for unknown input '${providedInput}' at range ${range.start.line}:${range.start.character}-${range.end.line}:${range.end.character}`, 'ValidationProvider');
                             diagnostics.push(diagnostic);
@@ -382,7 +409,8 @@ export class ValidationProvider implements vscode.CodeActionProvider {
                             // Add metadata for code actions
                             diagnostic.code = 'missing-required-input';
                             diagnostic.source = 'gitlab-component-helper';
-                            (diagnostic as any).metadata = {
+                            attachDiagnosticMetadata(diagnostic, {
+                                code: 'missing-required-input',
                                 componentName: component.name,
                                 componentUrl: componentUrl,
                                 missingInput: componentInput.name,
@@ -390,7 +418,7 @@ export class ValidationProvider implements vscode.CodeActionProvider {
                                 inputType: componentInput.type,
                                 inputDefault: componentInput.default,
                                 providedInputs: Object.keys(providedInputs)
-                            };
+                            });
 
                             diagnostics.push(diagnostic);
                         }
@@ -543,10 +571,11 @@ export class ValidationProvider implements vscode.CodeActionProvider {
 
             this.logger.debug(`[ValidationProvider] Processing diagnostic: code=${diagnostic.code}, range=${diagnostic.range.start.line}:${diagnostic.range.start.character}, message="${diagnostic.message}"`, 'ValidationProvider');
 
-            if (diagnostic.code === 'unknown-input' && (diagnostic as any).metadata) {
-                const metadata = (diagnostic as any).metadata;
-                const availableInputs = metadata.availableInputs as string[];
-                const unknownInput = metadata.unknownInput as string;
+            const diagnosticMetadata = readDiagnosticMetadata(diagnostic);
+            if (diagnosticMetadata?.code === 'unknown-input') {
+                const metadata = diagnosticMetadata;
+                const availableInputs = metadata.availableInputs;
+                const unknownInput = metadata.unknownInput;
 
                 // For individual input diagnostics, only suggest replacements for that specific input
                 // Don't exclude other provided inputs since this diagnostic is specific to one input
@@ -611,9 +640,9 @@ export class ValidationProvider implements vscode.CodeActionProvider {
                     }
                 }
             }
-            else if (diagnostic.code === 'unresolved-variables' && (diagnostic as any).metadata) {
-                const metadata = (diagnostic as any).metadata;
-                const isNonGitlabRepo = metadata.isNonGitlabRepo as boolean;
+            else if (diagnosticMetadata?.code === 'unresolved-variables') {
+                const metadata = diagnosticMetadata;
+                const isNonGitlabRepo = metadata.isNonGitlabRepo ?? false;
 
                 // Different suggestions based on repository type
                 if (isNonGitlabRepo) {
@@ -661,9 +690,9 @@ export class ValidationProvider implements vscode.CodeActionProvider {
                     }
                 }
             }
-            else if (diagnostic.code === 'component-fetch-failed' && (diagnostic as any).metadata) {
-                const metadata = (diagnostic as any).metadata;
-                const componentUrl = metadata.componentUrl as string;
+            else if (diagnosticMetadata?.code === 'component-fetch-failed') {
+                const metadata = diagnosticMetadata;
+                const componentUrl = metadata.componentUrl;
 
                 // Suggest actions for component fetch failures
                 const retryTitle = `Retry fetching component from '${componentUrl}'`;
@@ -693,11 +722,11 @@ export class ValidationProvider implements vscode.CodeActionProvider {
                     actions.push(validateUrlAction);
                 }
             }
-            else if (diagnostic.code === 'missing-required-input' && (diagnostic as any).metadata) {
-                const metadata = (diagnostic as any).metadata;
-                const missingInput = metadata.missingInput as string;
-                const inputDescription = metadata.inputDescription as string;
-                const inputType = metadata.inputType as string;
+            else if (diagnosticMetadata?.code === 'missing-required-input') {
+                const metadata = diagnosticMetadata;
+                const missingInput = metadata.missingInput;
+                const inputDescription = metadata.inputDescription;
+                const inputType = metadata.inputType;
                 const inputDefault = metadata.inputDefault;
 
                 const actionTitle = `Add required input '${missingInput}'`;
@@ -754,10 +783,12 @@ export class ValidationProvider implements vscode.CodeActionProvider {
 
                     // Add action to show all missing inputs for this component if there are multiple
                     const componentUrl = metadata.componentUrl;
-                    const allMissingForComponent = relevantDiagnostics.filter(d =>
-                        d.code === 'missing-required-input' &&
-                        (d as any).metadata?.componentUrl === componentUrl
-                    );
+                    const allMissingForComponent = relevantDiagnostics
+                        .map(d => ({ diagnostic: d, metadata: readDiagnosticMetadata(d) }))
+                        .filter((pair): pair is { diagnostic: vscode.Diagnostic; metadata: MissingRequiredInputMetadata } =>
+                            pair.metadata?.code === 'missing-required-input' &&
+                            pair.metadata.componentUrl === componentUrl
+                        );
 
                     if (allMissingForComponent.length > 1) {
                         const showAllMissingTitle = `Add all ${allMissingForComponent.length} missing inputs for '${metadata.componentName}'`;
@@ -773,13 +804,13 @@ export class ValidationProvider implements vscode.CodeActionProvider {
                                     type: 'add',
                                     documentUri: document.uri.toString(),
                                     range: diagnostic.range,
-                                    availableInputs: allMissingForComponent.map(d => (d as any).metadata.missingInput),
+                                    availableInputs: allMissingForComponent.map(p => p.metadata.missingInput),
                                     componentName: metadata.componentName,
-                                    missingInputs: allMissingForComponent.map(d => ({
-                                        name: (d as any).metadata.missingInput,
-                                        description: (d as any).metadata.inputDescription || '',
-                                        type: (d as any).metadata.inputType || 'string',
-                                        default: (d as any).metadata.inputDefault,
+                                    missingInputs: allMissingForComponent.map(p => ({
+                                        name: p.metadata.missingInput,
+                                        description: p.metadata.inputDescription || '',
+                                        type: p.metadata.inputType || 'string',
+                                        default: p.metadata.inputDefault,
                                         required: true
                                     }))
                                 }]
@@ -795,7 +826,7 @@ export class ValidationProvider implements vscode.CodeActionProvider {
         return actions;
     }
 
-    private findLineForInput(document: vscode.TextDocument, include: any, inputName: string): number {
+    private findLineForInput(document: vscode.TextDocument, include: IncludeEntry, inputName: string): number {
         const text = document.getText();
         const lines = text.split('\n');
         const componentLine = this.findLineForComponent(document, include);
@@ -933,7 +964,7 @@ export class ValidationProvider implements vscode.CodeActionProvider {
         }
     }
 
-    private findLineForComponent(document: vscode.TextDocument, include: any): number {
+    private findLineForComponent(document: vscode.TextDocument, include: IncludeEntry): number {
         const text = document.getText();
         const lines = text.split('\n');
         const componentUrl = include.component ?? include.local;
@@ -1137,15 +1168,11 @@ export class ValidationProvider implements vscode.CodeActionProvider {
         range: vscode.Range;
         unknownInput?: string;
         availableInputs: string[];
-        componentInputs?: Array<{ name: string; description?: string; type?: string; required?: boolean; default?: any }>; // Add full input details
+        /** Full component-spec parameters, used to render descriptions/types alongside replacement suggestions. */
+        componentInputs?: ComponentParameter[];
         componentName: string;
-        missingInputs?: Array<{
-            name: string;
-            description: string;
-            type: string;
-            default?: any;
-            required: boolean;
-        }>;
+        /** Required parameters the document is missing — same shape as componentInputs, populated from diagnostic metadata. */
+        missingInputs?: ComponentParameter[];
     }): Promise<void> {
         this.logger.debug(`[ValidationProvider] Showing QuickPick for ${args.type} with ${args.availableInputs.length} options`, 'ValidationProvider');
 
@@ -1414,15 +1441,15 @@ export class ValidationProvider implements vscode.CodeActionProvider {
             // Use VS Code's Git extension API if available
             const gitExtension = vscode.extensions.getExtension('vscode.git');
             if (gitExtension) {
-                const git = gitExtension.exports.getAPI(1);
+                const git: GitApi | undefined = gitExtension.exports.getAPI(1);
                 if (git) {
-                    let repo: any = null;
+                    let repo: GitRepository | null = null;
                     if (forUri) {
                         // File-relative lookup; null if file isn't in any repo.
                         // Do NOT fall through to workspace[0] here.
                         repo = git.getRepository(forUri);
                     } else if (git.repositories.length > 0) {
-                        repo = git.repositories.find((r: any) =>
+                        repo = git.repositories.find(r =>
                             workspacePath.startsWith(r.rootUri.fsPath)
                         ) || git.repositories[0];
                     }
@@ -1430,7 +1457,7 @@ export class ValidationProvider implements vscode.CodeActionProvider {
                     if (repo) {
                         // Get remote URLs
                         const remotes = repo.state.remotes;
-                        const origin = remotes.find((r: any) => r.name === 'origin') || remotes[0];
+                        const origin = remotes.find(r => r.name === 'origin') || remotes[0];
 
                         if (origin && origin.fetchUrl) {
                             const gitlabInfo = this.parseGitLabRemoteUrl(origin.fetchUrl);
@@ -1538,11 +1565,11 @@ export class ValidationProvider implements vscode.CodeActionProvider {
             // First try VS Code's Git extension API
             const gitExtension = vscode.extensions.getExtension('vscode.git');
             if (gitExtension) {
-                const git = gitExtension.exports.getAPI(1);
+                const git: GitApi | undefined = gitExtension.exports.getAPI(1);
                 if (git && git.repositories.length > 0) {
                     this.logger.debug(`[ValidationProvider] Found ${git.repositories.length} Git repositories via VS Code Git API`, 'ValidationProvider');
 
-                    const repo = git.repositories.find((r: any) =>
+                    const repo = git.repositories.find(r =>
                         workspacePath.startsWith(r.rootUri.fsPath) ||
                         r.rootUri.fsPath.startsWith(workspacePath)
                     ) || git.repositories[0];
@@ -1552,7 +1579,7 @@ export class ValidationProvider implements vscode.CodeActionProvider {
 
                         // Get remote URLs from VS Code Git API
                         const remotes = repo.state.remotes;
-                        const origin = remotes.find((r: any) => r.name === 'origin') || remotes[0];
+                        const origin = remotes.find(r => r.name === 'origin') || remotes[0];
 
                         if (origin && origin.fetchUrl) {
                             this.logger.debug(`[ValidationProvider] Found origin remote via VS Code Git API: ${origin.fetchUrl}`, 'ValidationProvider');


### PR DESCRIPTION
## Summary
- Phase 6 of the ESLint `@typescript-eslint/no-explicit-any` cleanup. This PR tackles [validationProvider.ts](src/providers/validationProvider.ts): introduces a discriminated union for diagnostic metadata keyed on `diagnostic.code`, types the YAML include shape, reuses the `vscode-git.ts` types from Phase 5 for the Git API filter callbacks, and consolidates two inline parameter shapes onto the canonical `ComponentParameter`.
- 30 warnings removed (**71 → 41**). All edits are type tightening — no behaviour changes.
- Link related issue(s): n/a

## Change Type
- [ ] feat
- [ ] fix
- [ ] refactor
- [ ] docs
- [ ] test
- [x] chore

## Context
### User-facing impact
- None expected. All edits are type tightening at warning sites; the diagnostic write/read contract is now statically enforced where it was previously held together by `(diagnostic as any).metadata.field` reads.

### GitLab scope
- [ ] gitlab.com
- [ ] self-managed GitLab
- [x] both (no behavioural change to either)

### Affected areas
- [ ] Component Browser
- [ ] Hover provider
- [ ] Completion provider
- [x] Validation provider (typing only — no logic change)
- [ ] Cache and refresh behavior
- [ ] GitLab API calls/auth/token storage
- [ ] Docs only

## What changed by bucket

| Bucket | Files | Warnings cleared | Approach |
|---|---|---|---|
| Diagnostic metadata contract | [validationMetadata.ts](src/providers/validationMetadata.ts) (new), [validationProvider.ts](src/providers/validationProvider.ts) | ~17 | New discriminated union `DiagnosticMetadata` over four variants keyed on `diagnostic.code`: `'unresolved-variables'`, `'component-fetch-failed'`, `'unknown-input'`, `'missing-required-input'` (the fifth code, `'local-include-not-found'`, carries no metadata). `attachDiagnosticMetadata(diagnostic, m)` setter and `readDiagnosticMetadata(diagnostic)` getter wrap a single `DiagnosticWithMetadata = vscode.Diagnostic & { metadata?: DiagnosticMetadata }` alias. 5 write sites and 4 read branches in the validation provider use them; one filter-map narrows `relevantDiagnostics` via a type-guard for the "all missing inputs" code action. |
| Include entry typing | [validationProvider.ts](src/providers/validationProvider.ts) | ~7 | Local discriminated union `IncludeEntry = ComponentInclude \| LocalInclude` + `isIncludeEntry` type-guard at module top. Replaces `include: any` on the loop iterator and two helper methods (`findLineForInput`, `findLineForComponent`). The `Array.isArray(parsedYaml.include)` widening to `any[]` is now filtered through the guard into `IncludeEntry[]`. `include.inputs` is properly typed as `Record<string, unknown>` so metadata writes drop the `as Record<string, unknown>` casts that appeared in initial drafts. |
| VS Code Git API typing | [validationProvider.ts](src/providers/validationProvider.ts) | 5 | Reuses `GitApi` / `GitRepository` from [types/vscode-git.ts](src/types/vscode-git.ts) (introduced in Phase 5). Both Git extension API call sites (one in `getGitInfoFromUri`, one in `getGitInfoForWorkspace`) type the `git`/`repo` locals and drop the `(r: any) =>` filter-callback annotations — TS infers from the new types. |
| QuickPick args parameter shapes | [validationProvider.ts](src/providers/validationProvider.ts) | 2 | The inline `componentInputs?: Array<{ name; description?; type?; required?; default?: any }>` and `missingInputs?: Array<{ name; description; type; default?: any; required }>` shapes on `showInputSuggestionsQuickPick`'s `args` are both replaced with `ComponentParameter[]`. Both site-shapes were structurally identical to the canonical model — they were inline rewrites that pre-dated `ParameterDefault`. |

Total: **30 warnings removed**.

## Notable design points

### Discriminated union over inline `(diagnostic as any).metadata.foo` reads
Each `DiagnosticMetadata` variant has a literal `code` field that matches the diagnostic it's attached to. Read sites narrow via control flow:
```ts
const metadata = readDiagnosticMetadata(diagnostic);
if (metadata?.code === 'unknown-input') {
    // metadata is UnknownInputMetadata here — availableInputs, unknownInput, etc. typed
}
```
This catches shape drift the old `(d as any).metadata.missingInputName` reads would have silently produced — a typo or a producer-side field rename now fails at compile time at the read site, not at runtime as `undefined`.

### `IncludeEntry` discriminated union
The two branches are `ComponentInclude` (has `component: string`) and `LocalInclude` (has `local: string`). Each has an optional `inputs?: Record<string, unknown>`. The `isIncludeEntry` guard requires **exactly one** of `component` / `local` (`hasComponent !== hasLocal`), so a malformed include with both keys is filtered out at the boundary rather than reaching the validation loop in an ambiguous state. The downstream `if (include.local)` / `if (include.component)` checks then narrow the union via TS's standard control-flow analysis.

### No `as` casts in caller code
Every narrowing uses a type-guard. The one `as DiagnosticWithMetadata` survives inside `attachDiagnosticMetadata` itself — a controlled mutation point where the wrapper enforces the union shape before assigning. This matches the pattern from Phase 2's `extractStatusCode` and Phase 4's `isYamlNode`.

### Reuse of Phase 5's `vscode-git.ts`
The Git API types added in [#160] for `componentDetector.ts` are imported directly here — both providers have identical filter-callback patterns over `git.repositories` and `repo.state.remotes`. No new types were needed; this PR is the first reuse of that shared file.

## Validation
### Local checks
- [x] `npm run check-types` — clean (both `tsconfig.json` and `tsconfig.tests.json`).
- [x] `npm run lint` — **71 → 41 `no-explicit-any` warnings**, zero new warnings of any rule.
- [x] `npm test` — 176/176 unit assertions passing.
- [x] Manual verification in VS Code Extension Host — `env -u ELECTRON_RUN_AS_NODE npm run test:extension-host` 10/10 passing.

### Manual test notes
- The local-include diagnostic tests in the extension host exercise the `IncludeEntry` narrowing for both branches (`unknown input` / `missing required input`) and the `readDiagnosticMetadata` round-trip through the code action provider.
- The hover-on-non-GitLab-file test exercises the `getGitInfoFromUri` Git API path with the new typed callbacks.
- Spot-checked the "Replace input" QuickPick path manually with a sample `.gitlab-ci.yml` containing a typoed input — the suggestion list still rendered with description/type/default metadata sourced from `ComponentParameter.description` and `ComponentParameter.default` (the now-canonical fields, identical to the inline shape they replaced).

## Breaking Changes
- [x] No breaking changes
- [ ] Breaking changes (describe below)

The diagnostic metadata shape is a property mutated on `vscode.Diagnostic` instances at runtime — it's not part of any persisted format or public API. The new wrappers preserve byte-identical runtime structure; only the static type contract is tightened.

## Screenshots / Recordings (if UI behavior changed)
- N/A — no UI changes.

## Risk and Rollback
- **Main risks:**
  - The `isIncludeEntry` guard filters out malformed includes (both `component:` and `local:` set, or neither). The old code would have proceeded into the loop with `include.local && !include.component` → false on the `local` branch, then `include.component` → potentially true on the next branch. The new guard rejects the malformed entry up front. Practically: GitLab CI YAML doesn't allow this shape, but a hand-typed in-progress file might briefly produce it. Net safer; the user sees no diagnostic rather than a half-valid one.
  - The four typed metadata variants are structurally what every existing write site already produced — verified against the five `attachDiagnosticMetadata` call sites in the same change. No silent data drop.
- **Rollback strategy:** Single PR, revert. No settings changes, no data migration, no CI secrets touched, no new dependencies.

## Release Notes Draft
- chore: validation provider's diagnostic metadata, include-entry, and Git API access now flow through typed contracts (discriminated unions, type-guards) instead of `as any` casts. 30 of the remaining 71 `no-explicit-any` warnings cleared.

## Checklist
- [x] Branch is up to date with target branch
- [x] Commit messages follow conventional commits
- [x] Added/updated docs for behavior or settings changes (none required)
- [x] Added/updated tests for new behavior (none required — pure typing)
- [x] No secrets or tokens in code, logs, screenshots, or test fixtures
