### PR TITLE
fix: input completions break after a multi-line array input

### DIFF
--- a/src/providers/completionInputContext.ts
+++ b/src/providers/completionInputContext.ts
@@ -1,0 +1,196 @@
+/**
+ * Pure helpers for the completion side of the component-input flow. Given the document text and a cursor line,
+ * work out whether the cursor sits in an empty/partial parameter-name slot inside an `include:` entry's `inputs:`
+ * block, and surface which include owns it plus the inputs already present (so the caller can offer only the
+ * missing ones).
+ */
+
+import { parseYaml, isYamlNode } from '../utils/yamlParser';
+import type { ComponentParameter } from '../types/git-component';
+
+/**
+ * The completion slot a YAML cursor position resolves to.
+ */
+export interface CompletionInputContext {
+  /** URL or local path of the include that owns the surrounding `inputs:` block. */
+  componentUrl: string;
+  /** Which include flavour matched: `component` for remote URLs, `local` for in-repo includes. */
+  includeKind: 'component' | 'local';
+  /** Names of inputs already written under this include, so the caller can filter them out of the suggestions. */
+  existingInputNames: string[];
+}
+
+interface ClosestInclude {
+  componentUrl: string;
+  includeKind: 'component' | 'local';
+  componentLineIndex: number;
+  /** Names of keys directly under this include's `inputs:` mapping. */
+  existingInputNames: string[];
+}
+
+function indentOf(line: string): number {
+  return line.length - line.trimStart().length;
+}
+
+/**
+ * Detect whether the `lineIndex` line in `text` is a parameter-name slot for an `include:` entry's inputs.
+ *
+ * @param text - The full YAML document text.
+ * @param lineIndex - 0-based line index where the cursor sits.
+ * @returns A populated {@link CompletionInputContext} when the cursor is in a parameter-name slot inside the
+ *   `inputs:` block of the closest preceding `component:`/`local:` include; `null` otherwise.
+ */
+export function findCompletionInputContextAtLine(text: string, lineIndex: number): CompletionInputContext | null {
+  const parsed = parseYaml(text);
+  if (!isYamlNode(parsed) || !parsed.include) return null;
+
+  const includes = Array.isArray(parsed.include) ? parsed.include : [parsed.include];
+  const lines = text.split('\n');
+  if (lines[lineIndex] === undefined) return null;
+
+  const closest = findClosestInclude(includes, lines, lineIndex);
+  if (!closest) return null;
+
+  const section = findInputsSection(lines, closest.componentLineIndex, lineIndex);
+  if (!section) return null;
+
+  // Containment in the inputs block is already established above; here we only check the line looks like a
+  // parameter-name slot: indented deeper than the `inputs:` key (i.e. a child of it, not a sibling) and not
+  // already a complete `key: value`.
+  const currentLine = lines[lineIndex];
+  const currentLineText = currentLine.trim();
+  const isParameterContext =
+    indentOf(currentLine) > section.inputsIndent && (!currentLineText.includes(':') || currentLineText.endsWith(':'));
+  if (!isParameterContext) return null;
+
+  return {
+    componentUrl: closest.componentUrl,
+    includeKind: closest.includeKind,
+    existingInputNames: closest.existingInputNames,
+  };
+}
+
+/**
+ * Find the include entry whose source line is the closest one above `lineIndex`, matching the parsed includes
+ * back to their position in the text.
+ */
+function findClosestInclude(includes: unknown[], lines: string[], lineIndex: number): ClosestInclude | null {
+  let closest: ClosestInclude | null = null;
+  let closestDistance = Infinity;
+
+  for (const include of includes) {
+    if (!isYamlNode(include)) continue;
+
+    const isLocal = typeof include.local === 'string' && typeof include.component !== 'string';
+    const componentUrl =
+      typeof include.component === 'string'
+        ? include.component
+        : typeof include.local === 'string'
+          ? include.local
+          : undefined;
+    if (componentUrl === undefined) continue;
+
+    const includeKey = isLocal ? 'local:' : 'component:';
+
+    let componentLineIndex = -1;
+    for (let i = 0; i < lines.length; i++) {
+      if (lines[i].includes(includeKey) && lines[i].includes(componentUrl)) {
+        componentLineIndex = i;
+        break;
+      }
+    }
+    if (componentLineIndex === -1 || componentLineIndex >= lineIndex) continue;
+
+    const distance = lineIndex - componentLineIndex;
+    if (distance < closestDistance) {
+      closestDistance = distance;
+      closest = {
+        componentUrl,
+        includeKind: isLocal ? 'local' : 'component',
+        componentLineIndex,
+        existingInputNames: isYamlNode(include.inputs) ? Object.keys(include.inputs) : [],
+      };
+    }
+  }
+
+  return closest;
+}
+
+/**
+ * Locate the `inputs:` block of the include declared at `componentLineIndex` and report whether `lineIndex` sits
+ * inside it.
+ *
+ * The include entry's own indentation anchors the section boundary: a list item (`- `) or mapping key at that
+ * indent or shallower starts the next include/job, whereas anything more deeply indented (e.g. an array value
+ * under an input) still belongs to this component's inputs. The `inputs:` key itself is recognised before the
+ * boundary test, so the mapping form (where `inputs:` sits at the same indent as the include's `component:` key)
+ * isn't mistaken for the section end.
+ *
+ * @returns the `inputs:` line's indentation when `lineIndex` is inside the block, so the caller can decide what
+ *   counts as a parameter-name slot relative to it; `null` when the cursor isn't inside an inputs block.
+ */
+function findInputsSection(lines: string[], componentLineIndex: number, lineIndex: number): { inputsIndent: number } | null {
+  const componentIndent = indentOf(lines[componentLineIndex]);
+
+  let inputsSectionStart = -1;
+  let inputsIndent = -1;
+  let inputsSectionEnd = -1;
+
+  for (let i = componentLineIndex + 1; i < lines.length; i++) {
+    const trimmedLine = lines[i].trim();
+    if (trimmedLine === '') continue;
+
+    // Recognise the `inputs:` header first: in the mapping form it sits at the same indent as the include's
+    // `component:`/`local:` key, so the boundary test below would otherwise treat it as the section end.
+    if (trimmedLine === 'inputs:') {
+      inputsSectionStart = i;
+      inputsIndent = indentOf(lines[i]);
+      continue;
+    }
+
+    if (indentOf(lines[i]) <= componentIndent && (trimmedLine.startsWith('- ') || trimmedLine.includes(':'))) {
+      inputsSectionEnd = i;
+      break;
+    }
+  }
+
+  if (inputsSectionStart === -1) return null;
+  if (inputsSectionEnd === -1) inputsSectionEnd = lines.length;
+
+  if (lineIndex > inputsSectionStart && lineIndex < inputsSectionEnd) {
+    return { inputsIndent };
+  }
+  return null;
+}
+
+/**
+ * Build the value portion of the snippet inserted after `param.name: ` when an input is accepted from completion.
+ *
+ * Returns a TextMate snippet body (with `${1...}` tab-stops) the caller wraps in a `vscode.SnippetString`:
+ * a quoted/literal form of the parameter's default when one exists, otherwise a type-appropriate placeholder
+ * (booleans offer both values, arrays/objects seed empty literals, enums offer a choice of the allowed values).
+ */
+export function buildInputInsertValue(param: ComponentParameter & { enum?: unknown[] }): string {
+  if (param.default !== undefined) {
+    return typeof param.default === 'string' ? `"${param.default}"` : String(param.default);
+  }
+
+  switch (param.type) {
+    case 'boolean':
+      return param.required ? '${1|true,false|}' : '${1|false,true|}';
+    case 'number':
+      return '${1:0}';
+    case 'integer':
+      return param.required ? '${1:1}' : '${1:0}';
+    case 'array':
+      return '${1:[]}';
+    case 'object':
+      return '${1:{}}';
+    default:
+      if (param.enum && Array.isArray(param.enum)) {
+        const enumValues = param.enum.map((val: unknown) => `"${String(val)}"`).join(',');
+        return `\${1|${enumValues}|}`;
+      }
+      return param.required ? '${1:"TODO: set value"}' : '${1:""}';
+  }
+}

