### PR TITLE
feat: monorepo tag scoping

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,44 @@ To keep the extension fast and predictable:
 
 ---
 
+## 🏷️ Monorepo tag conventions
+
+When a single repository holds **many components**, each component is usually released under its own tags that embed the component name — e.g. `deploy-app-1.1.0`, `deploy-app-2`, `build-image-4.0.0`. Without any hint, the version dropdown for *every* component would list *every* tag in the repo.
+
+Set a **tag pattern** on the source to tell the extension how tags map to components. Each component's dropdown is then scoped to its own tags, and the labels are shown without the prefix (e.g. `1.1.0`, not `deploy-app-1.1.0`). The full tag is still what gets inserted, so the GitLab include resolves correctly.
+
+```jsonc
+"gitlabComponentHelper.componentSources": [
+  {
+    "name": "Shared CI Monorepo",
+    "path": "infrastructure/shared-ci",
+    "gitlabInstance": "gitlab.com",
+    "tagPattern": "{name}-{version}"
+  }
+]
+```
+
+The template uses two tokens:
+
+| Token | Meaning |
+|---|---|
+| `{name}` | The component (= `templates/` directory) name. |
+| `{version}` | The version shown in the dropdown. Matches anything starting with a digit. |
+
+Everything else in the pattern is literal text, so other conventions work too:
+
+| Tag style | Pattern |
+|---|---|
+| `deploy-app-1.1.0` | `{name}-{version}` |
+| `apps/web/v2.0.0` | `apps/{name}/v{version}` |
+| `web_1.0.0` | `{name}_{version}` |
+
+> **Sibling names:** because `{version}` must start with a digit, a component named `build-image` won't pick up a sibling's `build-image-extra-1.0.0` tags. If you need pre-release-only tags with no leading digit (e.g. `web-rc1`), write a stricter custom pattern for that source.
+
+Leave `tagPattern` unset for ordinary single-component repos — their tags are listed as-is.
+
+---
+
 ## 🧩 Commands
 #### Use the Command Palette (`Ctrl+Shift+P`) to access:
 - **GitLab CI: Browse Components** — Explore and insert from all your sources
@@ -349,7 +387,7 @@ The following settings are available for the GitLab Component Helper extension. 
 | `gitlabComponentHelper.httpTimeout` | number | `10000` | HTTP request timeout in milliseconds |
 | `gitlabComponentHelper.retryAttempts` | number | `3` | Number of retry attempts for failed HTTP requests |
 | `gitlabComponentHelper.batchSize` | number | `5` | Number of components to process in parallel batches |
-| `gitlabComponentHelper.componentSources` | array | See below | GitLab repositories containing reusable CI/CD components. Each item supports an optional `discovery` block to override the global discovery defaults for that source. |
+| `gitlabComponentHelper.componentSources` | array | See below | GitLab repositories containing reusable CI/CD components. Each item supports an optional `discovery` block (override discovery defaults) and, for [monorepos](#-monorepo-tag-conventions), a `tagPattern` string. |
 | `gitlabComponentHelper.discovery.templateRoots` | array | `["templates"]` | Repository directories scanned for components. Up to 5 entries. |
 | `gitlabComponentHelper.discovery.maxDepth` | number | `1` | Subdirectory depth to recurse under each root. Range `0`–`3`. |
 | `gitlabComponentHelper.discovery.filePatterns` | array | `["*.yml", "*.yaml"]` | Filename globs identifying component template files. Filename only — no path globs. |

--- a/package.json
+++ b/package.json
@@ -133,6 +133,10 @@
                 "default": "gitlab.com",
                 "description": "GitLab instance hostname"
               },
