### PR TITLE
fix: validation diagnostics mis-anchored when one file includes the same component/template twice

### DIFF
--- a/src/providers/validationProvider.ts
+++ b/src/providers/validationProvider.ts
@@ -11,25 +11,14 @@ import { resolveLocalComponent, isUnsupportedLocalPath } from './localComponentR
 import { attachDiagnosticMetadata, readDiagnosticMetadata } from './validationMetadata';
 import type { MissingRequiredInputMetadata } from './validationMetadata';
 import type { GitApi, GitRepository } from '../types/vscode-git';
-
-/**
- * A `.gitlab-ci.yml` include entry that this provider validates. Either a remote `component:` URL
- * or a `local:` path; both branches carry an optional `inputs` mapping. Built by narrowing a parsed
- * YAML node — fields outside the union (anything else under the include) are intentionally not modelled.
- */
-type ComponentInclude = { component: string; local?: undefined; inputs?: Record<string, unknown> };
-type LocalInclude = { local: string; component?: undefined; inputs?: Record<string, unknown> };
-type IncludeEntry = ComponentInclude | LocalInclude;
-
-/** Narrow a parsed YAML value to an {@link IncludeEntry} (string-typed `component` or `local`). */
-function isIncludeEntry(value: unknown): value is IncludeEntry {
-    if (!isYamlNode(value)) {
-        return false;
-    }
-    const hasComponent = typeof value.component === 'string';
-    const hasLocal = typeof value.local === 'string';
-    return hasComponent !== hasLocal; // exactly one of the two
-}
+import {
+    type IncludeEntry,
+    type LocalInclude,
+    isIncludeEntry,
+    isLocalInclude,
+    includeKeyAndUrl,
+    includeLineMatches,
+} from '../utils/includeMatcher';
 
 export class ValidationProvider implements vscode.CodeActionProvider {
     private diagnosticCollection: vscode.DiagnosticCollection;
@@ -137,8 +126,8 @@ export class ValidationProvider implements vscode.CodeActionProvider {
 
         for (let includeIndex = 0; includeIndex < includes.length; includeIndex++) {
             const include = includes[includeIndex];
-            if (include.local && !include.component) {
-                await this.validateLocalInclude(document, include, diagnostics, diagnosticKeys);
+            if (isLocalInclude(include)) {
+                await this.validateLocalInclude(document, include, includes, includeIndex, diagnostics, diagnosticKeys);
                 continue;
             }
             if (include.component) {
@@ -174,7 +163,7 @@ export class ValidationProvider implements vscode.CodeActionProvider {
                             let diagnosticMessage = `Component URL contains unresolved GitLab variables: '${componentUrl}'. `;
                             diagnosticMessage += `This project is hosted on ${nonGitlabInfo.hostname}, not GitLab. GitLab Component Helper requires a GitLab repository to resolve CI/CD variables like $CI_SERVER_FQDN and $CI_PROJECT_PATH.`;
 
-                            const line = this.findLineForComponent(document, include);
+                            const line = this.findLineForComponent(document, includes, includeIndex);
                             const range = new vscode.Range(line, 0, line, document.lineAt(line).text.length);
 
                             const diagnostic = new vscode.Diagnostic(
@@ -208,7 +197,7 @@ export class ValidationProvider implements vscode.CodeActionProvider {
                     if (containsGitLabVariables(expandedUrl) || expandedUrl.includes('undefined') || expandedUrl === componentUrl) {
                         this.logger.debug(`[ValidationProvider] URL expansion failed or incomplete: ${expandedUrl}`, 'ValidationProvider');
 
-                        const line = this.findLineForComponent(document, include);
+                        const line = this.findLineForComponent(document, includes, includeIndex);
                         const range = new vscode.Range(line, 0, line, document.lineAt(line).text.length);
 
                         const diagnostic = new vscode.Diagnostic(
@@ -286,7 +275,7 @@ export class ValidationProvider implements vscode.CodeActionProvider {
                 // If component fetch failed, add a single diagnostic about the fetch failure
                 // instead of showing "unknown input" warnings for all inputs
                 if (componentFetchFailed) {
-                    const line = this.findLineForComponent(document, include);
+                    const line = this.findLineForComponent(document, includes, includeIndex);
                     const range = new vscode.Range(line, 0, line, document.lineAt(line).text.length);
 
                     const diagnostic = new vscode.Diagnostic(
@@ -344,7 +333,7 @@ export class ValidationProvider implements vscode.CodeActionProvider {
 
                     for (const providedInput in providedInputs) {
                         if (!componentInputs.some(p => p.name === providedInput)) {
-                            const line = this.findLineForInput(document, include, providedInput);
+                            const line = this.findLineForInput(document, includes, includeIndex, providedInput);
 
                             // Create a unique key to prevent duplicate diagnostics for the same input
                             const diagnosticKey = `unknown-input-${line}-${providedInput}-${componentUrl}`;
@@ -398,7 +387,7 @@ export class ValidationProvider implements vscode.CodeActionProvider {
 
                     for (const componentInput of componentInputs) {
                         if (componentInput.required && !Object.prototype.hasOwnProperty.call(providedInputs, componentInput.name)) {
-                            const line = this.findLineForComponent(document, include);
+                            const line = this.findLineForComponent(document, includes, includeIndex);
                             const range = new vscode.Range(line, 0, line, document.lineAt(line).text.length);
                             const diagnostic = new vscode.Diagnostic(
                                 range,
@@ -826,22 +815,31 @@ export class ValidationProvider implements vscode.CodeActionProvider {
         return actions;
     }
 
-    private findLineForInput(document: vscode.TextDocument, include: IncludeEntry, inputName: string): number {
-        const text = document.getText();
-        const lines = text.split('\n');
-        const componentLine = this.findLineForComponent(document, include);
+    private findLineForInput(
+        document: vscode.TextDocument,
+        includes: IncludeEntry[],
+        includeIndex: number,
+        inputName: string
+    ): number {
+        const lines = document.getText().split('\n');
+        const componentLine = this.findLineForComponent(document, includes, includeIndex);
+        const nextIncludeLine = this.findLineForNextInclude(document, includes, includeIndex, componentLine);
 
-        this.logger.debug(`[ValidationProvider] Finding line for input '${inputName}', component line: ${componentLine}`, 'ValidationProvider');
+        this.logger.debug(`[ValidationProvider] Finding line for input '${inputName}', component line: ${componentLine}, bounded by next include at ${nextIncludeLine}`, 'ValidationProvider');
 
-        for (let i = componentLine + 1; i < lines.length; i++) {
+        // Two bounds keep the scan inside this include's own inputs block:
+        //  - nextIncludeLine caps it before a sibling that may share input names (two includes of one component).
+        //  - the indent break ends it at the first non-indented line, so it can't bleed into a top-level section
+        //    (a job, `variables:`, etc.) below the last include, where nextIncludeLine is just end-of-file.
+        for (let i = componentLine + 1; i < nextIncludeLine; i++) {
             if (lines[i].includes('inputs:')) {
                 this.logger.debug(`[ValidationProvider] Found inputs section at line ${i}`, 'ValidationProvider');
-                for (let j = i + 1; j < lines.length; j++) {
+                for (let j = i + 1; j < nextIncludeLine; j++) {
                     if (lines[j].includes(`${inputName}:`)) {
                         this.logger.debug(`[ValidationProvider] Found input '${inputName}' at line ${j}`, 'ValidationProvider');
                         return j;
                     }
-                    if (!lines[j].match(/^\s+/)) {
+                    if (!/^\s/.test(lines[j]) && lines[j].trim() !== '') {
                         break;
                     }
                 }
@@ -860,8 +858,10 @@ export class ValidationProvider implements vscode.CodeActionProvider {
      *
      * @param document        The document being validated — used to read line text for diagnostic ranges and to
      *                        anchor workspace-relative path resolution.
-     * @param include         The parsed YAML include node, narrowed to the local-include shape: `local` is the
-     *                        workspace-relative path, `inputs` is the optional user-supplied input map.
+     * @param include         This local include, already narrowed to {@link LocalInclude} by the caller.
+     * @param includes        The full parsed include list, in document order. Passed alongside `includeIndex` so the
+     *                        line-finders can disambiguate this entry from siblings that share its path.
+     * @param includeIndex    This entry's position in `includes` (i.e. `includes[includeIndex] === include`).
      * @param diagnostics     Accumulator array. New diagnostics are pushed onto it; the caller owns publishing
      *                        the final list to the diagnostic collection.
      * @param diagnosticKeys  Dedup set shared across the whole validation pass. Prevents duplicate
@@ -871,7 +871,9 @@ export class ValidationProvider implements vscode.CodeActionProvider {
      */
     private async validateLocalInclude(
         document: vscode.TextDocument,
-        include: { local: string; inputs?: Record<string, unknown> },
+        include: LocalInclude,
+        includes: IncludeEntry[],
+        includeIndex: number,
         diagnostics: vscode.Diagnostic[],
         diagnosticKeys: Set<string>
     ): Promise<void> {
@@ -885,7 +887,7 @@ export class ValidationProvider implements vscode.CodeActionProvider {
 
         const component = await resolveLocalComponent(localPath, document);
         if (!component) {
-            const line = this.findLineForComponent(document, include);
+            const line = this.findLineForComponent(document, includes, includeIndex);
             const range = new vscode.Range(line, 0, line, document.lineAt(line).text.length);
             const diagnostic = new vscode.Diagnostic(
                 range,
@@ -910,7 +912,7 @@ export class ValidationProvider implements vscode.CodeActionProvider {
             if (componentInputs.some(p => p.name === providedInput)) {
                 continue;
             }
-            const line = this.findLineForInput(document, include, providedInput);
+            const line = this.findLineForInput(document, includes, includeIndex, providedInput);
             const diagnosticKey = `unknown-input-${line}-${providedInput}-${localPath}`;
             if (diagnosticKeys.has(diagnosticKey)) continue;
             diagnosticKeys.add(diagnosticKey);
@@ -941,7 +943,7 @@ export class ValidationProvider implements vscode.CodeActionProvider {
 
         for (const componentInput of componentInputs) {
             if (componentInput.required && !Object.prototype.hasOwnProperty.call(providedInputs, componentInput.name)) {
-                const line = this.findLineForComponent(document, include);
+                const line = this.findLineForComponent(document, includes, includeIndex);
                 const range = new vscode.Range(line, 0, line, document.lineAt(line).text.length);
                 const diagnostic = new vscode.Diagnostic(
                     range,
@@ -964,23 +966,80 @@ export class ValidationProvider implements vscode.CodeActionProvider {
         }
     }
 
-    private findLineForComponent(document: vscode.TextDocument, include: IncludeEntry): number {
-        const text = document.getText();
-        const lines = text.split('\n');
-        const componentUrl = include.component ?? include.local;
-        const includeKey = include.component ? 'component:' : 'local:';
+    /**
+     * Locate the document line of the include entry at {@link includeIndex}.
+     *
+     * Two include entries can share an identical key+URL (e.g. the same component included twice with different
+     * inputs). Matching on key+URL alone returns the first occurrence for both, mis-anchoring the second entry's
+     * diagnostics onto the first. To disambiguate, this counts how many earlier entries in the parsed `includes`
+     * array carry the same key+URL and returns the correspondingly-numbered occurrence in the document — relying
+     * on the array being built in document order.
+     *
+     * @param document     The document being validated; its text is scanned line by line for the include.
+     * @param includes     The full parsed include list, in document order.
+     * @param includeIndex The position in `includes` of the entry to locate.
+     * @returns The 0-based line number of the matching include declaration, or `0` when no matching line is found
+     *          (e.g. the URL doesn't appear literally on a single line — folded scalar, alias). Callers use the
+     *          returned line as the anchor for a diagnostic range.
+     */
+    private findLineForComponent(document: vscode.TextDocument, includes: IncludeEntry[], includeIndex: number): number {
+        const { key, url } = includeKeyAndUrl(includes[includeIndex]);
 
-        this.logger.debug(`[ValidationProvider] Looking for include URL: ${componentUrl}`, 'ValidationProvider');
+        // The occurrence ordinal: how many entries at-or-before includeIndex share this exact key+URL.
+        let targetOccurrence = 0;
+        for (let k = 0; k <= includeIndex; k++) {
+            const prior = includeKeyAndUrl(includes[k]);
+            if (prior.key === key && prior.url === url) {
+                targetOccurrence++;
+            }
+        }
 
+        this.logger.debug(`[ValidationProvider] Looking for include URL: ${url} (occurrence ${targetOccurrence})`, 'ValidationProvider');
+
+        const lines = document.getText().split('\n');
+        let seen = 0;
         for (let i = 0; i < lines.length; i++) {
-            const line = lines[i];
-            if (line.includes(includeKey) && line.includes(componentUrl)) {
-                this.logger.debug(`[ValidationProvider] Found include at line ${i}: ${line.trim()}`, 'ValidationProvider');
-                return i;
+            if (includeLineMatches(lines[i], key, url)) {
+                seen++;
+                if (seen === targetOccurrence) {
+                    this.logger.debug(`[ValidationProvider] Found include at line ${i}: ${lines[i].trim()}`, 'ValidationProvider');
+                    return i;
+                }
             }
         }
         this.logger.debug(`[ValidationProvider] Include URL not found, returning 0`, 'ValidationProvider');
         return 0;
+    }
+
+    /**
+     * The line where the include entry *after* {@link includeIndex} begins, used as an exclusive upper bound when
+     * scanning an include's inputs. Returns `document.lineCount` when this is the last include, so the scan runs to
+     * end-of-file. `searchFrom` is the current include's own line — the next entry is found by scanning past it.
+     *
+     * @param document     The document being validated; its text is scanned line by line for the next include.
+     * @param includes     The full parsed include list, in document order.
+     * @param includeIndex The position in `includes` of the *current* entry; the next entry is `includeIndex + 1`.
+     * @param searchFrom   The current include's own line; scanning starts at the line after it.
+     * @returns The 0-based line number where the next include begins, or `document.lineCount` when there is no next
+     *          include or its line can't be found — either way an exclusive upper bound that runs to end-of-file.
+     */
+    private findLineForNextInclude(
+        document: vscode.TextDocument,
+        includes: IncludeEntry[],
+        includeIndex: number,
+        searchFrom: number
+    ): number {
+        if (includeIndex + 1 >= includes.length) {
+            return document.lineCount;
+        }
+        const { key, url } = includeKeyAndUrl(includes[includeIndex + 1]);
+        const lines = document.getText().split('\n');
+        for (let i = searchFrom + 1; i < lines.length; i++) {
+            if (includeLineMatches(lines[i], key, url)) {
+                return i;
+            }
+        }
+        return document.lineCount;
     }
 
     /**

--- a/src/utils/includeMatcher.ts
+++ b/src/utils/includeMatcher.ts
@@ -1,0 +1,96 @@
+import { isYamlNode } from './yamlParser';
+
+/**
+ * A `.gitlab-ci.yml` include entry that the validation provider validates. Either a remote `component:` URL
+ * or a `local:` path; both branches carry an optional `inputs` mapping. Built by narrowing a parsed YAML node —
+ * fields outside the union (anything else under the include) are intentionally not modelled.
+ */
+export type ComponentInclude = { component: string; local?: undefined; inputs?: Record<string, unknown> };
+export type LocalInclude = { local: string; component?: undefined; inputs?: Record<string, unknown> };
+export type IncludeEntry = ComponentInclude | LocalInclude;
+
+/**
+ * Narrow a parsed YAML value to an {@link IncludeEntry} (string-typed `component` or `local`).
+ *
+ * @param value A parsed YAML value of unknown shape — typically one element of the `include:` array.
+ * @returns `true` (narrowing `value` to {@link IncludeEntry}) when `value` is a mapping with exactly one of a
+ *          string `component` or a string `local`; `false` for non-mappings, entries with neither, or entries
+ *          with both (e.g. `project:`/`template:`/`remote:` includes, which this provider does not validate).
+ */
+export function isIncludeEntry(value: unknown): value is IncludeEntry {
+    if (!isYamlNode(value)) {
+        return false;
+    }
+    let hasComponent = false;
+    if (typeof value.component === 'string') {
+        hasComponent = true;
+    }
+    let hasLocal = false;
+    if (typeof value.local === 'string') {
+        hasLocal = true;
+    }
+    if (hasComponent === hasLocal) {
+        // Neither key, or both — not a component/local include this provider validates.
+        return false;
+    }
+    return true;
+}
+
+/**
+ * Narrow an {@link IncludeEntry} to the local-include shape (`local` is a string, `component` is absent).
+ *
+ * @param entry An include entry already validated by {@link isIncludeEntry}.
+ * @returns `true` (narrowing `entry` to {@link LocalInclude}) when `entry.local` is a string; `false` for a
+ *          {@link ComponentInclude}.
+ */
+export function isLocalInclude(entry: IncludeEntry): entry is LocalInclude {
+    if (typeof entry.local === 'string') {
+        return true;
+    }
+    return false;
+}
+
+/**
+ * The YAML key and its URL/path value for an include entry — the two strings needed to locate the entry's line in
+ * the document.
+ *
+ * @param entry An include entry already validated by {@link isIncludeEntry}.
+ * @returns `{ key, url }` where `key` is the YAML key token (`'component:'` or `'local:'`) and `url` is the
+ *          corresponding remote component URL or local path.
+ */
+export function includeKeyAndUrl(entry: IncludeEntry): { key: string; url: string } {
+    if (entry.component !== undefined) {
+        return { key: 'component:', url: entry.component };
+    }
+    return { key: 'local:', url: entry.local };
+}
+
+/**
+ * Whether a document line is the one that declares an include with the given key and URL. The line must contain the
+ * include key and the URL, and the URL must be terminated at a token boundary — end-of-line, whitespace, or a closing
+ * quote. The boundary check is what stops a versioned URL from matching a longer sibling: e.g.
+ * `…/comp@cloud-deploy-aws-ecs-1` must not match the line `…/comp@cloud-deploy-aws-ecs-10`, where it appears only as
+ * a prefix. A bare substring test would, and that disagrees with the exact-equality occurrence counter the caller
+ * uses to disambiguate duplicate includes — mis-anchoring the diagnostic onto the wrong include.
+ *
+ * @param line A single document line (no trailing newline).
+ * @param key  The include key token to require on the line — `'component:'` or `'local:'`, as returned by
+ *             {@link includeKeyAndUrl}.
+ * @param url  The remote URL or local path that must appear on the line, terminated at a token boundary.
+ * @returns `true` when `line` contains `key` and `url`, with `url` followed by end-of-line, whitespace, or a
+ *          closing quote; `false` otherwise (including when `url` appears only as a prefix of a longer token).
+ */
+export function includeLineMatches(line: string, key: string, url: string): boolean {
+    if (!line.includes(key)) {
+        return false;
+    }
+    const at = line.indexOf(url);
+    if (at === -1) {
+        return false;
+    }
+    const after = line.charAt(at + url.length); // '' at end-of-line
+    if (after === '' || /\s/.test(after) || after === '"' || after === "'") {
+        return true;
+    }
+    return false;
+}

--- a/tests/extension-host/suite/duplicateInclude.test.ts
+++ b/tests/extension-host/suite/duplicateInclude.test.ts
@@ -1,0 +1,107 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+const EXTENSION_ID = 'eFAILution.gitlab-component-helper';
+
+// __dirname is <repo>/out-test/suite at runtime; fixtures live under tests/fixtures.
+const FIXTURE_DIR = path.resolve(__dirname, '..', '..', 'tests', 'fixtures', 'duplicate-include');
+const FIXTURE = path.join(FIXTURE_DIR, '.gitlab-ci.yml');
+
+async function ensureActive(): Promise<void> {
+  const ext = vscode.extensions.getExtension(EXTENSION_ID);
+  assert.ok(ext);
+  if (!ext.isActive) await ext.activate();
+}
+
+async function waitForDiagnostics(uri: vscode.Uri, timeoutMs = 5000): Promise<vscode.Diagnostic[]> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const diags = vscode.languages.getDiagnostics(uri);
+    if (diags.length > 0) return diags;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  return vscode.languages.getDiagnostics(uri);
+}
+
+/** 0-indexed line of the second `- local:` entry — derived from the document so it survives fixture edits. */
+function secondIncludeLine(doc: vscode.TextDocument): number {
+  const lines = doc.getText().split('\n');
+  let seen = 0;
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].includes('local:') && lines[i].includes('templates/deploy.yml')) {
+      seen++;
+      if (seen === 2) return i;
+    }
+  }
+  throw new Error('fixture missing a second - local: deploy.yml include');
+}
+
+// The fixture includes the same template twice: the first entry is correct, the second uses a wrong input
+// name (`target_cluster` instead of `cluster`). Before the per-entry line scoping fix, the diagnostics for
+// the second entry were anchored onto the first entry because the line-finders matched the first occurrence
+// of the shared path. These tests pin the diagnostics to the entry they actually belong to.
+suite('Duplicate include line scoping', () => {
+  suiteSetup(ensureActive);
+
+  test('unknown input on the second include is anchored to the second block', async () => {
+    const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(FIXTURE));
+    await vscode.window.showTextDocument(doc);
+    const secondLine = secondIncludeLine(doc);
+
+    const diags = await waitForDiagnostics(doc.uri);
+    const ourDiags = diags.filter((d) => d.source === 'gitlab-component-helper');
+    const unknown = ourDiags.find(
+      (d) => d.code === 'unknown-input' && /target_cluster/.test(d.message)
+    );
+    assert.ok(
+      unknown,
+      `expected an unknown-input diagnostic for target_cluster. Got: ${JSON.stringify(ourDiags.map((d) => ({ code: d.code, msg: d.message, line: d.range.start.line })))}`
+    );
+    assert.ok(
+      unknown.range.start.line >= secondLine,
+      `unknown-input for target_cluster should land in the second include block (line >= ${secondLine}), but landed on line ${unknown.range.start.line}`
+    );
+  });
+
+  test('missing required input on the second include is anchored to the second block', async () => {
+    const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(FIXTURE));
+    await vscode.window.showTextDocument(doc);
+    const secondLine = secondIncludeLine(doc);
+
+    const diags = await waitForDiagnostics(doc.uri);
+    const ourDiags = diags.filter((d) => d.source === 'gitlab-component-helper');
+
+    // Only the second include is missing `cluster`; the first supplies it. So there must be exactly one
+    // missing-required-input diagnostic for `cluster`, and it must sit on the second include line.
+    const missing = ourDiags.filter(
+      (d) => d.code === 'missing-required-input' && /cluster/.test(d.message)
+    );
+    assert.strictEqual(
+      missing.length,
+      1,
+      `expected exactly one missing-required-input for cluster (second include only). Got: ${JSON.stringify(missing.map((d) => ({ msg: d.message, line: d.range.start.line })))}`
+    );
+    assert.strictEqual(
+      missing[0].range.start.line,
+      secondLine,
+      `missing cluster diagnostic should anchor to the second include line (${secondLine}), but landed on line ${missing[0].range.start.line}`
+    );
+  });
+
+  test('the first include reports no diagnostics', async () => {
+    const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(FIXTURE));
+    await vscode.window.showTextDocument(doc);
+    const secondLine = secondIncludeLine(doc);
+
+    const diags = await waitForDiagnostics(doc.uri);
+    const firstBlockDiags = diags.filter(
+      (d) => d.source === 'gitlab-component-helper' && d.range.start.line < secondLine
+    );
+    assert.strictEqual(
+      firstBlockDiags.length,
+      0,
+      `the first (correct) include should have no diagnostics, but found: ${JSON.stringify(firstBlockDiags.map((d) => ({ code: d.code, msg: d.message, line: d.range.start.line })))}`
+    );
+  });
+});

--- a/tests/extension-host/suite/flowInputs.test.ts
+++ b/tests/extension-host/suite/flowInputs.test.ts
@@ -1,0 +1,61 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+const EXTENSION_ID = 'eFAILution.gitlab-component-helper';
+
+// __dirname is <repo>/out-test/suite at runtime; fixtures live under tests/fixtures.
+const FIXTURE_DIR = path.resolve(__dirname, '..', '..', 'tests', 'fixtures', 'flow-inputs');
+const FIXTURE = path.join(FIXTURE_DIR, '.gitlab-ci.yml');
+
+async function ensureActive(): Promise<void> {
+  const ext = vscode.extensions.getExtension(EXTENSION_ID);
+  assert.ok(ext);
+  if (!ext.isActive) await ext.activate();
+}
+
+async function waitForDiagnostics(uri: vscode.Uri, timeoutMs = 5000): Promise<vscode.Diagnostic[]> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const diags = vscode.languages.getDiagnostics(uri);
+    if (diags.length > 0) return diags;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  return vscode.languages.getDiagnostics(uri);
+}
+
+/** 0-indexed line of the top-level `deploy:` job that lies below the include. */
+function jobLine(doc: vscode.TextDocument): number {
+  const lines = doc.getText().split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i] === 'deploy:') return i;
+  }
+  throw new Error('fixture missing the top-level deploy: job');
+}
+
+// The single (last) include uses flow-style `inputs: { ... }`, so its unknown input `bad_input` appears only on
+// the `inputs:` line — never on its own line. A top-level job below reuses `bad_input:` under `variables:`. With
+// the input scan bounded only by end-of-file, the diagnostic would bleed down onto the job's variable. The
+// indent break keeps it inside the include's block.
+suite('Flow-style inputs do not bleed into a later top-level section', () => {
+  suiteSetup(ensureActive);
+
+  test('unknown input in flow-style inputs anchors inside the include, not the job below', async () => {
+    const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(FIXTURE));
+    await vscode.window.showTextDocument(doc);
+    const job = jobLine(doc);
+
+    const diags = await waitForDiagnostics(doc.uri);
+    const ourDiags = diags.filter((d) => d.source === 'gitlab-component-helper');
+
+    const badInput = ourDiags.find((d) => d.code === 'unknown-input' && /bad_input/.test(d.message));
+    assert.ok(
+      badInput,
+      `expected an unknown-input diagnostic for bad_input. Got: ${JSON.stringify(ourDiags.map((d) => ({ code: d.code, msg: d.message, line: d.range.start.line })))}`
+    );
+    assert.ok(
+      badInput.range.start.line < job,
+      `bad_input should anchor inside the include block (above the deploy: job at line ${job}), but landed on line ${badInput.range.start.line}`
+    );
+  });
+});

--- a/tests/fixtures/duplicate-include/.gitlab-ci.yml
+++ b/tests/fixtures/duplicate-include/.gitlab-ci.yml
@@ -1,0 +1,13 @@
+include:
+  # First include of the deploy template — all inputs correct.
+  - local: "duplicate-include/templates/deploy.yml"
+    inputs:
+      job_name: deploy:first
+      cluster: first-cluster
+
+  # Second include of the SAME template — `target_cluster` is a wrong name
+  # (the input is `cluster`), and the required `cluster` is therefore missing.
+  - local: "duplicate-include/templates/deploy.yml"
+    inputs:
+      job_name: deploy:second
+      target_cluster: second-cluster

--- a/tests/fixtures/duplicate-include/templates/deploy.yml
+++ b/tests/fixtures/duplicate-include/templates/deploy.yml
@@ -1,0 +1,16 @@
+spec:
+  inputs:
+    job_name:
+      description: The name of the CI job
+      type: string
+    cluster:
+      description: The target cluster (no default — required)
+      type: string
+    region:
+      description: The deployment region
+      type: string
+      default: eu-west-1
+---
+$[[ inputs.job_name ]]:
+  script:
+    - echo "deploying to $[[ inputs.cluster ]] in $[[ inputs.region ]]"

--- a/tests/fixtures/flow-inputs/.gitlab-ci.yml
+++ b/tests/fixtures/flow-inputs/.gitlab-ci.yml
@@ -1,0 +1,13 @@
+include:
+  # Last include, flow-style inputs: `bad_input` appears only on the `inputs:` line,
+  # never on its own line. `bad_input` is unknown (the template only defines job_name).
+  - local: "flow-inputs/templates/deploy.yml"
+    inputs: { job_name: deploy, bad_input: oops }
+
+# A top-level job below the include whose variables reuse the input name. The unknown-input
+# diagnostic for `bad_input` must NOT anchor here — the input scan must stop at this dedent.
+deploy:
+  variables:
+    bad_input: from-job
+  script:
+    - echo "$bad_input"

--- a/tests/fixtures/flow-inputs/templates/deploy.yml
+++ b/tests/fixtures/flow-inputs/templates/deploy.yml
@@ -1,0 +1,9 @@
+spec:
+  inputs:
+    job_name:
+      description: The name of the CI job
+      type: string
+---
+$[[ inputs.job_name ]]:
+  script:
+    - echo "deploy"

--- a/tests/unit/includeMatcher.test.ts
+++ b/tests/unit/includeMatcher.test.ts
@@ -1,0 +1,98 @@
+// @mocha
+/**
+ * includeMatcher tests — the pure include line-matching helpers used by the validation provider to anchor
+ * diagnostics to the correct include entry.
+ *
+ * The critical case is `includeLineMatches` token-boundary matching: a versioned URL (`…@deploy-1`) must not
+ * match a line declaring a longer sibling (`…@deploy-10`), or the provider's occurrence counter (exact equality)
+ * disagrees with the document walk (line match) and anchors a diagnostic onto the wrong include.
+ */
+
+import * as assert from 'node:assert/strict';
+import {
+    isIncludeEntry,
+    isLocalInclude,
+    includeKeyAndUrl,
+    includeLineMatches,
+} from '../../src/utils/includeMatcher';
+
+suite('includeMatcher — isIncludeEntry', () => {
+    test('accepts a component include', () => {
+        assert.equal(isIncludeEntry({ component: 'host/g/c@1' }), true);
+    });
+
+    test('accepts a local include', () => {
+        assert.equal(isIncludeEntry({ local: 'templates/x.yml' }), true);
+    });
+
+    test('rejects an entry with both component and local', () => {
+        assert.equal(isIncludeEntry({ component: 'host/g/c@1', local: 'x.yml' }), false);
+    });
+
+    test('rejects an entry with neither', () => {
+        assert.equal(isIncludeEntry({ project: 'g/p', file: 'x.yml' }), false);
+    });
+
+    test('rejects non-objects', () => {
+        assert.equal(isIncludeEntry('component: x'), false);
+        assert.equal(isIncludeEntry(null), false);
+        assert.equal(isIncludeEntry(['component']), false);
+    });
+});
+
+suite('includeMatcher — isLocalInclude / includeKeyAndUrl', () => {
+    test('isLocalInclude distinguishes local from component', () => {
+        assert.equal(isLocalInclude({ local: 'x.yml' }), true);
+        assert.equal(isLocalInclude({ component: 'host/g/c@1' }), false);
+    });
+
+    test('includeKeyAndUrl returns component key+url', () => {
+        assert.deepEqual(includeKeyAndUrl({ component: 'host/g/c@1' }), {
+            key: 'component:',
+            url: 'host/g/c@1',
+        });
+    });
+
+    test('includeKeyAndUrl returns local key+url', () => {
+        assert.deepEqual(includeKeyAndUrl({ local: 'templates/x.yml' }), {
+            key: 'local:',
+            url: 'templates/x.yml',
+        });
+    });
+});
+
+suite('includeMatcher — includeLineMatches token boundary', () => {
+    const url = 'host/g/c@deploy-1';
+
+    test('matches when the URL is at end of line', () => {
+        assert.equal(includeLineMatches(`  - component: ${url}`, 'component:', url), true);
+    });
+
+    test('matches when followed by whitespace (trailing space / comment)', () => {
+        assert.equal(includeLineMatches(`  - component: ${url}  # pinned`, 'component:', url), true);
+    });
+
+    test('matches when the URL is wrapped in quotes', () => {
+        assert.equal(includeLineMatches(`  - component: "${url}"`, 'component:', url), true);
+        assert.equal(includeLineMatches(`  - component: '${url}'`, 'component:', url), true);
+    });
+
+    test('does NOT match a longer sibling where the URL is only a prefix', () => {
+        // The bug this guards: `@deploy-1` appears as a prefix of `@deploy-10`.
+        assert.equal(includeLineMatches('  - component: host/g/c@deploy-10', 'component:', url), false);
+    });
+
+    test('does NOT match when the include key is absent', () => {
+        assert.equal(includeLineMatches(`      some_input: ${url}`, 'component:', url), false);
+    });
+
+    test('does NOT match when the URL is absent', () => {
+        assert.equal(includeLineMatches('  - component: host/g/other@1', 'component:', url), false);
+    });
+
+    test('local-path prefix collision is rejected too', () => {
+        const localUrl = 'templates/deploy';
+        assert.equal(includeLineMatches('  - local: templates/deploy10', 'local:', localUrl), false);
+        assert.equal(includeLineMatches('  - local: templates/deploy', 'local:', localUrl), true);
+    });
+});


### PR DESCRIPTION
## Summary
- Fixes validation diagnostics being mis-anchored when a `.gitlab-ci.yml` includes the same component URL (or `local:` template path) more than once. Previously the second (and later) include's `missing-required-input` / `unknown-input` diagnostics landed on the **first** matching include; now each diagnostic is pinned to the include entry it actually belongs to.
- The same-document line-finders in the validation provider matched includes by substring-searching the whole document for the include key + URL, returning the first occurrence for every entry that shared a URL. They now disambiguate by the include's **position in the parsed `include` array**, match the URL at a **token boundary** (so a versioned tag can't match a longer sibling), and bound the input scan to the include's own block.
- The include types and pure matching helpers are extracted into a `vscode`-free [includeMatcher.ts](../src/utils/includeMatcher.ts) module so the matching logic is unit-testable directly.
- Link related issue(s): Fixes #175

## Change Type
- [ ] feat
- [x] fix
- [x] refactor (extract `includeMatcher` helpers)
- [ ] docs
- [ ] test

## Context
### User-facing impact
- Diagnostics now appear on the correct include block. A correct first include is no longer flagged with errors that belong to a later, incorrect include of the same component/template; the incorrect include now shows its own squiggles.

### GitLab scope
- [ ] gitlab.com
- [ ] self-managed GitLab
- [x] both (diagnostic line-anchoring only; no GitLab interaction)

### Affected areas
- [ ] Component Browser
- [ ] Hover provider
- [ ] Completion provider
- [x] Validation provider
- [ ] Cache and refresh behavior
- [ ] GitLab API calls/auth/token storage
- [ ] Docs only

## What changed by bucket

| Bucket | Files | Approach |
|---|---|---|
| Matching helpers (new module) | [includeMatcher.ts](../src/utils/includeMatcher.ts) | New `vscode`-free module holding the `IncludeEntry`/`ComponentInclude`/`LocalInclude` types, the `isIncludeEntry`/`isLocalInclude` guards, `includeKeyAndUrl` (the key+URL derivation, previously duplicated across finders), and `includeLineMatches`. `includeLineMatches` requires the URL to terminate at a **token boundary** (end-of-line, whitespace, or closing quote), so `…@deploy-1` no longer matches a line declaring `…@deploy-10`. This keeps the document line match consistent with the exact-equality occurrence counter. |
| Line-finder scoping | [validationProvider.ts](../src/providers/validationProvider.ts) | `findLineForComponent` now takes `(includes, includeIndex)` and returns the **Nth** document occurrence of the entry's include key + URL (via `includeLineMatches`), where N is how many entries at-or-before `includeIndex` share that exact key+URL (relies on the array being built in document order). New `findLineForNextInclude` computes the line where the *following* include begins, used as an **exclusive upper bound** for the input scan. `findLineForInput` uses that bound **and** restores an indent break (`!/^\s/.test(line) && line.trim() !== ''`) — together they keep the scan inside this include's inputs block, including for the last include where the next-include bound is end-of-file. |
| Call sites & narrowing | [validationProvider.ts](../src/providers/validationProvider.ts) | All finder call sites thread `includes` + `includeIndex`. The caller narrows with `isLocalInclude` and passes a `LocalInclude` to `validateLocalInclude`, so local-ness is a compile-time fact — no runtime guard, no type assertion. |
| Regression tests | [includeMatcher.test.ts](../tests/unit/includeMatcher.test.ts), [duplicateInclude.test.ts](../tests/extension-host/suite/duplicateInclude.test.ts), [flowInputs.test.ts](../tests/extension-host/suite/flowInputs.test.ts), [tests/fixtures/duplicate-include/](../tests/fixtures/duplicate-include/), [tests/fixtures/flow-inputs/](../tests/fixtures/flow-inputs/) | **Unit:** `includeMatcher` helpers, incl. token-boundary cases (`@deploy-1` vs `@deploy-10`, local-path prefix collision) — verified load-bearing (fail when the boundary check is disabled). **Extension-host:** `duplicate-include` (one template included twice; second entry's diagnostics anchor to the second block, first block clean) and `flow-inputs` (flow-style `inputs: { … }` on a last include, with a top-level job below reusing the input name — the diagnostic must stay in the include block; verified load-bearing against the removed indent break). |

## Breaking Changes
- [x] No breaking changes
- [ ] Breaking changes (describe below)