### PR TITLE
fix: validation diagnostics appear on both panels of a diff view

### DIFF
--- a/src/providers/validationProvider.ts
+++ b/src/providers/validationProvider.ts
@@ -92,8 +92,27 @@ export class ValidationProvider implements vscode.CodeActionProvider {
         });
     }
 
+    /**
+     * Only the working-tree copy of a file should carry diagnostics. In a diff view the source (left) panel is a
+     * read-only document under a VCS scheme (`git`, `gitlens`, `pr`, …) sharing the same `fsPath` as the working-tree
+     * document, so validating both makes the squiggles appear on both panels. Restricting to the `file` scheme keeps
+     * diagnostics on the editable (right) panel only.
+     *
+     * @param document - The text document a provider is about to validate.
+     * @returns `true` if the document is the editable working-tree copy (`file` scheme); `false` for diff-source and
+     *   other non-`file` documents that should not receive diagnostics.
+     */
+    private isDiagnosableDocument(document: vscode.TextDocument): boolean {
+        return document.uri.scheme === 'file';
+    }
+
     private async validate(document: vscode.TextDocument) {
         this.logger.debug(`[ValidationProvider] validate() called for: ${document.fileName}, languageId: ${document.languageId}`, 'ValidationProvider');
+
+        if (!this.isDiagnosableDocument(document)) {
+            this.logger.debug(`[ValidationProvider] Skipping validation - non-file URI scheme: ${document.uri.scheme}`, 'ValidationProvider');
+            return;
+        }
 
         if (!isGitLabCIFile(document)) {
             this.logger.debug(`[ValidationProvider] Skipping validation - not a supported file type`, 'ValidationProvider');
@@ -440,7 +459,7 @@ export class ValidationProvider implements vscode.CodeActionProvider {
      * CI files or carry no `include`, and the 300ms throttle keeps typing responsive.
      */
     private scheduleValidation(document: vscode.TextDocument): void {
-        if (!isGitLabCIFile(document)) {
+        if (!this.isDiagnosableDocument(document) || !isGitLabCIFile(document)) {
             return;
         }
 

--- a/tests/extension-host/suite/diffSourcePanel.test.ts
+++ b/tests/extension-host/suite/diffSourcePanel.test.ts
@@ -1,0 +1,77 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+const EXTENSION_ID = 'eFAILution.gitlab-component-helper';
+
+// __dirname is <repo>/out-test/suite at runtime; fixtures live under tests/fixtures.
+// Reuse the local-include fixture: it reliably produces gitlab-component-helper diagnostics.
+const FIXTURE_DIR = path.resolve(__dirname, '..', '..', 'tests', 'fixtures', 'local-include');
+const FIXTURE = path.join(FIXTURE_DIR, '.gitlab-ci.yml');
+
+async function ensureActive(): Promise<void> {
+  const ext = vscode.extensions.getExtension(EXTENSION_ID);
+  assert.ok(ext);
+  if (!ext.isActive) await ext.activate();
+}
+
+/** Poll until `predicate` holds over the current diagnostics, or the timeout elapses. Returns the last snapshot. */
+async function waitForDiagnostics(
+  uri: vscode.Uri,
+  predicate: (diags: vscode.Diagnostic[]) => boolean,
+  timeoutMs = 5000
+): Promise<vscode.Diagnostic[]> {
+  const start = Date.now();
+  let diags = vscode.languages.getDiagnostics(uri);
+  while (Date.now() - start < timeoutMs) {
+    diags = vscode.languages.getDiagnostics(uri);
+    if (predicate(diags)) return diags;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  return diags;
+}
+
+const ours = (diags: vscode.Diagnostic[]) => diags.filter((d) => d.source === 'gitlab-component-helper');
+
+// In a diff view the source (left) panel is a read-only document under a VCS scheme that shares the working-tree
+// file's fsPath. Validating it made the squiggles appear on both panels; only the `file`-scheme copy should carry
+// diagnostics now.
+suite('Diff source panel diagnostics', () => {
+  suiteSetup(ensureActive);
+
+  test('the working-tree (file) document still carries diagnostics', async () => {
+    const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(FIXTURE));
+    await vscode.window.showTextDocument(doc, { preview: false });
+
+    const diags = await waitForDiagnostics(doc.uri, (d) => ours(d).length > 0);
+    assert.ok(
+      ours(diags).length > 0,
+      `file-scheme document should carry diagnostics. Got: ${JSON.stringify(ours(diags).map((d) => ({ code: d.code, msg: d.message })))}`
+    );
+  });
+
+  test('does not produce diagnostics for a non-file (diff source) document', async () => {
+    const fixtureText = (
+      await vscode.workspace.openTextDocument(vscode.Uri.file(FIXTURE))
+    ).getText();
+
+    // Mirror how a diff source panel opens: same fsPath, a VCS-style scheme, read-only content.
+    const provider: vscode.TextDocumentContentProvider = { provideTextDocumentContent: () => fixtureText };
+    const registration = vscode.workspace.registerTextDocumentContentProvider('gitlab-test', provider);
+    try {
+      const sourceUri = vscode.Uri.file(FIXTURE).with({ scheme: 'gitlab-test' });
+      const sourceDoc = await vscode.workspace.openTextDocument(sourceUri);
+      await vscode.window.showTextDocument(sourceDoc, { preview: false });
+
+      // Give validation a window to run (and incorrectly emit) before asserting it stayed silent.
+      const diags = await waitForDiagnostics(sourceUri, (d) => ours(d).length > 0, 2000);
+      assert.strictEqual(
+        ours(diags).length,
+        0,
+        `diff source panel should carry no diagnostics. Got: ${JSON.stringify(ours(diags).map((d) => ({ code: d.code, msg: d.message })))}`
+      );
+    } finally {
+      registration.dispose();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes validation diagnostics showing on both panels of a diff view. The provider matched documents by `fsPath`/`languageId` only, so the read-only source (left) panel — a VCS-scheme document sharing the working-tree file's path — passed `isGitLabCIFile()` and had diagnostics set against it too.
- Restricts validation to the `file` URI scheme so only the editable destination (right) panel carries diagnostics.
- Link related issue(s): Fixes #179 

## Change Type
- [ ] feat
- [x] fix
- [ ] refactor
- [ ] docs
- [ ] test

## Context
### User-facing impact
- In a diff view (Source Control changes, "Open Changes", GitLens, PR diffs), squiggles now appear only on the editable destination panel, not the read-only source panel. No behavior change for a normally-opened file.

### GitLab scope
- [x] both (local diagnostics scheme-gating only; no GitLab interaction)

### Affected areas
- [ ] Component Browser
- [ ] Hover provider
- [ ] Completion provider
- [x] Validation provider
- [ ] Cache and refresh behavior
- [ ] GitLab API calls/auth/token storage
- [ ] Docs only

## What changed by bucket

| Bucket | Files | Approach |
|---|---|---|
| Scheme gating | [validationProvider.ts](../src/providers/validationProvider.ts) | New `isDiagnosableDocument(document)` accepts only the `file` scheme. `validate()` (the sole place diagnostics are written) early-outs for non-`file` documents; `scheduleValidation()` gates on it too so diff-source documents don't schedule pointless re-validation timers. Diff source panels open under VCS schemes (`git`, `gitlens`, `pr`, …) sharing the working-tree `fsPath`, which is why both panels lit up. |
| Regression test | [revalidateOnEdit.test.ts](../tests/extension-host/suite/revalidateOnEdit.test.ts) | New extension-host case registers a `TextDocumentContentProvider` for a VCS-style scheme mirroring the fixture's `fsPath` and content (how a diff source panel opens), then asserts the document carries zero `gitlab-component-helper` diagnostics. Verified load-bearing — fails when validation runs on non-`file` schemes. |

## Validation
### Local checks
- [x] `npm run compile` (`tsc --noEmit` clean)
- [x] `npm run test:extension-host` (12 passing, incl. the new diff-source case)

### Manual test notes
- Opened a `.gitlab-ci.yml` with a diagnostic-producing include, modified it, then opened a git diff. Before: squiggles on both panels. After: squiggles only on the destination (right) panel; the read-only source panel is clean.

## Breaking Changes
- [x] No breaking changes
- [ ] Breaking changes (describe below)

## Release Notes Draft
- Fix: validation diagnostics no longer appear on the read-only source panel of a diff view.