+              "tagPattern": {
+                "type": "string",
+                "description": "Tag pattern for a tag-per-component monorepo, describing how tags embed the component name and version. Use the tokens {name} (the component/directory name) and {version} (the version shown in the dropdown); {version} matches anything starting with a digit. Examples: '{name}-{version}', 'apps/{name}/v{version}', '{name}_{version}'. When set, each component's versions are scoped to its own tags; leave unset for ordinary single-component repositories."
+              },
               "discovery": {
                 "type": "object",
                 "description": "Per-source discovery overrides (uses gitlabComponentHelper.discovery.* defaults if omitted)",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,7 @@ import { CompletionProvider } from './providers/completionProvider';
 import { ComponentDocumentLinkProvider } from './providers/documentLinkProvider';
 import { ComponentBrowserProvider } from './providers/componentBrowserProvider';
 import { detectIncludeComponent, Component } from './providers/componentDetector';
+import { stripTagPrefix } from './services/component/tagScoping';
 import { getComponentCacheManager, ComponentCacheManager } from './services/cache/componentCacheManager';
 import { Logger } from './utils/logger';
 import { ValidationProvider } from './providers/validationProvider';
@@ -410,6 +411,12 @@ export function activate(context: vscode.ExtensionContext) {
           logger.debug(`[Extension] Failed to enrich detached hover component: ${error}`, 'Extension');
         }
 
+        // Recover the full (and, for monorepos, scoped) version list plus tag-template settings from the cache so the
+        // hover details dropdown matches the browser's — instead of every tag in the repo, unscoped and unstripped.
+        // Stamp the monorepo settings onto activeComponent too, so the panel's later `fetchVersions` round-trip
+        // (cacheManager.fetchComponentVersions) scopes to this component instead of returning every repo tag.
+        const enriched = await componentBrowser.lookupComponentDetails(activeComponent);
+        activeComponent = { ...activeComponent, ...enriched };
         panel.webview.html = componentBrowser.getComponentDetailsHtml(activeComponent);
 
         // Ensure the original editor remains focused after panel creation
@@ -503,9 +510,19 @@ export function activate(context: vscode.ExtensionContext) {
                   throw new Error('Component is missing required fields (source, sourcePath, gitlabInstance, version) for version lookup.');
                 }
                 const versions = await cacheManager.fetchComponentVersions(activeComponent);
+                // For a monorepo source, map each full tag to its stripped {version} so the dropdown shows short
+                // labels while keeping the full tag as the option value (the inserted ref).
+                let versionLabels: Record<string, string> | undefined;
+                if (activeComponent.tagPattern) {
+                  versionLabels = {};
+                  for (const v of versions) {
+                    versionLabels[v] = stripTagPrefix(v, activeComponent.name, activeComponent.tagPattern);
+                  }
+                }
                 panel.webview.postMessage({
                   command: 'versionsLoaded',
                   versions: versions,
+                  versionLabels,
                   currentVersion: activeComponent.version
                 });
               } catch (error) {

--- a/src/providers/componentBrowserProvider.ts
+++ b/src/providers/componentBrowserProvider.ts
@@ -1185,8 +1185,17 @@ export class ComponentBrowserProvider {
                 // full tag as the option value (the inserted ref).
                 const labels = message.versionLabels || {};
                 const label = function(v) { return labels[v] || v; };
-                const opts = versions.map(function(v) { return '<option value="' + v + '" ' + (v === defaultVersion ? 'selected' : '') + '>' + label(v) + '</option>'; }).join('');
-                actionsDiv.innerHTML = '<select class="version-dropdown" onchange="updateComponentVersion(&#39;' + componentName + '&#39;, this.value, &#39;' + projectId + '&#39;)">' + opts + '</select><button onclick="viewDetailsById(&#39;' + componentName + '&#39;, &#39;' + defaultVersion + '&#39;, &#39;' + projectId + '&#39;)">Details</button><button onclick="insertComponentById(&#39;' + componentName + '&#39;, &#39;' + defaultVersion + '&#39;, &#39;' + projectId + '&#39;)">Insert</button>';
+                // Build the dropdown shell + buttons as markup, then append options via the DOM so the untrusted
+                // version strings (tag names can contain <, >, &) are never interpolated into HTML.
+                actionsDiv.innerHTML = '<select class="version-dropdown" onchange="updateComponentVersion(&#39;' + componentName + '&#39;, this.value, &#39;' + projectId + '&#39;)"></select><button onclick="viewDetailsById(&#39;' + componentName + '&#39;, &#39;' + defaultVersion + '&#39;, &#39;' + projectId + '&#39;)">Details</button><button onclick="insertComponentById(&#39;' + componentName + '&#39;, &#39;' + defaultVersion + '&#39;, &#39;' + projectId + '&#39;)">Insert</button>';
+                const select = actionsDiv.querySelector('.version-dropdown');
+                versions.forEach(function(v) {
+                  const option = document.createElement('option');
+                  option.value = v;
+                  option.textContent = label(v);
+                  if (v === defaultVersion) { option.selected = true; }
+                  select.appendChild(option);
+                });
                 const descElement = document.getElementById('desc-' + componentName + '-' + projectId);
                 if (descElement && !document.getElementById('version-info-' + componentName + '-' + projectId)) {
                   const versionInfo = document.createElement('div');
@@ -1744,7 +1753,7 @@ export class ComponentBrowserProvider {
                   : null;
                 return availableVersions.map((version: string) => {
                   const label = matcher?.extractVersion(version) ?? version;
-                  return `<option value="${version}" ${version === component.version ? 'selected' : ''}>${label}</option>`;
+                  return `<option value="${this.escapeHtml(version)}" ${version === component.version ? 'selected' : ''}>${this.escapeHtml(label)}</option>`;
                 }).join('');
               })()}
             </select>

--- a/src/providers/componentBrowserProvider.ts
+++ b/src/providers/componentBrowserProvider.ts
@@ -12,6 +12,7 @@ import { templateFileUrlForResolved } from '../utils/templateFileUrl';
 import { generateComponentText } from './componentBrowserGenerate';
 import { findComponentLineRange, parseExistingComponentText } from './componentBrowserEdit';
 import { transformCachedComponentsToGroups } from './componentBrowserTransform';
+import { compileTagTemplate, stripTagPrefix } from '../services/component/tagScoping';
 
 /**
  * Component shape carried through the detach-hover webview's "Open in Detailed View" round trip.
@@ -492,8 +493,12 @@ export class ComponentBrowserProvider {
       }
     );
 
+    // The component arrives from the webview carrying only the selected version and none of the source settings;
+    // recover the full version list and monorepo settings from the cache so the dropdown is complete and labelled.
+    const enriched = await this.lookupComponentDetails(component);
+
     // Show component details
-    detailsPanel.webview.html = this.getComponentDetailsHtml(component);
+    detailsPanel.webview.html = this.getComponentDetailsHtml({ ...component, ...enriched });
 
     // Handle messages from the details panel
     detailsPanel.webview.onDidReceiveMessage(
@@ -648,6 +653,32 @@ export class ComponentBrowserProvider {
     `;
   }
 
+  /**
+   * Render the `<option>` markup for a component's version dropdown.
+   *
+   * For a monorepo source the available versions are full prefixed tags (`<name>-1.1.0`). The option **value** is
+   * always the full tag (the ref inserted into the file); only the visible label is the prefix-stripped form.
+   * Non-monorepo components keep value == label == the version string.
+   *
+   * @param component  The component group to render options for. Its `availableVersions` become the options,
+   *                   `defaultVersion` marks the pre-selected one, and a `tagPattern` (if present) drives the
+   *                   prefix-stripped labels.
+   * @returns          The concatenated `<option>` HTML for the dropdown's contents (no wrapping `<select>`).
+   */
+  private renderVersionOptions(component: ComponentGroup): string {
+    const selectedAttr = (version: string): string =>
+      version === component.defaultVersion ? ' selected' : '';
+
+    return component.availableVersions
+      .map((version) => {
+        const label = component.tagPattern
+          ? stripTagPrefix(version, component.name, component.tagPattern)
+          : version;
+        return `<option value="${this.escapeHtml(version)}"${selectedAttr(version)}>${this.escapeHtml(label)}</option>`;
+      })
+      .join('');
+  }
+
   private getComponentBrowserHtml(componentGroups: SourceGroup[], cacheErrors: Record<string, string> = {}): string {
     const hasErrors = Object.keys(cacheErrors).length > 0;
 
@@ -713,9 +744,7 @@ export class ComponentBrowserProvider {
                     ${hasVersions ? `
                       ${component.availableVersions.length > 1 ? `
                         <select class="version-dropdown" onchange="updateComponentVersion('${component.name}', this.value, '${projectId}')" oncontextmenu="showContextMenu(event, '${component.name}', this.value, '${projectId}')">
-                          ${component.availableVersions.map((version: string) => `
-                            <option value="${version}" ${version === component.defaultVersion ? 'selected' : ''}>${version}</option>
-                          `).join('')}
+                          ${this.renderVersionOptions(component)}
                         </select>
                       ` : `<span class="single-version">${component.availableVersions[0] || 'latest'}</span>`}
                       <button onclick="viewDetailsById('${component.name}', '${component.defaultVersion || component.availableVersions[0]}', '${projectId}')">Details</button>
@@ -1151,7 +1180,12 @@ export class ComponentBrowserProvider {
             const projectId = componentCard.getAttribute('data-project-id'), actionsDiv = document.getElementById('actions-' + componentKey);
             if (actionsDiv) {
               if (versions.length > 1) {
-                const opts = versions.map(function(v) { return '<option value="' + v + '" ' + (v === defaultVersion ? 'selected' : '') + '>' + v + '</option>'; }).join('');
+                // For monorepo sources the version values are full tags (e.g. <name>-1.1.0); the server sends a
+                // versionLabels map (full tag → stripped {version}) so we display the short form while keeping the
+                // full tag as the option value (the inserted ref).
+                const labels = message.versionLabels || {};
+                const label = function(v) { return labels[v] || v; };
+                const opts = versions.map(function(v) { return '<option value="' + v + '" ' + (v === defaultVersion ? 'selected' : '') + '>' + label(v) + '</option>'; }).join('');
                 actionsDiv.innerHTML = '<select class="version-dropdown" onchange="updateComponentVersion(&#39;' + componentName + '&#39;, this.value, &#39;' + projectId + '&#39;)">' + opts + '</select><button onclick="viewDetailsById(&#39;' + componentName + '&#39;, &#39;' + defaultVersion + '&#39;, &#39;' + projectId + '&#39;)">Details</button><button onclick="insertComponentById(&#39;' + componentName + '&#39;, &#39;' + defaultVersion + '&#39;, &#39;' + projectId + '&#39;)">Insert</button>';
                 const descElement = document.getElementById('desc-' + componentName + '-' + projectId);
                 if (descElement && !document.getElementById('version-info-' + componentName + '-' + projectId)) {
@@ -1449,7 +1483,61 @@ export class ComponentBrowserProvider {
     `;
   }
 
-  public getComponentDetailsHtml(component: Component & { availableVersions?: string[] }): string {
+  /**
+   * Enrich a webview-supplied component from the cache for the details panel. The object posted from the browser
+   * carries only the selected version and none of the source-level settings, so here we recover:
+   *  - the full `availableVersions` list (so the version dropdown isn't limited to the one selected version), and
+   *  - the source's `tagPattern` (for monorepo prefix-stripped labels).
+   *
+   * Best-effort: returns an empty object if the component isn't found or the cache read fails.
+   *
+   * @param component  Identity of the component to look up. Matched against the cache by `name` plus its location —
+   *                   the flat `sourcePath`/`gitlabInstance` fields (browser components) or `context` (hover-detected
+   *                   components).
+   * @returns          The recovered `availableVersions` and `tagPattern`, each omitted when the cache has no value
+   *                   for it; an empty object if no matching component is cached or the read fails.
+   */
+  public async lookupComponentDetails(
+    component: {
+      name: string;
+      sourcePath?: string;
+      gitlabInstance?: string;
+      context?: { gitlabInstance: string; path: string };
+    },
+  ): Promise<{ availableVersions?: string[]; tagPattern?: string }> {
+    try {
+      // Hover-detected components carry their location under `context`; browser components use the flat fields.
+      const sourcePath = component.sourcePath || component.context?.path;
+      const gitlabInstance = component.gitlabInstance || component.context?.gitlabInstance;
+
+      const cached = await this.cacheManager.getComponents();
+      const match = cached.find(c =>
+        c.name === component.name &&
+        c.sourcePath === sourcePath &&
+        c.gitlabInstance === gitlabInstance
+      );
+      if (!match) return {};
+
+      const enriched: { availableVersions?: string[]; tagPattern?: string } = {};
+      if (match.availableVersions && match.availableVersions.length > 0) {
+        enriched.availableVersions = match.availableVersions;
+      }
+      if (match.tagPattern) {
+        enriched.tagPattern = match.tagPattern;
+      }
+      return enriched;
+    } catch {
+      // Best-effort enrichment — fall through to no enrichment.
+      return {};
+    }
+  }
+
+  public getComponentDetailsHtml(
+    component: Component & {
+      availableVersions?: string[];
+      tagPattern?: string;
+    },
+  ): string {
     const parameters = component.parameters || [];
     const availableVersions = component.availableVersions || [component.version || 'main'];
     const headerSummary = component.summary;
@@ -1648,9 +1736,17 @@ export class ComponentBrowserProvider {
           <div class="version-control">
             <strong>Version:</strong>
             <select id="versionSelect" onchange="onVersionChange()">
-              ${availableVersions.map((version: string) =>
-                `<option value="${version}" ${version === component.version ? 'selected' : ''}>${version}</option>`
-              ).join('')}
+              ${(() => {
+                // For monorepo tags show the template's {version} capture as the label, keeping the full tag as the
+                // option value (the ref used to fetch and insert the version).
+                const matcher = component.tagPattern
+                  ? compileTagTemplate(component.tagPattern, component.name)
+                  : null;
+                return availableVersions.map((version: string) => {
+                  const label = matcher?.extractVersion(version) ?? version;
+                  return `<option value="${version}" ${version === component.version ? 'selected' : ''}>${label}</option>`;
+                }).join('');
+              })()}
             </select>
             <span class="version-loading" id="versionLoading" style="display: none;">Loading version details...</span>
           </div>
@@ -1966,7 +2062,7 @@ export class ComponentBrowserProvider {
 
             switch (message.command) {
               case 'versionsLoaded':
-                updateVersionDropdown(message.versions, message.currentVersion);
+                updateVersionDropdown(message.versions, message.currentVersion, message.versionLabels);
                 break;
               case 'versionsError':
                 document.getElementById('versionLoading').style.display = 'none';
@@ -1984,18 +2080,20 @@ export class ComponentBrowserProvider {
             }
           });
 
-          function updateVersionDropdown(versions, currentVersion) {
+          function updateVersionDropdown(versions, currentVersion, versionLabels) {
             const select = document.getElementById('versionSelect');
             const loading = document.getElementById('versionLoading');
+            const labels = versionLabels || {};
 
             // Clear existing options
             select.innerHTML = '';
 
-            // Add new options
+            // Add new options. The option value is the full tag (the inserted ref); the label is the stripped
+            // {version} for monorepo sources (falls back to the full tag when no label is provided).
             versions.forEach(version => {
               const option = document.createElement('option');
               option.value = version;
-              option.textContent = version;
+              option.textContent = labels[version] || version;
               if (version === currentVersion) {
                 option.selected = true;
               }
@@ -2494,19 +2592,26 @@ ${sourceErrors.size > 0 ? '\nErrors:\n' + Array.from(sourceErrors.entries()).map
       this.versionsFetched.add(componentKey);
       this.versionsLoading.delete(componentKey);
 
-      // Calculate default version (prefer latest, main, master, or highest semantic version)
+      // Pick the default version. `availableVersions` is already sorted highest-priority-first (semantic versions
+      // before branches), so the first entry is the best default — except `latest`, the catalog floating tag, which
+      // wins when present.
       const availableVersions = updatedComponent.availableVersions || [];
       let defaultVersion = updatedComponent.version || 'latest';
 
       if (availableVersions.length > 0) {
-        if (availableVersions.includes('latest')) {
-          defaultVersion = 'latest';
-        } else if (availableVersions.includes('main')) {
-          defaultVersion = 'main';
-        } else if (availableVersions.includes('master')) {
-          defaultVersion = 'master';
-        } else {
-          defaultVersion = availableVersions[0];
+        defaultVersion = availableVersions.includes('latest') ? 'latest' : availableVersions[0];
+      }
+
+      // For a monorepo source, precompute display labels (full tag → stripped {version}) server-side, since the
+      // webview can't reach the template matcher. Non-monorepo sources send no labels (value == label).
+      let versionLabels: Record<string, string> | undefined;
+      if (updatedComponent.tagPattern) {
+        const matcher = compileTagTemplate(updatedComponent.tagPattern, componentName);
+        if (matcher) {
+          versionLabels = {};
+          for (const v of availableVersions) {
+            versionLabels[v] = matcher.extractVersion(v) ?? v;
+          }
         }
       }
 
@@ -2517,6 +2622,7 @@ ${sourceErrors.size > 0 ? '\nErrors:\n' + Array.from(sourceErrors.entries()).map
           componentName,
           sourcePath,
           versions: availableVersions,
+          versionLabels,
           defaultVersion
         });
       }

--- a/src/providers/componentBrowserTransform.ts
+++ b/src/providers/componentBrowserTransform.ts
@@ -10,6 +10,7 @@ import type {
   ProjectGroupBuilder,
   ComponentGroupBuilder,
 } from './componentBrowserTypes';
+import { compileTagTemplate } from '../services/component/tagScoping';
 
 /**
  * Convert a `https://host/group/project/name@version` component URL into the public GitLab project URL by stripping
@@ -63,15 +64,29 @@ export function versionPriority(version: string | undefined): number {
  * synthetic `'latest'` tag, resolve it by re-running the priority pass on the remaining versions so users land on a
  * pinned semver instead of the floating tag.
  *
- * @param availableVersions  Candidates. May include falsy entries (filtered out internally).
+ * @param availableVersions  Candidates. May include falsy entries (filtered out internally). For a monorepo source
+ *                           these are full tags (`<name>-1.1.0`, `apps/<name>/v1.1.0`).
  * @param fallback           Returned when `availableVersions` has no truthy entries.
+ * @param monorepoComponent  When set, candidates are scored with the tag-version template applied (the `{version}`
+ *                           capture), so monorepo tags rank by their underlying semver. The returned value is the
+ *                           original (full) tag.
  */
-export function selectDefaultVersion(availableVersions: string[], fallback: string): string {
+export function selectDefaultVersion(
+  availableVersions: string[],
+  fallback: string,
+  monorepoComponent?: { name: string; tagPattern?: string },
+): string {
   const validVersions = availableVersions.filter(Boolean);
   if (validVersions.length === 0) return fallback;
 
+  const matcher = monorepoComponent
+    ? compileTagTemplate(monorepoComponent.tagPattern, monorepoComponent.name)
+    : null;
+  const score = (version: string): number =>
+    versionPriority(matcher?.extractVersion(version) ?? version);
+
   const bestVersionString = validVersions.reduce(
-    (best, current) => (versionPriority(current) > versionPriority(best) ? current : best),
+    (best, current) => (score(current) > score(best) ? current : best),
     validVersions[0],
   );
 
@@ -81,7 +96,7 @@ export function selectDefaultVersion(availableVersions: string[], fallback: stri
   const nonLatestVersions = validVersions.filter((v) => v !== 'latest');
   if (nonLatestVersions.length === 0) return bestVersionString;
   return nonLatestVersions.reduce(
-    (best, current) => (versionPriority(current) > versionPriority(best) ? current : best),
+    (best, current) => (score(current) > score(best) ? current : best),
     nonLatestVersions[0],
   );
 }
@@ -169,6 +184,7 @@ export function transformCachedComponentsToGroups(
         versions: new Map(),
         defaultVersion: comp.version || 'latest',
         availableVersions: comp.availableVersions || [],
+        tagPattern: comp.tagPattern,
       };
       projectGroup.components.set(comp.name, componentGroup);
       sourceGroup.totalComponents++;
@@ -226,7 +242,13 @@ export function transformCachedComponentsToGroups(
           };
         });
 
-        const defaultVersion = selectDefaultVersion(availableVersions, component.defaultVersion || 'latest');
+        const defaultVersion = selectDefaultVersion(
+          availableVersions,
+          component.defaultVersion || 'latest',
+          component.tagPattern
+            ? { name: component.name, tagPattern: component.tagPattern }
+            : undefined,
+        );
 
         return {
           ...component,

--- a/src/providers/componentBrowserTypes.ts
+++ b/src/providers/componentBrowserTypes.ts
@@ -56,6 +56,11 @@ export interface ComponentGroupBuilder {
   versions: Map<string, ComponentVersion>;
   defaultVersion: string;
   availableVersions: string[];
+  /**
+   * The per-source tag-version template (e.g. `{name}-{version}`). Its presence marks a tag-per-component monorepo
+   * and drives prefix-stripped version labels.
+   */
+  tagPattern?: string;
 }
 
 // -----------------------------------------------------------------------------
@@ -101,6 +106,11 @@ export interface ComponentGroup {
   versionCount: number;
   defaultVersion: string;
   availableVersions: string[];
+  /**
+   * The per-source tag-version template (e.g. `{name}-{version}`). Its presence marks a tag-per-component monorepo
+   * and drives prefix-stripped version labels.
+   */
+  tagPattern?: string;
 }
 
 /**

--- a/src/services/cache/componentCacheManager.ts
+++ b/src/services/cache/componentCacheManager.ts
@@ -205,6 +205,7 @@ export class ComponentCacheManager {
           path: string;
           gitlabInstance?: string;
           type?: 'project' | 'group';
+          tagPattern?: string;
         }>
       >('componentSources', []);
 
@@ -242,21 +243,22 @@ export class ComponentCacheManager {
               'ComponentCache'
             );
 
-            if (sourceType === 'group') {
-              // Fetch all projects from the group and then get components from each
-              return await this.groupCache.fetchComponentsFromGroup(
-                gitlabInstance,
-                source.path,
-                source.name
-              );
-            } else {
-              // Original project-based fetching
-              return await this.projectCache.fetchComponentsFromProject(
-                gitlabInstance,
-                source.path,
-                source.name
-              );
+            const fetched =
+              sourceType === 'group'
+                ? // Fetch all projects from the group and then get components from each
+                  await this.groupCache.fetchComponentsFromGroup(gitlabInstance, source.path, source.name)
+                : // Original project-based fetching
+                  await this.projectCache.fetchComponentsFromProject(gitlabInstance, source.path, source.name);
+
+            // For a tag-per-component monorepo source, stamp its tag-version template onto each component so version
+            // discovery can scope tags to the component. Absent template = ordinary single-component repo.
+            if (source.tagPattern) {
+              for (const component of fetched) {
+                component.tagPattern = source.tagPattern;
+              }
             }
+
+            return fetched;
           } catch (error) {
             const errorMessage = error instanceof Error ? error.message : String(error);
             this.logger.error(

--- a/src/services/cache/versionCache.ts
+++ b/src/services/cache/versionCache.ts
@@ -1,7 +1,7 @@
 import { getComponentService } from '../component';
 import { compileTagTemplate, scopeTagsToComponent } from '../component/tagScoping';
 import { Logger } from '../../utils/logger';
-import { CachedComponent } from '../../types/cache';
+import { CachedComponent, VersionCacheSnapshot } from '../../types/cache';
 
 /**
  * VersionCache - Handles version fetching and caching for components
@@ -163,23 +163,36 @@ export class VersionCache {
   }
 
   /**
-   * Get serializable cache data for persistence
+   * Get serializable cache data for persistence.
    *
-   * @returns Array of [key, tags] tuples
+   * @returns Both per-project maps (tags and default branches) so they round-trip together across a restart.
    */
-  serializeCache(): Array<[string, string[]]> {
-    return Array.from(this.projectTagsCache.entries());
+  serializeCache(): VersionCacheSnapshot {
+    return {
+      tags: Array.from(this.projectTagsCache.entries()),
+      defaultBranches: Array.from(this.projectDefaultBranchCache.entries()),
+    };
   }
 
   /**
-   * Restore cache from serialized data
+   * Restore the version caches from serialized data.
    *
-   * @param data Array of [key, tags] tuples
+   * Accepts either a {@link VersionCacheSnapshot} object or a bare `Array<[key, tags]>`; the array form carries no
+   * default branches, so those stay empty until the next fetch.
+   *
+   * @param data The serialized snapshot, or a tags-only array.
    */
-  deserializeCache(data: Array<[string, string[]]>): void {
-    this.projectTagsCache = new Map(data);
+  deserializeCache(data: VersionCacheSnapshot | Array<[string, string[]]>): void {
+    if (Array.isArray(data)) {
+      this.projectTagsCache = new Map(data);
+      this.projectDefaultBranchCache = new Map();
+    } else {
+      this.projectTagsCache = new Map(data.tags);
+      this.projectDefaultBranchCache = new Map(data.defaultBranches);
+    }
     this.logger.debug(
-      `[VersionCache] Restored ${this.projectTagsCache.size} cached tag entries`,
+      `[VersionCache] Restored ${this.projectTagsCache.size} cached tag entries, ` +
+        `${this.projectDefaultBranchCache.size} default-branch entries`,
       'VersionCache'
     );
   }

--- a/src/services/cache/versionCache.ts
+++ b/src/services/cache/versionCache.ts
@@ -1,4 +1,5 @@
 import { getComponentService } from '../component';
+import { compileTagTemplate, scopeTagsToComponent } from '../component/tagScoping';
 import { Logger } from '../../utils/logger';
 import { CachedComponent } from '../../types/cache';
 
@@ -13,46 +14,60 @@ import { CachedComponent } from '../../types/cache';
  */
 export class VersionCache {
   private logger = Logger.getInstance();
-  // Cache for project versions: key = `${gitlabInstance}|${sourcePath}`
-  private projectVersionsCache: Map<string, string[]> = new Map();
+  // Cache for a project's raw tag names: key = `${gitlabInstance}|${sourcePath}`. Shared across every component in
+  // the project so the tag list is fetched once, then scoped per component for monorepo sources.
+  private projectTagsCache: Map<string, string[]> = new Map();
+  // Cache for a project's default branch name (e.g. `main`), keyed the same way. `null` means "looked up, none found".
+  private projectDefaultBranchCache: Map<string, string | null> = new Map();
 
   /**
-   * Fetch and cache all available versions for a specific component
+   * Fetch and cache all available versions for a specific component.
+   *
+   * The project's tag list is fetched once and cached per project. For a monorepo source (one carrying a
+   * `tagPattern`), the tags are then scoped to the component using that template so the component only
+   * surfaces its own releases; otherwise the full project tag list is used (single-component behaviour).
    *
    * @param component Component to fetch versions for
-   * @returns Array of sorted version strings
+   * @returns Array of sorted version strings (full prefixed tags for monorepo sources, plus `main`/`master`)
    */
   async fetchComponentVersions(component: CachedComponent): Promise<string[]> {
     try {
       const cacheKey = `${component.gitlabInstance}|${component.sourcePath}`;
-      let sortedVersions: string[] | undefined = this.projectVersionsCache.get(cacheKey);
+      let projectTags: string[] | undefined = this.projectTagsCache.get(cacheKey);
 
-      if (sortedVersions) {
+      if (projectTags) {
         this.logger.info(
-          `[VersionCache] [CACHE HIT] Reusing cached versions for project ${component.gitlabInstance}/${component.sourcePath}`,
+          `[VersionCache] [CACHE HIT] Reusing cached tags for project ${component.gitlabInstance}/${component.sourcePath}`,
           'VersionCache'
         );
       } else {
         const componentService = getComponentService();
-        const tags = await componentService.fetchProjectTags(
-          component.gitlabInstance,
-          component.sourcePath
-        );
-
-        // Extract version names and add common branch names
-        const versions = ['main', 'master', ...tags.map(tag => tag.name)];
-
-        // Remove duplicates and sort by priority
-        const uniqueVersions = Array.from(new Set(versions));
-        sortedVersions = this.sortVersionsByPriority(uniqueVersions);
-
-        this.projectVersionsCache.set(cacheKey, sortedVersions);
+        const [tags, defaultBranch] = await Promise.all([
+          componentService.fetchProjectTags(component.gitlabInstance, component.sourcePath),
+          componentService.fetchProjectDefaultBranch(component.gitlabInstance, component.sourcePath),
+        ]);
+        projectTags = tags.map(tag => tag.name).filter(Boolean);
+        this.projectTagsCache.set(cacheKey, projectTags);
+        this.projectDefaultBranchCache.set(cacheKey, defaultBranch);
 
         this.logger.info(
-          `[VersionCache] [API FETCH] Fetched ${sortedVersions.length} versions for project ${component.gitlabInstance}/${component.sourcePath}`,
+          `[VersionCache] [API FETCH] Fetched ${projectTags.length} tags for project ${component.gitlabInstance}/${component.sourcePath}`,
           'VersionCache'
         );
       }
+
+      const scopedTags = component.tagPattern
+        ? scopeTagsToComponent(projectTags, component.name, component.tagPattern)
+        : projectTags;
+
+      // Add the project's real default branch (if any); remove duplicates and sort by priority.
+      const defaultBranch = this.projectDefaultBranchCache.get(cacheKey);
+      const branches = defaultBranch ? [defaultBranch] : [];
+      const uniqueVersions = Array.from(new Set([...branches, ...scopedTags]));
+      const sortedVersions = this.sortVersionsByPriority(
+        uniqueVersions,
+        component.tagPattern ? component : undefined,
+      );
 
       this.logger.debug(
         `[VersionCache] Available versions for ${component.name}: ${sortedVersions
@@ -72,31 +87,51 @@ export class VersionCache {
   }
 
   /**
-   * Sort versions by priority (latest semantic versions first)
+   * Sort versions by priority (latest semantic versions first, branches last).
    *
    * Priority order:
-   * 1. main branch (priority 1000)
-   * 2. master branch (priority 900)
-   * 3. Semantic versions (vX.Y.Z) sorted by version number descending
-   * 4. Other versions (priority 0)
+   * 1. Semantic versions (vX.Y.Z) sorted by version number descending
+   * 2. main branch
+   * 3. master branch
+   * 4. Other versions
    *
    * @param versions Array of version strings
+   * @param monorepoComponent When set, each version is scored with its tag-version template applied (the `{version}`
+   *                          capture), so monorepo tags (`<name>-1.1.0`, `apps/<name>/v1.1.0`) rank by their
+   *                          underlying semver. The returned strings are the originals (full tags) — only the
+   *                          scoring strips.
    * @returns Sorted array with highest priority first
    */
-  sortVersionsByPriority(versions: string[]): string[] {
-    return versions.sort((a, b) => {
-      // Helper function to determine version priority
-      const versionPriority = (version: string) => {
-        if (version === 'main') return 1000;
-        if (version === 'master') return 900;
+  sortVersionsByPriority(
+    versions: string[],
+    monorepoComponent?: { name: string; tagPattern?: string },
+  ): string[] {
+    const matcher = monorepoComponent
+      ? compileTagTemplate(monorepoComponent.tagPattern, monorepoComponent.name)
+      : null;
+    const strip = (version: string): string => matcher?.extractVersion(version) ?? version;
 
-        // Semantic versions get priority based on version number
-        const semanticMatch = version.match(/^v?(\d+)\.(\d+)\.(\d+)/);
+    return versions.sort((a, b) => {
+      // Branch names sort below all semantic versions; `main`/`master` keep a fixed order above other branches.
+      const versionPriority = (version: string) => {
+        if (version === 'main') return 2;
+        if (version === 'master') return 1;
+
+        const stripped = strip(version);
+
+        // Full semantic versions get priority based on version number, well above the branch fallbacks.
+        const semanticMatch = stripped.match(/^v?(\d+)\.(\d+)\.(\d+)/);
         if (semanticMatch) {
           const major = parseInt(semanticMatch[1]);
           const minor = parseInt(semanticMatch[2]);
           const patch = parseInt(semanticMatch[3]);
-          return major * 1000000 + minor * 1000 + patch;
+          return 1000 + major * 1000000 + minor * 1000 + patch;
+        }
+
+        // A bare `<major>` (the floating monorepo major-alias tag) ranks just below that major's pinned releases.
+        const majorMatch = stripped.match(/^v?(\d+)$/);
+        if (majorMatch) {
+          return 1000 + parseInt(majorMatch[1]) * 1000000;
         }
 
         return 0; // Lowest priority for other versions
@@ -107,43 +142,44 @@ export class VersionCache {
   }
 
   /**
-   * Clear the project versions cache
+   * Clear the project tags and default-branch caches
    */
   clearCache(): void {
-    this.projectVersionsCache.clear();
-    this.logger.debug('[VersionCache] Cleared project versions cache', 'VersionCache');
+    this.projectTagsCache.clear();
+    this.projectDefaultBranchCache.clear();
+    this.logger.debug('[VersionCache] Cleared project tags cache', 'VersionCache');
   }
 
   /**
-   * Get cached project versions (if available)
+   * Get a project's cached raw tag names (if available)
    *
    * @param gitlabInstance GitLab instance hostname
    * @param sourcePath Project path
-   * @returns Cached versions or undefined if not cached
+   * @returns Cached tag names or undefined if not cached
    */
   getCachedVersions(gitlabInstance: string, sourcePath: string): string[] | undefined {
     const cacheKey = `${gitlabInstance}|${sourcePath}`;
-    return this.projectVersionsCache.get(cacheKey);
+    return this.projectTagsCache.get(cacheKey);
   }
 
   /**
    * Get serializable cache data for persistence
    *
-   * @returns Array of [key, versions] tuples
+   * @returns Array of [key, tags] tuples
    */
   serializeCache(): Array<[string, string[]]> {
-    return Array.from(this.projectVersionsCache.entries());
+    return Array.from(this.projectTagsCache.entries());
   }
 
   /**
    * Restore cache from serialized data
    *
-   * @param data Array of [key, versions] tuples
+   * @param data Array of [key, tags] tuples
    */
   deserializeCache(data: Array<[string, string[]]>): void {
-    this.projectVersionsCache = new Map(data);
+    this.projectTagsCache = new Map(data);
     this.logger.debug(
-      `[VersionCache] Restored ${this.projectVersionsCache.size} cached version entries`,
+      `[VersionCache] Restored ${this.projectTagsCache.size} cached tag entries`,
       'VersionCache'
     );
   }
@@ -158,8 +194,8 @@ export class VersionCache {
     keys: string[];
   } {
     return {
-      count: this.projectVersionsCache.size,
-      keys: Array.from(this.projectVersionsCache.keys()),
+      count: this.projectTagsCache.size,
+      keys: Array.from(this.projectTagsCache.keys()),
     };
   }
 }

--- a/src/services/component/componentService.ts
+++ b/src/services/component/componentService.ts
@@ -106,15 +106,44 @@ export class ComponentService implements ComponentSource {
   }
 
   // Version management delegation
+  /**
+   * Fetch all tags/versions for a GitLab project.
+   *
+   * @param gitlabInstance The GitLab instance hostname.
+   * @param projectPath The project path.
+   * @param scopeToComponent When set, the project is treated as a tag-per-component monorepo and tags are scoped to
+   *                         this component using `tagPattern` (full tags retained as the version strings).
+   * @param tagPattern The tag pattern for scoping (e.g. `{name}-{version}`); defaults to the house convention when
+   *                   omitted.
+   * @returns Array of version strings (tags and important branches).
+   */
   public async fetchProjectVersions(
     gitlabInstance: string,
-    projectPath: string
+    projectPath: string,
+    scopeToComponent?: string,
+    tagPattern?: string
   ): Promise<string[]> {
-    return this.versionManager.fetchProjectVersions(gitlabInstance, projectPath);
+    return this.versionManager.fetchProjectVersions(
+      gitlabInstance,
+      projectPath,
+      scopeToComponent,
+      tagPattern
+    );
   }
 
   public async fetchProjectTags(gitlabInstance: string, projectPath: string) {
     return this.versionManager.fetchProjectTags(gitlabInstance, projectPath);
+  }
+
+  /**
+   * Fetch a project's default branch name (e.g. `main`) from its project info.
+   *
+   * @param gitlabInstance The GitLab instance hostname.
+   * @param projectPath The project path; URL-encoded internally.
+   * @returns The default branch name, or null if it can't be resolved (network error, no access).
+   */
+  public async fetchProjectDefaultBranch(gitlabInstance: string, projectPath: string) {
+    return this.versionManager.fetchProjectDefaultBranch(gitlabInstance, projectPath);
   }
 
   /**

--- a/src/services/component/componentService.ts
+++ b/src/services/component/componentService.ts
@@ -111,24 +111,13 @@ export class ComponentService implements ComponentSource {
    *
    * @param gitlabInstance The GitLab instance hostname.
    * @param projectPath The project path.
-   * @param scopeToComponent When set, the project is treated as a tag-per-component monorepo and tags are scoped to
-   *                         this component using `tagPattern` (full tags retained as the version strings).
-   * @param tagPattern The tag pattern for scoping (e.g. `{name}-{version}`); defaults to the house convention when
-   *                   omitted.
    * @returns Array of version strings (tags and important branches).
    */
   public async fetchProjectVersions(
     gitlabInstance: string,
-    projectPath: string,
-    scopeToComponent?: string,
-    tagPattern?: string
+    projectPath: string
   ): Promise<string[]> {
-    return this.versionManager.fetchProjectVersions(
-      gitlabInstance,
-      projectPath,
-      scopeToComponent,
-      tagPattern
-    );
+    return this.versionManager.fetchProjectVersions(gitlabInstance, projectPath);
   }
 
   public async fetchProjectTags(gitlabInstance: string, projectPath: string) {

--- a/src/services/component/tagScoping.ts
+++ b/src/services/component/tagScoping.ts
@@ -1,0 +1,134 @@
+/**
+ * Pure helpers for monorepo tag scoping.
+ *
+ * In a tag-per-component monorepo, every component lives in `templates/<name>/` of a single GitLab project and its
+ * releases are git tags that embed the component name, e.g. `cloud-deploy-aws-ecs-1.1.0` or `apps/web/v2.0.0`. A
+ * single project therefore carries the tags of *all* its components mixed together, and the viewer needs to pick out
+ * the tags belonging to one component.
+ *
+ * The convention varies between teams, so the shape is described per-source by a **tag-version template** — a string
+ * with two tokens:
+ *  - `{name}`    — the component (== `templates/` directory) name.
+ *  - `{version}` — the version portion to surface; captured for display.
+ *
+ * Examples: `{name}-{version}` (our house style), `apps/{name}/v{version}`, `{name}_{version}`.
+ *
+ * A template compiles to a regex anchored at both ends: literal text is escaped, `{name}` becomes the (escaped)
+ * component name, and `{version}` becomes a capture group that must start with a digit (`\d.*`). The digit anchor
+ * stops a component whose name is a prefix of another's (`docker-publish` vs `docker-publish-extra`) from capturing
+ * the sibling's tags.
+ *
+ * The **full tag** is always retained as the canonical ref — it is what GitLab resolves an include against; the
+ * `{version}` capture is presentation only.
+ *
+ * Kept free of `vscode`/`HttpClient` imports so the unit suite can exercise them directly.
+ */
+
+/** The default template — used as the fallback when a source's `tagPattern` is set but empty. */
+export const DEFAULT_TAG_PATTERN = '{name}-{version}';
+
+/** A template compiled against a specific component name, ready to test/strip that component's tags. */
+export interface TagMatcher {
+  /** Returns true if `tag` belongs to this component under the template. */
+  matches(tag: string): boolean;
+  /** Returns the `{version}` capture for `tag`, or `null` if it doesn't match. */
+  extractVersion(tag: string): string | null;
+}
+
+const NAME_TOKEN = '{name}';
+const VERSION_TOKEN = '{version}';
+
+/**
+ * Escape a string for safe literal use inside a `RegExp`.
+ *
+ * @param value The raw string (e.g. a component name or a template literal slice).
+ * @returns The string with all regex metacharacters backslash-escaped, so it matches itself literally.
+ */
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Compile a tag-version template into a {@link TagMatcher} bound to one component name.
+ *
+ * The template must contain `{version}`; `{name}` is optional but normally present. Everything else is treated as
+ * literal text (regex-escaped). `{version}` compiles to `(\d.*)` so a matched version always begins with a digit.
+ *
+ * @param template      The per-source template, e.g. `{name}-{version}`. Falls back to {@link DEFAULT_TAG_PATTERN}.
+ * @param componentName The component name substituted for `{name}`.
+ * @returns A matcher, or `null` if the template is malformed (missing `{version}`) — callers should treat `null` as
+ *          "not a monorepo source" and fall back to using the full tag list.
+ */
+export function compileTagTemplate(
+  template: string | undefined,
+  componentName: string,
+): TagMatcher | null {
+  const tmpl = template && template.length > 0 ? template : DEFAULT_TAG_PATTERN;
+  if (!tmpl.includes(VERSION_TOKEN)) return null;
+
+  // Build the regex by escaping the literal slices around the tokens, substituting the (escaped) name and a version
+  // capture group. Splitting on the tokens keeps surrounding literals (separators, `apps/`, `v`, …) intact.
+  let pattern = '^';
+  let rest = tmpl;
+  while (rest.length > 0) {
+    const nameAt = rest.indexOf(NAME_TOKEN);
+    const versionAt = rest.indexOf(VERSION_TOKEN);
+
+    // No more tokens — append the trailing literal and stop.
+    if (nameAt === -1 && versionAt === -1) {
+      pattern += escapeRegExp(rest);
+      break;
+    }
+
+    // Whichever token comes first.
+    const useName = nameAt !== -1 && (versionAt === -1 || nameAt < versionAt);
+    const at = useName ? nameAt : versionAt;
+    const token = useName ? NAME_TOKEN : VERSION_TOKEN;
+
+    pattern += escapeRegExp(rest.slice(0, at));
+    pattern += useName ? escapeRegExp(componentName) : '(\\d.*)';
+    rest = rest.slice(at + token.length);
+  }
+  pattern += '$';
+
+  const regex = new RegExp(pattern);
+
+  return {
+    matches: (tag: string): boolean => regex.test(tag),
+    extractVersion: (tag: string): string | null => {
+      const m = regex.exec(tag);
+      return m ? m[1] ?? null : null;
+    },
+  };
+}
+
+/**
+ * Filter a project's full tag list down to the tags belonging to a single component, under the given template.
+ *
+ * @param allTagNames  Every tag name in the project.
+ * @param componentName The component name to scope to.
+ * @param template     The per-source tag-version template. Defaults to {@link DEFAULT_TAG_PATTERN}.
+ * @returns The subset of tag names belonging to this component, order preserved. Empty if the template is malformed.
+ */
+export function scopeTagsToComponent(
+  allTagNames: readonly string[],
+  componentName: string,
+  template?: string,
+): string[] {
+  const matcher = compileTagTemplate(template, componentName);
+  if (!matcher) return [];
+  return allTagNames.filter((tag) => matcher.matches(tag));
+}
+
+/**
+ * Strip a tag down to its `{version}` portion for display. Tags that don't match the template (e.g. branch names
+ * like `main`) are returned verbatim.
+ *
+ * @param tag           The full tag.
+ * @param componentName The component name substituted for `{name}`.
+ * @param template      The per-source tag-version template. Defaults to {@link DEFAULT_TAG_PATTERN}.
+ */
+export function stripTagPrefix(tag: string, componentName: string, template?: string): string {
+  const matcher = compileTagTemplate(template, componentName);
+  return matcher?.extractVersion(tag) ?? tag;
+}

--- a/src/services/component/versionManager.ts
+++ b/src/services/component/versionManager.ts
@@ -1,7 +1,6 @@
 import { Logger } from '../../utils/logger';
 import { HttpClient } from '../../utils/httpClient';
 import { TokenManager } from './tokenManager';
-import { scopeTagsToComponent } from './tagScoping';
 import type { GitLabProjectInfo, GitLabTag, GitLabBranch } from '../../types/api';
 import { NetworkError } from '../../errors';
 
@@ -22,17 +21,11 @@ export class VersionManager {
    * Fetch all tags/versions for a GitLab project with optimizations
    * @param gitlabInstance The GitLab instance hostname
    * @param projectPath The project path
-   * @param scopeToComponent When set, the project is treated as a tag-per-component monorepo and tags are scoped to
-   *                         this component using `tagPattern` (full tags retained as the version strings).
-   * @param tagPattern The tag-version template for scoping (e.g. `{name}-{version}`); defaults to the house
-   *                           convention when omitted.
    * @returns Array of version strings (tags and important branches)
    */
   public async fetchProjectVersions(
     gitlabInstance: string,
-    projectPath: string,
-    scopeToComponent?: string,
-    tagPattern?: string
+    projectPath: string
   ): Promise<string[]> {
     const startTime = Date.now();
 
@@ -76,12 +69,9 @@ export class VersionManager {
 
       // Process tags
       if (tagsResult.status === 'fulfilled' && Array.isArray(tagsResult.value)) {
-        const tagNames = tagsResult.value
+        const tagVersions = tagsResult.value
           .map(tag => tag.name)
           .filter(name => name);
-        const tagVersions = scopeToComponent
-          ? scopeTagsToComponent(tagNames, scopeToComponent, tagPattern)
-          : tagNames;
         versions.push(...tagVersions);
         this.logger.debug(`Found ${tagVersions.length} tags`);
       } else {

--- a/src/services/component/versionManager.ts
+++ b/src/services/component/versionManager.ts
@@ -1,6 +1,7 @@
 import { Logger } from '../../utils/logger';
 import { HttpClient } from '../../utils/httpClient';
 import { TokenManager } from './tokenManager';
+import { scopeTagsToComponent } from './tagScoping';
 import type { GitLabProjectInfo, GitLabTag, GitLabBranch } from '../../types/api';
 import { NetworkError } from '../../errors';
 
@@ -21,11 +22,17 @@ export class VersionManager {
    * Fetch all tags/versions for a GitLab project with optimizations
    * @param gitlabInstance The GitLab instance hostname
    * @param projectPath The project path
+   * @param scopeToComponent When set, the project is treated as a tag-per-component monorepo and tags are scoped to
+   *                         this component using `tagPattern` (full tags retained as the version strings).
+   * @param tagPattern The tag-version template for scoping (e.g. `{name}-{version}`); defaults to the house
+   *                           convention when omitted.
    * @returns Array of version strings (tags and important branches)
    */
   public async fetchProjectVersions(
     gitlabInstance: string,
-    projectPath: string
+    projectPath: string,
+    scopeToComponent?: string,
+    tagPattern?: string
   ): Promise<string[]> {
     const startTime = Date.now();
 
@@ -69,9 +76,12 @@ export class VersionManager {
 
       // Process tags
       if (tagsResult.status === 'fulfilled' && Array.isArray(tagsResult.value)) {
-        const tagVersions = tagsResult.value
+        const tagNames = tagsResult.value
           .map(tag => tag.name)
           .filter(name => name);
+        const tagVersions = scopeToComponent
+          ? scopeTagsToComponent(tagNames, scopeToComponent, tagPattern)
+          : tagNames;
         versions.push(...tagVersions);
         this.logger.debug(`Found ${tagVersions.length} tags`);
       } else {
@@ -152,6 +162,31 @@ export class VersionManager {
     } catch (error) {
       this.logger.warn(`Error fetching tags: ${error}`);
       return [];
+    }
+  }
+
+  /**
+   * Fetch a project's default branch name (e.g. `main`) from its project info.
+   *
+   * @param gitlabInstance The GitLab instance hostname.
+   * @param projectPath The project path; URL-encoded internally.
+   * @returns The default branch name, or null if it can't be resolved (network error, no access).
+   */
+  public async fetchProjectDefaultBranch(
+    gitlabInstance: string,
+    projectPath: string
+  ): Promise<string | null> {
+    try {
+      const apiUrl = `https://${gitlabInstance}/api/v4/projects/${encodeURIComponent(projectPath)}`;
+      const token = await this.tokenManager.getTokenForProject(gitlabInstance);
+      const options = token ? { headers: { 'PRIVATE-TOKEN': token } } : undefined;
+      const projectInfo = await this.httpClient.fetchJson<GitLabProjectInfo>(apiUrl, options);
+      return projectInfo?.default_branch || null;
+    } catch (error) {
+      this.logger.debug(
+        `[VersionManager] Could not resolve default branch for ${projectPath}: ${error}`
+      );
+      return null;
     }
   }
 

--- a/src/types/cache.ts
+++ b/src/types/cache.ts
@@ -104,6 +104,12 @@ export interface CachedComponent {
   cachedAt?: number;
   /** Authoritative ref classification for this entry, resolved once against GitLab and persisted. */
   refType?: RefType;
+  /**
+   * The per-source tag-version template (e.g. `{name}-{version}`, `apps/{name}/v{version}`) used to scope and strip
+   * this component's tags. Its presence marks the source as a tag-per-component monorepo; absent means an ordinary
+   * single-component repository whose tags are listed as-is.
+   */
+  tagPattern?: string;
 }
 
 /**

--- a/src/types/cache.ts
+++ b/src/types/cache.ts
@@ -113,11 +113,22 @@ export interface CachedComponent {
 }
 
 /**
+ * Serialized form of the per-project version caches, persisted in global state.
+ *
+ * Holds both maps so they survive a session restart together: the raw tag list and the resolved default branch.
+ */
+export interface VersionCacheSnapshot {
+  tags: Array<[string, string[]]>;
+  defaultBranches: Array<[string, string | null]>;
+}
+
+/**
  * Persistent cache data structure stored in global state
  */
 export interface PersistentCacheData {
   components: CachedComponent[];
   lastRefreshTime: number;
-  projectVersionsCache: Array<[string, string[]]>;
+  /** Serialized version caches. A bare `Array<[key, tags]>` is also accepted on read (no default branches). */
+  projectVersionsCache: VersionCacheSnapshot | Array<[string, string[]]>;
   version: string;
 }

--- a/tests/unit/tagScoping.test.ts
+++ b/tests/unit/tagScoping.test.ts
@@ -1,0 +1,138 @@
+// @mocha
+/**
+ * Tests src/services/component/tagScoping.ts — the pure helpers that turn a monorepo project's full tag list into a
+ * per-component view via a configurable tag-version template (`{name}`/`{version}` tokens): scoping a project's tags
+ * to one component and stripping each tag down to its `{version}` for display.
+ *
+ * Also covers the monorepo branch of componentBrowserTransform.selectDefaultVersion, which scores tags by the
+ * template's `{version}` capture.
+ */
+
+import * as assert from 'node:assert/strict';
+import {
+  compileTagTemplate,
+  scopeTagsToComponent,
+  stripTagPrefix,
+  DEFAULT_TAG_PATTERN,
+} from '../../src/services/component/tagScoping';
+import { selectDefaultVersion } from '../../src/providers/componentBrowserTransform';
+
+// A realistic mixed tag list for a tag-per-component monorepo using the default `{name}-{version}` convention.
+const ALL_TAGS = [
+  'deploy-app-1',
+  'deploy-app-1.0.0',
+  'deploy-app-1.1.0',
+  'deploy-app-2',
+  'deploy-app-2.0.0',
+  'deploy-app-2.1.0',
+  'run-job-1',
+  'run-job-1.0.0',
+  'push-artifact-1.0.0',
+  'push-artifact-4.0.0',
+  'build-image-4',
+  'build-image-4.0.0',
+];
+
+suite('scopeTagsToComponent — default template', () => {
+  test('keeps only the tags belonging to the component', () => {
+    assert.deepStrictEqual(scopeTagsToComponent(ALL_TAGS, 'deploy-app'), [
+      'deploy-app-1',
+      'deploy-app-1.0.0',
+      'deploy-app-1.1.0',
+      'deploy-app-2',
+      'deploy-app-2.0.0',
+      'deploy-app-2.1.0',
+    ]);
+  });
+
+  test('digit-anchored {version} stops a shorter name capturing a longer sibling component', () => {
+    // `build-image` must NOT pick up `build-image-extra-1.0.0`: the char after the prefix is `e`, not a digit.
+    const tags = ['build-image-4.0.0', 'build-image-extra-1.0.0', 'build-image-4'];
+    assert.deepStrictEqual(scopeTagsToComponent(tags, 'build-image'), [
+      'build-image-4.0.0',
+      'build-image-4',
+    ]);
+  });
+
+  test('returns empty when no tags match', () => {
+    assert.deepStrictEqual(scopeTagsToComponent(ALL_TAGS, 'no-such-component'), []);
+  });
+});
+
+suite('scopeTagsToComponent — custom templates', () => {
+  test('apps/{name}/v{version} layout', () => {
+    const tags = ['apps/web/v1.0.0', 'apps/web/v2.0.0', 'apps/api/v1.0.0', 'apps/web/vbeta'];
+    // `vbeta` fails the digit anchor (char after `v` is `b`), so it is excluded.
+    assert.deepStrictEqual(scopeTagsToComponent(tags, 'web', 'apps/{name}/v{version}'), [
+      'apps/web/v1.0.0',
+      'apps/web/v2.0.0',
+    ]);
+  });
+
+  test('{name}_{version} separator', () => {
+    const tags = ['web_1.0.0', 'web_2.0.0', 'web-extra_1.0.0', 'api_1.0.0'];
+    assert.deepStrictEqual(scopeTagsToComponent(tags, 'web', '{name}_{version}'), ['web_1.0.0', 'web_2.0.0']);
+  });
+
+  test('regex metacharacters in literals and names are escaped', () => {
+    // A `.` in the template literal must match a literal dot, not any char; a name with regex chars is escaped too.
+    const tags = ['c++.1.0.0', 'cXX.1.0.0'];
+    assert.deepStrictEqual(scopeTagsToComponent(tags, 'c++', '{name}.{version}'), ['c++.1.0.0']);
+  });
+});
+
+suite('compileTagTemplate', () => {
+  test('returns null for a template missing {version}', () => {
+    assert.strictEqual(compileTagTemplate('{name}-only', 'web'), null);
+  });
+
+  test('falls back to the default template when none is given', () => {
+    const matcher = compileTagTemplate(undefined, 'web');
+    assert.ok(matcher);
+    assert.strictEqual(matcher.matches('web-1.0.0'), true);
+    assert.strictEqual(DEFAULT_TAG_PATTERN, '{name}-{version}');
+  });
+
+  test('extractVersion returns the {version} capture or null', () => {
+    const matcher = compileTagTemplate('apps/{name}/v{version}', 'web');
+    assert.ok(matcher);
+    assert.strictEqual(matcher.extractVersion('apps/web/v1.2.3'), '1.2.3');
+    assert.strictEqual(matcher.extractVersion('apps/api/v1.2.3'), null);
+  });
+});
+
+suite('stripTagPrefix', () => {
+  test('returns the {version} portion under the default template', () => {
+    assert.strictEqual(stripTagPrefix('deploy-app-1.1.0', 'deploy-app'), '1.1.0');
+    assert.strictEqual(stripTagPrefix('build-image-4', 'build-image'), '4');
+  });
+
+  test('returns the {version} portion under a custom template', () => {
+    assert.strictEqual(stripTagPrefix('apps/web/v2.0.0', 'web', 'apps/{name}/v{version}'), '2.0.0');
+  });
+
+  test('passes non-matching strings through unchanged', () => {
+    assert.strictEqual(stripTagPrefix('main', 'build-image'), 'main');
+  });
+});
+
+suite('selectDefaultVersion — monorepo', () => {
+  const scoped = scopeTagsToComponent(ALL_TAGS, 'deploy-app');
+
+  test('picks the highest full semver (scored by {version}), returning the full tag', () => {
+    const chosen = selectDefaultVersion(scoped, 'main', { name: 'deploy-app' });
+    assert.strictEqual(chosen, 'deploy-app-2.1.0');
+  });
+
+  test('works with a custom template', () => {
+    const tags = ['apps/web/v1.0.0', 'apps/web/v2.3.0', 'apps/web/v2.1.0'];
+    const chosen = selectDefaultVersion(tags, 'main', { name: 'web', tagPattern: 'apps/{name}/v{version}' });
+    assert.strictEqual(chosen, 'apps/web/v2.3.0');
+  });
+
+  test('without a monorepo component the tags score 0 (regression guard for the flag plumbing)', () => {
+    // Full prefixed tags fail the bare-semver regex, so the reduce keeps the first element.
+    const chosen = selectDefaultVersion(scoped, 'main');
+    assert.strictEqual(chosen, scoped[0]);
+  });
+});


### PR DESCRIPTION
## Summary
- Makes version discovery **monorepo-aware**. In a tag-per-component monorepo, one project carries every component's tags (e.g. `deploy-app-1.1.0`, `build-image-4.0.0`). Previously every component's dropdown listed *all* repo tags, unscoped and unstripped, with a meaningless version count and broken default selection.
- **New per-source tag-version template.** A source can declare `tagPattern` (e.g. `{name}-{version}`, `apps/{name}/v{version}`, `{name}_{version}`) using two tokens: `{name}` (the component/directory name) and `{version}` (the version shown; matches anything starting with a digit). Its presence enables monorepo scoping; leaving it unset means an ordinary single-component repo, unchanged.
- **New pure matcher** (`src/services/component/tagScoping.ts`): `compileTagTemplate(template, name)` compiles a template to an anchored regex (literals escaped, `{name}` → the escaped component name, `{version}` → a `(\d.*)` capture). `scopeTagsToComponent` and `stripTagPrefix` delegate to it. The digit anchor stops a component whose name is a prefix of another's (`build-image` vs `build-image-extra`) from capturing the sibling's tags.
- **Wired through discovery and UI**: the template flows from the source config → `CachedComponent` → version discovery (`versionCache.ts`), default-version scoring (`componentBrowserTransform.ts`), and all three version dropdowns — Component Browser, browser **Details** panel, and editor-**hover** details panel (`componentBrowserProvider.ts`, `extension.ts`). Option **values** stay the full tag (the inserted ref); only **labels** are stripped.
- **Default-branch fix**: the dropdown previously hard-coded `main` *and* `master`. It now lists only the repo's real `default_branch` (new `fetchProjectDefaultBranch`), so phantom branches no longer appear.
- Link related issue(s): Fixes #170

## Change Type
- [x] feat
- [x] fix
- [ ] refactor
- [ ] docs
- [x] test
- [ ] chore

## Context
### User-facing impact
- Sources flagged as monorepos show each component **only its own versions**, prefix-stripped (`2.1.0`, not `deploy-app-2.1.0`), with an accurate version count and a sensible default (highest semver of that component).
- The inserted include ref is unchanged in form — the full tag, e.g. `…/deploy-app@deploy-app-2.1.0`.
- Scoping is consistent across the Component Browser, the browser details panel, and the editor-hover details panel.
- The version dropdown no longer lists a `master` branch that doesn't exist; it shows the repo's real default branch.
- No change for ordinary single-component sources (no `tagPattern`).

### GitLab scope
- [ ] gitlab.com
- [ ] self-managed GitLab
- [x] both (template/scoping logic is instance-independent; default branch comes from the standard project-info API)

### Affected areas
- [x] Component Browser
- [x] Hover provider
- [ ] Completion provider
- [ ] Validation provider
- [x] Cache and refresh behavior
- [x] GitLab API calls/auth/token storage
- [ ] Docs only

## Validation
### Local checks
- [x] `npm run compile`
- [x] `npm test` or targeted tests
- [x] Manual verification in VS Code Extension Host

### Manual test notes
Against a tag-per-component monorepo (dozens of components) with:
```jsonc
"gitlabComponentHelper.componentSources": [
  {
    "name": "Shared CI",
    "path": "my-group/shared-ci",
    "gitlabInstance": "gitlab.com",
    "tagPattern": "{name}-{version}"
  }
]
```
Observed after **Reset Cache** + reload:
- `deploy-app` shows only its `1.x`/`2.x` tags (labelled `2.1.0`, `2.0.0`, …); `build-image` shows only its `4.x` tags. Counts match.
- Inserting `2.1.0` writes `…/deploy-app@deploy-app-2.1.0`.
- The **Details** panel and the **editor-hover** details panel (triggered from an `include:` in a `.gitlab-ci.yml`) both show the same scoped, stripped list.
- Only the real default branch appears (no `master`).
- Custom templates exercised in unit tests: `apps/{name}/v{version}`, `{name}_{version}`.
- A source without `tagPattern` still lists all tags exactly as before.

Unit tests in `tests/unit/tagScoping.test.ts` cover the default and custom templates, regex-metacharacter escaping, the digit-anchor sibling-collision guard, malformed templates (missing `{version}` → no match), and template-aware default selection. Full suite: 221 passing.

## Breaking Changes
- [x] No breaking changes

New settings are additive and opt-in. The persisted version-cache shape gains a `defaultBranches` map, but `deserializeCache` still reads the previous tags-only array form, so no cache-version bump is needed and no user action is required.

## Risk and Rollback
- Main risks:
  - A custom template that's too greedy could over-match a sibling component's tags. Mitigated by the digit-anchored `{version}` and documented in the README.
  - One extra lightweight API call per project to read `default_branch` (cached per project alongside tags).
- Rollback strategy: revert the PR. The settings are opt-in, so reverting only removes the scoping; no data migration. A reverted build's `deserializeCache` can't read this PR's object-shaped snapshot, but that failure is caught in `loadCacheFromDisk`'s try/catch — the cache is treated as empty and refetched on next load, so the revert is safe.

## Release Notes Draft
- Monorepo support: scope each component's version dropdown to its own tags via a per-source `tagPattern`; the version picker now also shows only the repo's real default branch.

## Checklist
- [x] Branch is up to date with target branch
- [x] Commit messages follow conventional commits
- [x] Added/updated docs for behavior or settings changes
- [x] Added/updated tests for new behavior
- [x] No secrets or tokens in code, logs, screenshots, or test fixtures
