### PR TITLE
docs(ci): document dev-scope security-alert policy in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,11 @@
+# Dependabot version updates.
+#
+# Security-alert policy (handled OUTSIDE this file): dev-scoped npm vulnerabilities are not gated.
+# They are auto-dismissed by a Dependabot auto-triage rule (repo Settings -> Code security ->
+# Dependabot -> Auto-triage rules: scope = development -> dismiss), mirroring the dev-group override
+# in osv-scanner.toml that the Argus scan honors. Do NOT add a dev-dep `ignore:` here to suppress
+# those alerts -- `ignore:` also stops the version-update PRs below, which are how dev tools stay
+# current and how a transitive fix (e.g. serialize-javascript >= 7.0.5) actually lands.
 version: 2
 updates:
   # Maintain npm dependencies


### PR DESCRIPTION
Adds a header comment to `.github/dependabot.yml` documenting where dev-scope security alerts are handled, so the policy is discoverable in-repo.

## Why
Dev-scoped npm vuln alerts are intentionally not gated: they're auto-dismissed by a Dependabot **auto-triage rule** (Settings → Code security → Dependabot → Auto-triage rules: scope = development → dismiss), mirroring the dev-group override in `osv-scanner.toml` that the Argus scan honors. None of that lives in `dependabot.yml`, so a maintainer reading this file had no breadcrumb.

The comment also warns against adding a dev-dep `ignore:` here — that would also stop the version-update PRs (the `dev-dependencies` group), which keep dev tools current and deliver transitive fixes (e.g. `serialize-javascript >= 7.0.5`).

## Change Type
- [x] docs

Docs-only, no behavior change. Companion to dismissing the two open dev-scope `serialize-javascript` alerts (#34, #73).