### PR TITLE
fix: validation diagnostics go stale when editing an input far from its component line

### DIFF
--- a/src/providers/validationProvider.ts
+++ b/src/providers/validationProvider.ts
@@ -69,8 +69,7 @@ export class ValidationProvider implements vscode.CodeActionProvider {
         context.subscriptions.push(
             vscode.workspace.onDidOpenTextDocument(doc => this.validate(doc)),
             vscode.workspace.onDidChangeTextDocument(e => {
-                // Only validate if the change affects component inputs
-                this.validateIfInputsChanged(e);
+                this.scheduleValidation(e.document);
             }),
             vscode.workspace.onDidCloseTextDocument(doc => {
                 const documentId = doc.uri.toString();
@@ -444,35 +443,19 @@ export class ValidationProvider implements vscode.CodeActionProvider {
     }
 
     /**
-     * Smart validation that only triggers when inputs are actually changed
+     * Re-validate a document after an edit, throttled to coalesce rapid keystrokes.
+     *
+     * Every edit to a GitLab CI file schedules a full pass: diagnostics depend on the whole document (an input edit
+     * can resolve or raise a component-level error several lines away), so the change must be re-checked as a whole
+     * rather than judged "relevant" by its surrounding lines. {@link validate} cheaply skips files that aren't GitLab
+     * CI files or carry no `include`, and the 300ms throttle keeps typing responsive.
      */
-    private validateIfInputsChanged(e: vscode.TextDocumentChangeEvent): void {
-        const document = e.document;
-        const documentId = document.uri.toString();
-
+    private scheduleValidation(document: vscode.TextDocument): void {
         if (!isGitLabCIFile(document)) {
             return;
         }
 
-        // Check if the changes affect component inputs
-        let shouldValidate = false;
-        for (const change of e.contentChanges) {
-            const changedText = change.text;
-            const rangeText = document.getText(change.range);
-
-            // Check if the change is in an inputs section or affects component/include declarations
-            if (this.isInputRelatedChange(document, change.range, changedText, rangeText)) {
-                shouldValidate = true;
-                break;
-            }
-        }
-
-        if (!shouldValidate) {
-            this.logger.debug(`[ValidationProvider] Skipping validation - changes don't affect component inputs`, 'ValidationProvider');
-            return;
-        }
-
-        // Throttle validation to avoid excessive calls
+        const documentId = document.uri.toString();
         const existingTimeout = this.validationTimeouts.get(documentId);
         if (existingTimeout) {
             clearTimeout(existingTimeout);
@@ -483,41 +466,6 @@ export class ValidationProvider implements vscode.CodeActionProvider {
             this.validate(document);
             this.validationTimeouts.delete(documentId);
         }, 300)); // 300ms delay to allow user to finish typing
-    }
-
-    /**
-     * Check if a change affects component inputs
-     */
-    private isInputRelatedChange(document: vscode.TextDocument, range: vscode.Range, newText: string, oldText: string): boolean {
-        const startLine = range.start.line;
-        const endLine = range.end.line;
-
-        // Check lines around the change for component/inputs context
-        const contextStart = Math.max(0, startLine - 5);
-        const contextEnd = Math.min(document.lineCount - 1, endLine + 5);
-
-        let hasComponentContext = false;
-        let hasInputsContext = false;
-
-        for (let i = contextStart; i <= contextEnd; i++) {
-            const lineText = document.lineAt(i).text;
-            if (lineText.includes('component:') || lineText.includes('include:')) {
-                hasComponentContext = true;
-            }
-            if (lineText.includes('inputs:')) {
-                hasInputsContext = true;
-            }
-        }
-
-        // If we're in a component context and either:
-        // 1. We're in an inputs section, or
-        // 2. The change involves input-like text (contains ':' which is common in YAML key-value pairs)
-        if (hasComponentContext && (hasInputsContext || newText.includes(':') || oldText.includes(':'))) {
-            this.logger.debug(`[ValidationProvider] Input-related change detected at line ${startLine}`, 'ValidationProvider');
-            return true;
-        }
-
-        return false;
     }
 
     /**

--- a/tests/extension-host/suite/revalidateOnEdit.test.ts
+++ b/tests/extension-host/suite/revalidateOnEdit.test.ts
@@ -1,0 +1,73 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+const EXTENSION_ID = 'eFAILution.gitlab-component-helper';
+
+// __dirname is <repo>/out-test/suite at runtime; fixtures live under tests/fixtures.
+const FIXTURE_DIR = path.resolve(__dirname, '..', '..', 'tests', 'fixtures', 'revalidate-on-edit');
+const FIXTURE = path.join(FIXTURE_DIR, '.gitlab-ci.yml');
+
+async function ensureActive(): Promise<void> {
+  const ext = vscode.extensions.getExtension(EXTENSION_ID);
+  assert.ok(ext);
+  if (!ext.isActive) await ext.activate();
+}
+
+/** Poll until `predicate` holds over the current diagnostics, or the timeout elapses. Returns the last snapshot. */
+async function waitForDiagnostics(
+  uri: vscode.Uri,
+  predicate: (diags: vscode.Diagnostic[]) => boolean,
+  timeoutMs = 5000
+): Promise<vscode.Diagnostic[]> {
+  const start = Date.now();
+  let diags = vscode.languages.getDiagnostics(uri);
+  while (Date.now() - start < timeoutMs) {
+    diags = vscode.languages.getDiagnostics(uri);
+    if (predicate(diags)) return diags;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  return diags;
+}
+
+const ours = (diags: vscode.Diagnostic[]) => diags.filter((d) => d.source === 'gitlab-component-helper');
+
+// The edited input sits >5 lines below the include line in the fixture. A proximity-gated change detector skipped
+// re-validation for such edits, so the diagnostics went stale. Validation now runs on every edit to a CI file.
+suite('Re-validation on edit', () => {
+  suiteSetup(ensureActive);
+
+  test('renaming a valid input to an unknown one updates diagnostics', async () => {
+    const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(FIXTURE));
+    const editor = await vscode.window.showTextDocument(doc);
+
+    // The fixture is valid on open: no unknown-input diagnostics.
+    const clean = await waitForDiagnostics(
+      doc.uri,
+      (d) => !ours(d).some((x) => x.code === 'unknown-input')
+    );
+    assert.ok(
+      !ours(clean).some((x) => x.code === 'unknown-input'),
+      `fixture should open clean. Got: ${JSON.stringify(ours(clean).map((d) => ({ code: d.code, msg: d.message })))}`
+    );
+
+    // Rename `target_input` -> `target_inputX` (now an unknown input) far below the include line.
+    const text = doc.getText();
+    const offset = text.indexOf('target_input:');
+    assert.ok(offset > 0, 'fixture missing target_input');
+    const namePos = doc.positionAt(offset + 'target_input'.length);
+    await editor.edit((b) => b.insert(namePos, 'X'));
+
+    const after = await waitForDiagnostics(
+      doc.uri,
+      (d) => ours(d).some((x) => x.code === 'unknown-input' && /target_inputX/.test(x.message))
+    );
+    const unknown = ours(after).find(
+      (x) => x.code === 'unknown-input' && /target_inputX/.test(x.message)
+    );
+    assert.ok(
+      unknown,
+      `expected an unknown-input diagnostic for target_inputX after the edit. Got: ${JSON.stringify(ours(after).map((d) => ({ code: d.code, msg: d.message, line: d.range.start.line })))}`
+    );
+  });
+});

--- a/tests/fixtures/revalidate-on-edit/.gitlab-ci.yml
+++ b/tests/fixtures/revalidate-on-edit/.gitlab-ci.yml
@@ -1,0 +1,13 @@
+include:
+  # The edited input below sits well more than 5 lines under this `local:` line, so a
+  # proximity-gated change detector would deem an edit to it "unrelated" and skip
+  # re-validation — leaving stale diagnostics. The test edits `target_input` and asserts
+  # the diagnostics track the current text.
+  - local: "revalidate-on-edit/templates/deploy.yml"
+    inputs:
+      a_input: a
+      b_input: b
+      c_input: c
+      d_input: d
+      e_input: e
+      target_input: ok

--- a/tests/fixtures/revalidate-on-edit/templates/deploy.yml
+++ b/tests/fixtures/revalidate-on-edit/templates/deploy.yml
@@ -1,0 +1,12 @@
+spec:
+  inputs:
+    a_input: { type: string }
+    b_input: { type: string }
+    c_input: { type: string }
+    d_input: { type: string }
+    e_input: { type: string }
+    target_input: { type: string }
+---
+job:
+  script:
+    - echo "$[[ inputs.target_input ]]"


### PR DESCRIPTION
## Summary
- Fixes validation diagnostics going stale after an edit. The on-change handler only re-validated when a `component:`/`include:` line sat within ±5 lines of the edit; an input edited further down a long `inputs:` block was deemed "unrelated" and validation was skipped, leaving the previous diagnostics in place.
- Replaces the proximity heuristic with a plain throttled re-validation on every edit to a GitLab CI file.
- Link related issue(s): Fixes #177

## Change Type
- [ ] feat
- [x] fix
- [ ] refactor
- [ ] docs
- [ ] test

## Context
### User-facing impact
- Editing any input now refreshes diagnostics, regardless of how far the input is from its `component:` line. No more lingering squiggles that reference text the edit has already changed.

### GitLab scope
- [ ] gitlab.com
- [ ] self-managed GitLab
- [x] both (local re-validation scheduling only; no GitLab interaction)

### Affected areas
- [ ] Component Browser
- [ ] Hover provider
- [ ] Completion provider
- [x] Validation provider
- [ ] Cache and refresh behavior
- [ ] GitLab API calls/auth/token storage
- [ ] Docs only

## What changed by bucket

| Bucket | Files | Approach |
|---|---|---|
| Re-validation trigger | [validationProvider.ts](../src/providers/validationProvider.ts) | The `onDidChangeTextDocument` listener now calls a new `scheduleValidation(document)` that re-validates any edit to a GitLab CI file, keeping the existing 300ms throttle. `validate()` already early-outs cheaply for non-CI files and files without `include`, so validating every edit is correct and inexpensive. Removed `validateIfInputsChanged` and the `isInputRelatedChange` proximity heuristic that caused the false negatives. |
| Regression test | [revalidateOnEdit.test.ts](../tests/extension-host/suite/revalidateOnEdit.test.ts), [tests/fixtures/revalidate-on-edit/](../tests/fixtures/revalidate-on-edit/) | New extension-host suite + fixture: a long `inputs:` block whose edited input sits well below the include line (outside the old ±5-line window). Opens clean, renames the input to an unknown name, and asserts the `unknown-input` diagnostic appears. Verified load-bearing — fails when the on-edit validation is skipped. |

## Validation
### Local checks
- [x] `npm run compile` (`tsc --noEmit` clean)
- [x] `npm test`
- [x] `npm run test:extension-host` (incl. the new on-edit suite)
- [x] `npm run lint` clean

### Manual test notes
- Reproduced in a `.gitlab-ci.yml` with a long `inputs:` block: renaming an input near the bottom of the block (more than 5 lines below the `component:` line) left the old diagnostics referencing the pre-edit text. After the fix, diagnostics update on each keystroke (debounced 300ms).

## Breaking Changes
- [x] No breaking changes
- [ ] Breaking changes (describe below)
