### PR TITLE
fix: recognise braced ${VAR} GitLab variables in component URLs

### DIFF
--- a/src/utils/gitlabVariables.ts
+++ b/src/utils/gitlabVariables.ts
@@ -165,15 +165,16 @@ export const GITLAB_PREDEFINED_VARIABLES: GitLabVariable[] = [
  * Detects GitLab predefined variables in a string
  */
 export function detectGitLabVariables(text: string): string[] {
-  const variablePattern = /\$([A-Z_][A-Z0-9_]*)/g;
-  const matches = text.match(variablePattern);
-
-  if (!matches) {
-    return [];
-  }
-
-  const variables = matches.map(match => match.substring(1)); // Remove the $
+  // Match both the bare `$VAR` and braced `${VAR}` forms GitLab CI accepts; the capture group
+  // yields just the variable name, excluding the `$` and any surrounding braces.
+  const variablePattern = /\$\{?([A-Z_][A-Z0-9_]*)\}?/g;
   const predefinedVariableNames = GITLAB_PREDEFINED_VARIABLES.map(v => v.name);
+
+  const variables: string[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = variablePattern.exec(text)) !== null) {
+    variables.push(match[1]);
+  }
 
   return variables.filter(variable => predefinedVariableNames.includes(variable));
 }
@@ -195,6 +196,10 @@ export function expandComponentUrl(componentUrl: string, context?: {
   commitSha?: string; // Optionally provide a commit SHA for expansion
 }): string {
   let expanded = componentUrl;
+
+  // Normalize the braced `${VAR}` form to bare `$VAR` up front, so the expansions below — and the
+  // `$CI_SERVER_FQDN/` URL special-case — handle both spellings GitLab CI accepts.
+  expanded = expanded.replace(/\$\{([A-Z_][A-Z0-9_]*)\}/g, (_match, name) => `$${name}`);
 
   if (context) {
     // Handle URL expansion carefully to maintain proper URL structure

--- a/tests/unit/gitlabVariables.test.ts
+++ b/tests/unit/gitlabVariables.test.ts
@@ -1,0 +1,64 @@
+// @mocha
+/**
+ * gitlabVariables tests — predefined-variable detection and component-URL expansion.
+ *
+ * The load-bearing case here is the braced `${VAR}` form (issue #136): GitLab CI accepts both
+ * `$CI_SERVER_FQDN` and `${CI_SERVER_FQDN}`, but only the bare form used to be detected/expanded,
+ * so a braced component URL got no hover/completion/validation.
+ */
+
+import * as assert from 'node:assert/strict';
+import {
+  detectGitLabVariables,
+  containsGitLabVariables,
+  expandComponentUrl,
+} from '../../src/utils/gitlabVariables';
+
+suite('detectGitLabVariables', () => {
+  test('detects the bare $VAR form', () => {
+    assert.deepStrictEqual(detectGitLabVariables('$CI_SERVER_FQDN/group/comp@1.0.0'), ['CI_SERVER_FQDN']);
+  });
+
+  test('detects the braced ${VAR} form', () => {
+    assert.deepStrictEqual(detectGitLabVariables('${CI_SERVER_FQDN}/group/comp@1.0.0'), ['CI_SERVER_FQDN']);
+  });
+
+  test('detects both forms in the same string', () => {
+    assert.deepStrictEqual(
+      detectGitLabVariables('${CI_SERVER_FQDN}/$CI_PROJECT_PATH/comp@1.0.0'),
+      ['CI_SERVER_FQDN', 'CI_PROJECT_PATH'],
+    );
+  });
+
+  test('ignores non-predefined variables in either form', () => {
+    assert.deepStrictEqual(detectGitLabVariables('$NOT_A_GITLAB_VAR/${ALSO_NOT_ONE}'), []);
+  });
+});
+
+suite('containsGitLabVariables', () => {
+  test('is true for both the bare and braced forms', () => {
+    assert.strictEqual(containsGitLabVariables('$CI_SERVER_FQDN/x'), true);
+    assert.strictEqual(containsGitLabVariables('${CI_SERVER_FQDN}/x'), true);
+  });
+
+  test('is false when no predefined variable is present', () => {
+    assert.strictEqual(containsGitLabVariables('gitlab.com/group/comp@1.0.0'), false);
+  });
+});
+
+suite('expandComponentUrl — braced and bare forms expand identically', () => {
+  const context = { gitlabInstance: 'gitlab.example.com', projectPath: 'my-group/my-project' };
+
+  test('$CI_SERVER_FQDN expands to an https:// URL in both forms', () => {
+    const expected = 'https://gitlab.example.com/group/comp@1.0.0';
+    assert.strictEqual(expandComponentUrl('$CI_SERVER_FQDN/group/comp@1.0.0', context), expected);
+    assert.strictEqual(expandComponentUrl('${CI_SERVER_FQDN}/group/comp@1.0.0', context), expected);
+  });
+
+  test('a mid-path braced variable is expanded', () => {
+    assert.strictEqual(
+      expandComponentUrl('$CI_SERVER_FQDN/${CI_PROJECT_PATH}/comp@1.0.0', context),
+      'https://gitlab.example.com/my-group/my-project/comp@1.0.0',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes hover/completion/validation not firing on component URLs that use the **braced** `${VAR}` GitLab variable form. `detectGitLabVariables` / `containsGitLabVariables` and `expandComponentUrl` only handled the bare `$VAR` form, so `${CI_SERVER_FQDN}/group/comp@1.0.0` got no expansion and therefore no assistance — while `$CI_SERVER_FQDN/...` worked.
- Link related issue(s): Fixes #136

## Change Type
- [x] fix
- [x] test

## What changed
- **Detection** ([gitlabVariables.ts](src/utils/gitlabVariables.ts)) — `detectGitLabVariables` now matches both `$VAR` and `${VAR}` via `/\$\{?([A-Z_][A-Z0-9_]*)\}?/g`, capturing just the name (no `$`/braces). `containsGitLabVariables` rides on it unchanged.
- **Expansion** — `expandComponentUrl` normalizes `${VAR}` → `$VAR` up front, so the existing replacement chain (and the `$CI_SERVER_FQDN/` → `https://` URL special-case) handles both spellings without duplicating every rule.
- **Tests** ([gitlabVariables.test.ts](tests/unit/gitlabVariables.test.ts), new) — both forms for detection, `containsGitLabVariables`, and `expandComponentUrl` (including a mid-path `${CI_PROJECT_PATH}`), plus a negative case.

The "also surfaced" minor cleanups noted in #136 (restoring a couple of `logger.warn`s, a stale JSDoc) are intentionally out of scope here — happy to split those into a follow-up.

## Validation
- [x] `npm run check-types` clean
- [x] `npm test` — 255 passing (8 new)
- [x] `npm run lint` — clean (`--max-warnings 0`)

## Affected areas
- [x] Completion provider
- [x] Hover provider
- [x] Validation provider

## Breaking Changes
- [x] No breaking changes