--- a/src/providers/completionProvider.ts
+++ b/src/providers/completionProvider.ts
@@ -5,7 +5,7 @@ import { getVariableCompletions, containsGitLabVariables, expandComponentUrl } f
 import { Logger } from '../utils/logger';
 import { isGitLabCIFile } from '../utils/gitlabCiFileMatcher';
 import { resolveLocalComponent } from './localComponentResolver';
-import { parseYaml, isYamlNode } from '../utils/yamlParser';
+import { findCompletionInputContextAtLine, buildInputInsertValue } from './completionInputContext';
 import type { ComponentParameter } from '../types/git-component';
 import type { CachedComponent } from '../types/cache';
 
@@ -362,204 +362,59 @@ export class CompletionProvider implements vscode.CompletionItemProvider {
   ): Promise<vscode.CompletionItem[] | null> {
     try {
       const text = document.getText();
-      const parsedYaml = parseYaml(text);
 
-      if (!isYamlNode(parsedYaml) || !parsedYaml.include) {
+      const context = findCompletionInputContextAtLine(text, position.line);
+      if (!context) {
+        this.logger.debug(`[CompletionProvider] No inputs parameter-name slot at cursor`, 'CompletionProvider');
         return null;
       }
 
-      const includes = Array.isArray(parsedYaml.include) ? parsedYaml.include : [parsedYaml.include];
-      const currentLineIndex = position.line;
-      const lines = text.split('\n');
+      const { componentUrl, includeKind, existingInputNames } = context;
+      const isLocal = includeKind === 'local';
 
-      this.logger.debug(`[CompletionProvider] Found ${includes.length} components in YAML at line ${currentLineIndex + 1}`, 'CompletionProvider');
+      this.logger.debug(`[CompletionProvider] In inputs slot for ${componentUrl} (local=${isLocal})`, 'CompletionProvider');
 
-      // Find which component the cursor is actually within by finding the closest component above the cursor
-      let closestComponent = null;
-      let closestDistance = Infinity;
-
-      // Find which component's inputs section we're in
-      for (const include of includes) {
-        const isLocal = !!include.local && !include.component;
-        const componentUrl = include.component ?? include.local;
-        if (!componentUrl) continue;
-        const includeKey = isLocal ? 'local:' : 'component:';
-
-        // Look for this component's position in the file
-        let componentLineIndex = -1;
-        for (let i = 0; i < lines.length; i++) {
-          if (lines[i].includes(includeKey) && lines[i].includes(componentUrl)) {
-            componentLineIndex = i;
-            break;
-          }
-        }
-
-        if (componentLineIndex === -1) continue;
-
-        // Check if this component is above the cursor and closer than any previous component
-        if (componentLineIndex < currentLineIndex) {
-          const distance = currentLineIndex - componentLineIndex;
-          if (distance < closestDistance) {
-            closestDistance = distance;
-            closestComponent = { include, componentLineIndex, componentUrl, isLocal };
-          }
-        }
-      }
-
-      if (!closestComponent) {
-        this.logger.debug(`[CompletionProvider] No component found above cursor position`, 'CompletionProvider');
+      // Get the component details - local includes resolve from the workspace file, others from cache.
+      const component = isLocal
+        ? await resolveLocalComponent(componentUrl, document)
+        : await this.findComponentInCache(componentUrl, document.uri);
+      if (!component || !component.parameters) {
+        this.logger.debug(`[CompletionProvider] Component not found in cache or has no parameters: ${componentUrl}`, 'CompletionProvider');
         return null;
       }
 
-      this.logger.debug(`[CompletionProvider] Found closest component at line ${closestComponent.componentLineIndex + 1}: ${closestComponent.componentUrl}`, 'CompletionProvider');
+      this.logger.debug(`[CompletionProvider] Found component ${component.name} with ${component.parameters.length} parameters; existing inputs: ${existingInputNames.join(', ') || 'none'}`, 'CompletionProvider');
 
-      // Now check if we're in the inputs section of the closest component
-      const include = closestComponent.include;
-      const componentUrl = closestComponent.componentUrl;
-      const componentLineIndex = closestComponent.componentLineIndex;
+      // Filter out already provided inputs
+      const existing = new Set(existingInputNames);
+      const missingInputs = component.parameters.filter((param: ComponentParameter) => !existing.has(param.name));
 
-      // Check if we're in the inputs section of this component
-      let inputsSectionStart = -1;
-      let inputsSectionEnd = -1;
+      this.logger.debug(`[CompletionProvider] Found ${missingInputs.length} missing inputs for completion: ${missingInputs.map(p => p.name).join(', ')}`, 'CompletionProvider');
 
-      // Look for inputs: after the component line
-      for (let i = componentLineIndex + 1; i < lines.length; i++) {
-        const line = lines[i];
-        const trimmedLine = line.trim();
+      // Create completion items for missing inputs
+      return missingInputs.map((param: ComponentParameter & { enum?: unknown[] }) => {
+        const item = new vscode.CompletionItem(param.name, vscode.CompletionItemKind.Property);
 
-        // If we find a new component or job, stop looking
-        if (trimmedLine.startsWith('- ') || (trimmedLine.includes(':') && !line.startsWith('  '))) {
-          inputsSectionEnd = i;
-          break;
+        // Enhanced documentation
+        let documentation = `**${param.name}** (${param.required ? 'required' : 'optional'})\n\n`;
+        documentation += `${param.description || 'No description available'}\n\n`;
+        documentation += `**Type:** ${param.type || 'string'}\n`;
+        if (param.default !== undefined) {
+          documentation += `**Default:** \`${param.default}\`\n`;
         }
 
-        // If we find inputs:, mark the start
-        if (trimmedLine === 'inputs:') {
-          inputsSectionStart = i;
-          continue;
-        }
-      }
+        item.documentation = new vscode.MarkdownString(documentation);
 
-      // If we didn't find an explicit end, assume it goes to the end of the component
-      if (inputsSectionStart !== -1 && inputsSectionEnd === -1) {
-        inputsSectionEnd = lines.length;
-      }
+        item.insertText = new vscode.SnippetString(`${param.name}: ${buildInputInsertValue(param)}`);
 
-      this.logger.debug(`[CompletionProvider] Component ${componentUrl}: inputs section from line ${inputsSectionStart + 1} to ${inputsSectionEnd}`, 'CompletionProvider');
+        // Add sorting priority (required params first)
+        item.sortText = param.required ? `0${param.name}` : `1${param.name}`;
 
-      // Check if current position is in the inputs section
-      if (inputsSectionStart !== -1 &&
-          currentLineIndex > inputsSectionStart &&
-          currentLineIndex < inputsSectionEnd) {
+        // Add detail showing requirement status
+        item.detail = `${param.type || 'string'} ${param.required ? '(required)' : '(optional)'}`;
 
-        this.logger.debug(`[CompletionProvider] Found inputs section context for component: ${componentUrl}`, 'CompletionProvider');
-
-        // Check if we're on a line that looks like it's starting a parameter
-        const currentLine = lines[currentLineIndex];
-        const currentLineText = currentLine.trim();
-
-        // Only provide completions if:
-        // 1. Line is empty or only has whitespace and partial parameter name
-        // 2. Line starts with proper indentation for parameters (6+ spaces)
-        // 3. We're not in the middle of a value assignment
-        const lineIndent = currentLine.length - currentLine.trimStart().length;
-        const isParameterContext = lineIndent >= 6 &&
-          (!currentLineText.includes(':') || currentLineText.endsWith(':'));
-
-        if (!isParameterContext) {
-          this.logger.debug(`[CompletionProvider] Not in parameter name context (line: "${currentLineText}")`, 'CompletionProvider');
-          return null;
-        }
-
-        // Get the component details - local includes resolve from the workspace file, others from cache.
-        this.logger.debug(`[CompletionProvider] Looking up component: ${componentUrl} (local=${closestComponent.isLocal})`, 'CompletionProvider');
-        const component = closestComponent.isLocal
-          ? await resolveLocalComponent(componentUrl, document)
-          : await this.findComponentInCache(componentUrl, document.uri);
-        if (!component || !component.parameters) {
-          this.logger.debug(`[CompletionProvider] Component not found in cache or has no parameters: ${componentUrl}`, 'CompletionProvider');
-          return null;
-        }
-
-        this.logger.debug(`[CompletionProvider] Found component ${component.name} with ${component.parameters.length} parameters`, 'CompletionProvider');
-
-        // Get existing inputs
-        const existingInputs = include.inputs || {};
-
-        this.logger.debug(`[CompletionProvider] Component ${component.name} has ${component.parameters.length} total parameters`, 'CompletionProvider');
-        this.logger.debug(`[CompletionProvider] Existing inputs: ${Object.keys(existingInputs).join(', ') || 'none'}`, 'CompletionProvider');
-
-        // Filter out already provided inputs
-        const missingInputs = component.parameters.filter((param: ComponentParameter) =>
-          !Object.prototype.hasOwnProperty.call(existingInputs, param.name)
-        );
-
-        this.logger.debug(`[CompletionProvider] Found ${missingInputs.length} missing inputs for completion: ${missingInputs.map(p => p.name).join(', ')}`, 'CompletionProvider');
-
-        // Create completion items for missing inputs
-        return missingInputs.map((param: ComponentParameter & { enum?: unknown[] }) => {
-          const item = new vscode.CompletionItem(param.name, vscode.CompletionItemKind.Property);
-
-          // Enhanced documentation
-          let documentation = `**${param.name}** (${param.required ? 'required' : 'optional'})\n\n`;
-          documentation += `${param.description || 'No description available'}\n\n`;
-          documentation += `**Type:** ${param.type || 'string'}\n`;
-          if (param.default !== undefined) {
-            documentation += `**Default:** \`${param.default}\`\n`;
-          }
-
-          item.documentation = new vscode.MarkdownString(documentation);
-
-          // Smart insert text based on parameter type and default value
-          let insertValue: string;
-          if (param.default !== undefined) {
-            if (typeof param.default === 'string') {
-              insertValue = `"${param.default}"`;
-            } else {
-              insertValue = String(param.default);
-            }
-          } else {
-            // Provide type-appropriate placeholders with better snippets
-            switch (param.type) {
-              case 'boolean':
-                insertValue = param.required ? '${1|true,false|}' : '${1|false,true|}';
-                break;
-              case 'number':
-                insertValue = param.required ? '${1:0}' : '${1:0}';
-                break;
-              case 'integer':
-                insertValue = param.required ? '${1:1}' : '${1:0}';
-                break;
-              case 'array':
-                insertValue = '${1:[]}';
-                break;
-              case 'object':
-                insertValue = '${1:{}}';
-                break;
-              default:
-                // Check if there are enum values
-                if (param.enum && Array.isArray(param.enum)) {
-                  const enumValues = param.enum.map((val: unknown) => `"${String(val)}"`).join(',');
-                  insertValue = `\${1|${enumValues}|}`;
-                } else {
-                  insertValue = param.required ? '${1:"TODO: set value"}' : '${1:""}';
-                }
-            }
-          }
-
-          item.insertText = new vscode.SnippetString(`${param.name}: ${insertValue}`);
-
-          // Add sorting priority (required params first)
-          item.sortText = param.required ? `0${param.name}` : `1${param.name}`;
-
-          // Add detail showing requirement status
-          item.detail = `${param.type || 'string'} ${param.required ? '(required)' : '(optional)'}`;
-
-          return item;
-        });
-      }
-
-      return null;
+        return item;
+      });
     } catch (error) {
       this.logger.error(`[CompletionProvider] Error in provideComponentInputCompletions: ${error}`, 'CompletionProvider');
       return null;

--- a/tests/unit/completionInputContext.test.ts
+++ b/tests/unit/completionInputContext.test.ts
@@ -1,0 +1,194 @@
+// @mocha
+/**
+ * Imports the real `findCompletionInputContextAtLine` and `buildInputInsertValue` from
+ * src/providers/completionInputContext.ts. Covers the pure stages of CompletionProvider's input-completion flow:
+ * resolving which `include:` entry's `inputs:` block a cursor sits in (the part that previously broke when an
+ * earlier input was a multi-line array), and turning a parameter spec into a snippet body.
+ *
+ * The cache/local resolution and `vscode.CompletionItem` rendering still live in CompletionProvider and are
+ * exercised by the extension-host suite.
+ */
+
+import * as assert from 'node:assert/strict';
+import {
+  findCompletionInputContextAtLine,
+  buildInputInsertValue,
+} from '../../src/providers/completionInputContext';
+import type { ComponentParameter } from '../../src/types/git-component';
+
+const FULL_PIPELINE_URL = 'https://gitlab.com/components/opentofu/full-pipeline@2.6.1';
+
+suite('findCompletionInputContextAtLine', () => {
+  test('detects an empty parameter slot under the only include', () => {
+    const text = `include:
+  - component: ${FULL_PIPELINE_URL}
+    inputs:
+      environment: "development"
+      `;
+    const ctx = findCompletionInputContextAtLine(text, 4); // blank, 6-space-indented slot
+    assert.deepStrictEqual(ctx, {
+      componentUrl: FULL_PIPELINE_URL,
+      includeKind: 'component',
+      existingInputNames: ['environment'],
+    });
+  });
+
+  test('detects a slot after a multi-line array input (regression)', () => {
+    // An array value's `- item` lines must not be mistaken for the start of the next include entry.
+    const text = `include:
+  - component: ${FULL_PIPELINE_URL}
+    inputs:
+      tags:
+        - one
+        - two
+      `;
+    const ctx = findCompletionInputContextAtLine(text, 6); // blank slot below the array
+    assert.deepStrictEqual(ctx, {
+      componentUrl: FULL_PIPELINE_URL,
+      includeKind: 'component',
+      existingInputNames: ['tags'],
+    });
+  });
+
+  test('reports existing inputs so the caller can filter them out', () => {
+    const text = `include:
+  - component: ${FULL_PIPELINE_URL}
+    inputs:
+      environment: "dev"
+      debug: true
+      `;
+    const ctx = findCompletionInputContextAtLine(text, 5);
+    assert.deepStrictEqual(ctx?.existingInputNames, ['environment', 'debug']);
+  });
+
+  test('scopes to the closest include when several are present', () => {
+    const second = 'https://gitlab.com/my-group/my-component@v1.0.0';
+    const text = `include:
+  - component: ${FULL_PIPELINE_URL}
+    inputs:
+      environment: "dev"
+  - component: ${second}
+    inputs:
+      stage: build
+      `;
+    const ctx = findCompletionInputContextAtLine(text, 7); // slot under the second include
+    assert.deepStrictEqual(ctx, {
+      componentUrl: second,
+      includeKind: 'component',
+      existingInputNames: ['stage'],
+    });
+  });
+
+  test('detects a slot under a `- local:` include and reports includeKind = local', () => {
+    const text = `include:
+  - local: /templates/nx-test.yml
+    inputs:
+      stage: build
+      `;
+    const ctx = findCompletionInputContextAtLine(text, 4);
+    assert.deepStrictEqual(ctx, {
+      componentUrl: '/templates/nx-test.yml',
+      includeKind: 'local',
+      existingInputNames: ['stage'],
+    });
+  });
+
+  test('detects a slot in the mapping form, where include is a single mapping not a list', () => {
+    // `include:` as a bare mapping (no leading `- `): `component:` and `inputs:` are siblings at the same indent.
+    const text = `include:
+  component: ${FULL_PIPELINE_URL}
+  inputs:
+    environment: "dev"
+    `;
+    const ctx = findCompletionInputContextAtLine(text, 4); // slot under `inputs:`, indented past it
+    assert.deepStrictEqual(ctx, {
+      componentUrl: FULL_PIPELINE_URL,
+      includeKind: 'component',
+      existingInputNames: ['environment'],
+    });
+  });
+
+  test('detects a slot regardless of the indentation step (threshold is relative to `inputs:`)', () => {
+    // 4-space steps rather than the conventional 2 — the slot is a child of `inputs:`, not pinned to 6 columns.
+    const text = `include:
+    - component: ${FULL_PIPELINE_URL}
+      inputs:
+          environment: "dev"
+          `;
+    const ctx = findCompletionInputContextAtLine(text, 4);
+    assert.deepStrictEqual(ctx, {
+      componentUrl: FULL_PIPELINE_URL,
+      includeKind: 'component',
+      existingInputNames: ['environment'],
+    });
+  });
+
+  test('returns null when the cursor is on a complete key: value line', () => {
+    const text = `include:
+  - component: ${FULL_PIPELINE_URL}
+    inputs:
+      environment: "development"`;
+    const ctx = findCompletionInputContextAtLine(text, 3); // a finished assignment, not a name slot
+    assert.strictEqual(ctx, null);
+  });
+
+  test('returns null when the slot is too shallow to be an inputs child', () => {
+    const text = `include:
+  - component: ${FULL_PIPELINE_URL}
+    inputs:
+      environment: "dev"
+    `; // only 4-space indent — sibling of inputs:, not a child
+    const ctx = findCompletionInputContextAtLine(text, 4);
+    assert.strictEqual(ctx, null);
+  });
+
+  test('returns null when the cursor is outside any inputs section', () => {
+    const text = `include:
+  - component: ${FULL_PIPELINE_URL}
+    inputs:
+      environment: "dev"
+stages:
+  - build`;
+    const ctx = findCompletionInputContextAtLine(text, 5); // the `- build` stages line
+    assert.strictEqual(ctx, null);
+  });
+
+  test('returns null when there are no include blocks parsed', () => {
+    const text = `stages:
+  - build
+variables:
+  MY_VAR: value`;
+    const ctx = findCompletionInputContextAtLine(text, 3);
+    assert.strictEqual(ctx, null);
+  });
+});
+
+suite('buildInputInsertValue', () => {
+  const base: ComponentParameter = { name: 'p', description: '', required: false, type: 'string' };
+
+  test('quotes a string default and stringifies a non-string default', () => {
+    assert.strictEqual(buildInputInsertValue({ ...base, default: 'dev' }), '"dev"');
+    assert.strictEqual(buildInputInsertValue({ ...base, type: 'number', default: 42 }), '42');
+    assert.strictEqual(buildInputInsertValue({ ...base, type: 'boolean', default: true }), 'true');
+  });
+
+  test('offers both boolean values, leading with the safer one by requiredness', () => {
+    assert.strictEqual(buildInputInsertValue({ ...base, type: 'boolean', required: true }), '${1|true,false|}');
+    assert.strictEqual(buildInputInsertValue({ ...base, type: 'boolean', required: false }), '${1|false,true|}');
+  });
+
+  test('seeds empty literals for array and object inputs', () => {
+    assert.strictEqual(buildInputInsertValue({ ...base, type: 'array' }), '${1:[]}');
+    assert.strictEqual(buildInputInsertValue({ ...base, type: 'object' }), '${1:{}}');
+  });
+
+  test('offers a choice of allowed values when an enum is present', () => {
+    const param = { ...base, enum: ['a', 'b'] } as ComponentParameter & { enum?: unknown[] };
+    assert.strictEqual(buildInputInsertValue(param), '${1|"a","b"|}');
+  });
+
+  test('falls back to a TODO placeholder for a required untyped input', () => {
+    assert.strictEqual(buildInputInsertValue({ ...base, required: true }), '${1:"TODO: set value"}');
+    assert.strictEqual(buildInputInsertValue({ ...base, required: false }), '${1:""}');
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes input completions silently disappearing inside a component's `inputs:` block once an **earlier input is a multi-line array**. The inputs-section boundary detection treated any line beginning with `- ` as the start of the next include entry; an array value's item lines (`- one`, `- two`) match that shape, so the section was judged to end at the first array item and any cursor below it was considered outside `inputs:` — no suggestions. Scalar inputs above the cursor were unaffected, which is why this only surfaced with array-valued inputs.
- The boundary check is now **indentation-aware**: it anchors on the include entry's own indent, so a `- ` (or mapping key) ends the section only when it sits at that indent or shallower (a genuine sibling include/job). More-deeply-indented `- ` lines are array values belonging to the current input and no longer close the section.
- The parameter-slot gate is now **derived from the actual `inputs:` indentation** (a cursor line indented past `inputs:`) rather than a hardcoded `>= 6`-column floor. This fixes a second case the literal floor couldn't handle — the **mapping form** of `include:` (a bare mapping, not a `- ` list), where `component:` and `inputs:` are siblings at the same indent — and makes detection work under any indentation step, matching how `hoverInputContext.ts` already does it.
- Along the way, the detection logic and the type→snippet placeholder logic were **extracted out of the `vscode`-coupled provider method into a pure module**, so the bug-prone part is now unit-testable — following the existing `hoverInputContext.ts` precedent. The fix and the refactor are bundled because the refactor is what makes the fix testable.
- Link related issue(s): #163 

## Change Type
- [ ] feat
- [x] fix
- [x] refactor
- [ ] docs
- [x] test
- [ ] chore

## Context
### User-facing impact
- Triggering completion on an indented line inside an `inputs:` block now offers the remaining un-set inputs regardless of whether an earlier input is a scalar (`key: value`) or a multi-line array (`key:` followed by `- item` lines). Previously, an array input above the cursor suppressed all further input suggestions for that include.
- Input completion now also works for the **mapping form** of `include:` (a single bare mapping rather than a `- ` list) and for files that don't use 2-space indentation steps — both previously got no input suggestions because the slot test assumed a fixed column.

### GitLab scope
- [ ] gitlab.com
- [ ] self-managed GitLab
- [x] both (detection is on local document text; instance-independent)

### Affected areas
- [ ] Component Browser
- [ ] Hover provider
- [x] Completion provider
- [ ] Validation provider
- [ ] Cache and refresh behavior
- [ ] GitLab API calls/auth/token storage
- [ ] Docs only

## What changed by bucket

| Bucket | Files | Approach |
|---|---|---|
| Root-cause fix | [completionInputContext.ts](src/providers/completionInputContext.ts) (new) | `findInputsSection` anchors the section boundary on the include entry's own indentation. A `- ` list item or a `key:` mapping ends the section only when `indent <= componentIndent`; deeper `- ` lines (array values under an input) are skipped, so they no longer masquerade as the next include entry. The `inputs:` header is recognised **before** the boundary test, so the mapping form (`inputs:` at the same indent as the include's `component:` key) isn't read as the section end. Blank lines are skipped rather than scanned. |
| Slot threshold | [completionInputContext.ts](src/providers/completionInputContext.ts) (new) | `findInputsSection` returns the `inputs:` line's indent, and the caller gates the parameter-name slot on `indent > inputsIndent` (a child of `inputs:`) instead of a hardcoded `>= 6`. Removes the implicit 2-space-ladder assumption and makes the mapping form / non-standard indentation work. |
| Test-enabling refactor | [completionInputContext.ts](src/providers/completionInputContext.ts) (new), [completionProvider.ts](src/providers/completionProvider.ts) | The slot-detection and snippet-body logic moved out of `provideComponentInputCompletions` into a `vscode`-free module exporting `findCompletionInputContextAtLine(text, lineIndex)` → `{ componentUrl, includeKind, existingInputNames } \| null` and `buildInputInsertValue(param)` → snippet body string. The provider keeps only the `vscode`/cache-coupled parts (local/cache resolution, `CompletionItem` rendering) and shrank from ~210 to ~55 lines. Dropped the now-unused `parseYaml`/`isYamlNode` imports. |
| Tests | [completionInputContext.test.ts](tests/unit/completionInputContext.test.ts) (new) | 16 unit tests modeled on `hoverInputContext.test.ts`: detection (empty slot, **multi-line array regression**, **mapping-form include**, **indentation-step independence**, existing-input reporting, closest-include scoping, `local:` includes) and four `null` cases (complete `key: value`, too-shallow indent, outside inputs, no includes); plus snippet-builder coverage (string/non-string defaults, boolean choices, array/object literals, enum choices, required/optional fallbacks). |

## Notable details

### The root cause: array item lines mistaken for the next include
The boundary loop ended the inputs section on `trimmedLine.startsWith('- ')`, intended to catch the next `- component:`/`- local:` entry. But a YAML array input renders as:

```yaml
inputs:
  tags:
    - one      # <- this `- ` ended the section
    - two
  next_param:  # <- judged "outside inputs", no completion
```

So the first array item closed the section and the cursor below it fell outside the detected range. The fix distinguishes the two uses of `- ` by indentation: the include entry (`  - component:`) sits at `componentIndent`; a sibling include is at that same indent or shallower, while array items are deeper. Only the former now ends the section.

### The second case: the mapping form and the hardcoded indent floor
The original slot test was `lineIndent >= 6`, which silently assumed the conventional `include:`(0) → `- component:`(2) → `inputs:`(4) → `key:`(6) ladder. Two valid layouts break that assumption:

```yaml
# mapping form — `include:` is a bare mapping, not a list
include:
  component: https://gitlab.com/x/y/z@1.0
  inputs:
    environment: "dev"
    # cursor here is at indent 4, below the >= 6 floor → no completion
```

Here `component:` and `inputs:` are siblings at indent 2, so input keys land at indent 4 — under the `>= 6` floor. The same applies to any file that doesn't use 2-space steps. The fix derives the threshold from the located `inputs:` line: `findInputsSection` returns its indent, and a slot is any line indented past it (`indent > inputsIndent`). It also recognises the `inputs:` header before the boundary test, so the mapping form's `inputs:` (which shares the include's indent) isn't mistaken for the section end. This mirrors `hoverInputContext.ts`, which already gates on `inputIndent > inputsLineIndent`.

### Why the detection logic was extracted
All the interesting (and buggy) logic lived inside `provideComponentInputCompletions`, tangled with `vscode` types (`TextDocument`, `Position`, `CompletionItem`, `SnippetString`) and async cache lookups, so the unit runner — which can't import `vscode` — couldn't reach it. The hover provider had already solved the equivalent problem by extracting [hoverInputContext.ts](src/providers/hoverInputContext.ts). This PR mirrors that: a sibling pure module rather than a merge into the hover one, because the two answer different questions about the current line (hover requires a complete `key: value`; completion requires an empty/partial name slot), so sharing would have meant a flag-heavy API.

### Behavior preserved across the refactor
The provider's downstream only ever read existing input **names** (`Object.keys`/`hasOwnProperty`), so the helper returns `existingInputNames: string[]` and the raw YAML node stays out of the public surface. The closest-include-above selection and the type→placeholder snippet mapping are carried over unchanged and now covered by tests. The "parameter-name slot" gate is carried over in intent (an indented line that isn't a finished `key: value`) but its indent threshold was upgraded from the hardcoded `>= 6` to one derived from the `inputs:` indent — see the section above.

## Latent invariants made explicit
- An `include:` entry's indentation is the anchor for "what belongs to this entry": anything more deeply indented (nested keys, array values) is part of it; anything at that indent or shallower starts the next entry. The previous `- `-prefix heuristic conflated array items with sibling entries; this is now stated and enforced in one place.
- A parameter-name slot is "a line indented deeper than its own `inputs:` key", not "a line at column ≥ 6". The depth is relative to the block, so it holds for the list form, the mapping form, and any indentation step — the same rule `hoverInputContext.ts` uses.

## Validation
### Local checks
- [x] `npm run check-types` — clean (`tsc --noEmit`).
- [x] `npm run lint` — 0 errors on the new/modified source files (the test file is in ESLint's ignore set, same as the existing `hoverInputContext.test.ts`).
- [x] `npm test` — 192 passing, including the 16 new tests (`findCompletionInputContextAtLine` + `buildInputInsertValue`, with the multi-line array regression, mapping-form, and indentation-step cases).

### Manual test notes
- Suggested Extension Host check: in a `.gitlab-ci.yml`, give a component an array input followed by a blank indented line, trigger completion below the array, and confirm the remaining inputs are offered (and that already-set inputs, including the array one, are filtered out).

## Breaking Changes
- [x] No breaking changes
- [ ] Breaking changes (describe below)

No settings, cache shape, or public API changes — internal extraction plus a boundary-detection fix.

## Screenshots / Recordings (if UI behavior changed)
- N/A — no UI changes; only which completions are offered.

## Risk and Rollback
- **Main risks:** The change is confined to local-text section detection. Both thresholds are now derived from the document (the include entry's indent for the boundary, the `inputs:` indent for the slot) rather than hardcoded columns, so unusual-but-valid layouts (mapping form, non-2-space steps, includes nested under extra indentation) are handled relative to the actual structure. Worst case of a detection miss is the prior behavior — no completions — never a wrong edit.
- **Rollback strategy:** Single PR, revert. No data migration, cache bump, new dependencies, or CI secrets.

## Release Notes Draft
- fix: input completions are now offered correctly after a multi-line array input inside a component's `inputs:` block (previously an array input above the cursor suppressed further suggestions), and for the mapping form of `include:` and files that don't use 2-space indentation.

## Checklist
- [x] Branch is up to date with target branch
- [x] Commit messages follow conventional commits
- [x] Added/updated docs for behavior or settings changes (none — no settings changed)
- [x] Added/updated tests for new behavior (array-input regression + detection/snippet unit coverage)
- [x] No secrets or tokens in code, logs, screenshots, or test fixtures
