### PR TITLE
fix: input completions offered outside the input-name slot

### DIFF
--- a/src/providers/completionInputContext.ts
+++ b/src/providers/completionInputContext.ts
@@ -37,10 +37,17 @@ function indentOf(line: string): number {
  *
  * @param text - The full YAML document text.
  * @param lineIndex - 0-based line index where the cursor sits.
+ * @param column - 0-based cursor column. When given, the cursor must actually sit at the slot's indent column —
+ *   typing the right indentation then moving the cursor left leaves the spaces in place but no longer offers
+ *   completions. Omit to check the line's text alone (the cursor-agnostic form used by tests).
  * @returns A populated {@link CompletionInputContext} when the cursor is in a parameter-name slot inside the
  *   `inputs:` block of the closest preceding `component:`/`local:` include; `null` otherwise.
  */
-export function findCompletionInputContextAtLine(text: string, lineIndex: number): CompletionInputContext | null {
+export function findCompletionInputContextAtLine(
+  text: string,
+  lineIndex: number,
+  column?: number
+): CompletionInputContext | null {
   const parsed = parseYaml(text);
   if (!isYamlNode(parsed) || !parsed.include) return null;
 
@@ -55,12 +62,26 @@ export function findCompletionInputContextAtLine(text: string, lineIndex: number
   if (!section) return null;
 
   // Containment in the inputs block is already established above; here we only check the line looks like a
-  // parameter-name slot: indented deeper than the `inputs:` key (i.e. a child of it, not a sibling) and not
-  // already a complete `key: value`.
+  // parameter-name slot. A name slot must line up at the same column as the existing input keys
+  // (`section.childIndent`) — one column shallower is a sibling of `inputs:`, deeper is a value nested under
+  // another input. When the block has no keys yet, fall back to "deeper than `inputs:`". It must also not be an
+  // array-item line (`- value`, part of a parameter value) nor an already-complete `key: value`.
   const currentLine = lines[lineIndex];
   const currentLineText = currentLine.trim();
+  const currentIndent = indentOf(currentLine);
+  const indentMatches =
+    section.childIndent !== null ? currentIndent === section.childIndent : currentIndent > section.inputsIndent;
+  // When a cursor column is supplied, the cursor must sit at the slot's indent column or within the name being
+  // typed after it — never left of the indent. Typing the right indentation then moving the cursor left leaves
+  // the line's whitespace intact, so the indent check above still matches; but the cursor is no longer in the
+  // name slot, so we must not offer completions there.
+  const cursorAtSlot = column === undefined || column >= currentIndent;
   const isParameterContext =
-    indentOf(currentLine) > section.inputsIndent && (!currentLineText.includes(':') || currentLineText.endsWith(':'));
+    indentMatches &&
+    cursorAtSlot &&
+    !currentLineText.startsWith('- ') &&
+    currentLineText !== '-' &&
+    (!currentLineText.includes(':') || currentLineText.endsWith(':'));
   if (!isParameterContext) return null;
 
   return {
@@ -126,15 +147,21 @@ function findClosestInclude(includes: unknown[], lines: string[], lineIndex: num
  * boundary test, so the mapping form (where `inputs:` sits at the same indent as the include's `component:` key)
  * isn't mistaken for the section end.
  *
- * @returns the `inputs:` line's indentation when `lineIndex` is inside the block, so the caller can decide what
- *   counts as a parameter-name slot relative to it; `null` when the cursor isn't inside an inputs block.
+ * @returns when `lineIndex` is inside the block: the `inputs:` line's indentation, and `childIndent` — the
+ *   indentation of the first parameter key under it (the column input names line up at), or `null` when the block
+ *   has no keys yet. `null` (the whole result) when the cursor isn't inside an inputs block.
  */
-function findInputsSection(lines: string[], componentLineIndex: number, lineIndex: number): { inputsIndent: number } | null {
+function findInputsSection(
+  lines: string[],
+  componentLineIndex: number,
+  lineIndex: number
+): { inputsIndent: number; childIndent: number | null } | null {
   const componentIndent = indentOf(lines[componentLineIndex]);
 
   let inputsSectionStart = -1;
   let inputsIndent = -1;
   let inputsSectionEnd = -1;
+  let childIndent: number | null = null;
 
   for (let i = componentLineIndex + 1; i < lines.length; i++) {
     const trimmedLine = lines[i].trim();
@@ -152,13 +179,25 @@ function findInputsSection(lines: string[], componentLineIndex: number, lineInde
       inputsSectionEnd = i;
       break;
     }
+
+    // The first key directly under `inputs:` (not an array item, deeper than `inputs:` itself) fixes the column
+    // that input names line up at. Lines nested deeper than this belong to a parameter's value, not a name slot.
+    if (
+      inputsSectionStart !== -1 &&
+      childIndent === null &&
+      indentOf(lines[i]) > inputsIndent &&
+      !trimmedLine.startsWith('- ') &&
+      trimmedLine.includes(':')
+    ) {
+      childIndent = indentOf(lines[i]);
+    }
   }
 
   if (inputsSectionStart === -1) return null;
   if (inputsSectionEnd === -1) inputsSectionEnd = lines.length;
 
   if (lineIndex > inputsSectionStart && lineIndex < inputsSectionEnd) {
-    return { inputsIndent };
+    return { inputsIndent, childIndent };
   }
   return null;
 }

--- a/src/providers/completionProvider.ts
+++ b/src/providers/completionProvider.ts
@@ -363,7 +363,7 @@ export class CompletionProvider implements vscode.CompletionItemProvider {
     try {
       const text = document.getText();
 
-      const context = findCompletionInputContextAtLine(text, position.line);
+      const context = findCompletionInputContextAtLine(text, position.line, position.character);
       if (!context) {
         this.logger.debug(`[CompletionProvider] No inputs parameter-name slot at cursor`, 'CompletionProvider');
         return null;

--- a/tests/unit/completionInputContext.test.ts
+++ b/tests/unit/completionInputContext.test.ts
@@ -50,6 +50,79 @@ suite('findCompletionInputContextAtLine', () => {
     });
   });
 
+  test('returns null when the cursor sits left of the slot indent, even though the line is indented correctly', () => {
+    // The slot line has the right 6-space indent, but the cursor has been moved left to column 3 — it is no
+    // longer in the name slot, so no completions should be offered.
+    const text = `include:
+  - component: ${FULL_PIPELINE_URL}
+    inputs:
+      environment: "dev"
+      `;
+    assert.strictEqual(findCompletionInputContextAtLine(text, 4, 3), null);
+  });
+
+  test('detects the slot when the cursor sits at the slot indent', () => {
+    const text = `include:
+  - component: ${FULL_PIPELINE_URL}
+    inputs:
+      environment: "dev"
+      `;
+    assert.deepStrictEqual(findCompletionInputContextAtLine(text, 4, 6)?.existingInputNames, ['environment']);
+  });
+
+  test('returns null inside a multi-line array input, where a `- item` line is a value not a name slot', () => {
+    // An array item nested under an input is deeper-indented than `inputs:` and has no `:`, but it is part of a
+    // parameter value — completing input names there would interrupt the array.
+    const text = `include:
+  - component: ${FULL_PIPELINE_URL}
+    inputs:
+      tags:
+        - one
+        - two
+      environment: "dev"`;
+    const ctx = findCompletionInputContextAtLine(text, 5); // the `- two` array item line
+    assert.strictEqual(ctx, null);
+  });
+
+  test('returns null when the slot is one column shallower than the existing input keys', () => {
+    // Existing keys sit at 6 spaces; a 5-space slot is misaligned (a sibling of `inputs:`), not a name slot.
+    const text =
+      'include:\n' +
+      `  - component: ${FULL_PIPELINE_URL}\n` +
+      '    inputs:\n' +
+      '      environment: "dev"\n' +
+      '     ';
+    const ctx = findCompletionInputContextAtLine(text, 4);
+    assert.strictEqual(ctx, null);
+  });
+
+  test('returns null when the slot is deeper than the existing input keys (a nested value position)', () => {
+    // Existing keys sit at 6 spaces; an 8-space slot is nested under a value, not a name slot.
+    const text =
+      'include:\n' +
+      `  - component: ${FULL_PIPELINE_URL}\n` +
+      '    inputs:\n' +
+      '      environment: "dev"\n' +
+      '        ';
+    const ctx = findCompletionInputContextAtLine(text, 4);
+    assert.strictEqual(ctx, null);
+  });
+
+  test('detects a slot aligned with the existing input keys', () => {
+    const text =
+      'include:\n' +
+      `  - component: ${FULL_PIPELINE_URL}\n` +
+      '    inputs:\n' +
+      '      environment: "dev"\n' +
+      '      ';
+    const ctx = findCompletionInputContextAtLine(text, 4);
+    assert.deepStrictEqual(ctx, {
+      componentUrl: FULL_PIPELINE_URL,
+      includeKind: 'component',
+      existingInputNames: ['environment'],
+    });
+  });
+
   test('reports existing inputs so the caller can filter them out', () => {
     const text = `include:
   - component: ${FULL_PIPELINE_URL}


### PR DESCRIPTION
## Summary
- Fixes input-name completion being offered outside a genuine parameter-name slot. Slot detection in `findCompletionInputContextAtLine` decided "is this a name slot?" from the line's leading-whitespace count alone (just "deeper than `inputs:`"), so it fired on array-item lines, at misaligned indentation (shallower or deeper than the existing keys), and — because it never read the cursor column — when the cursor was moved left along the indentation of an otherwise-correct line.
- Anchors the slot to the column the existing input keys line up at, excludes array-item lines, and gates on the cursor column so the cursor must sit at or beyond the slot indent.
- Link related issue(s): Fixes #184 

## Change Type
- [ ] feat
- [x] fix
- [ ] refactor
- [ ] docs
- [ ] test
- [ ] chore

## Context
### User-facing impact
- Input-name suggestions now appear only in a real parameter-name slot: aligned with the existing input keys (or, for an empty `inputs:` block, deeper than `inputs:`), never on an array value's `- item` line, and only when the cursor actually sits in the slot rather than having been moved left along its leading whitespace.

### GitLab scope
- [ ] gitlab.com
- [ ] self-managed GitLab
- [x] both (local slot detection only; no GitLab interaction)

### Affected areas
- [ ] Component Browser
- [ ] Hover provider
- [x] Completion provider
- [ ] Validation provider
- [ ] Cache and refresh behavior
- [ ] GitLab API calls/auth/token storage
- [ ] Docs only

## What changed by bucket

| Bucket | Files | Approach |
|---|---|---|
| Slot indentation | [completionInputContext.ts](../src/providers/completionInputContext.ts) | `findInputsSection` now also reports `childIndent` — the column of the first real input key under `inputs:` (skipping array items and the `inputs:` header). The slot check requires the cursor line to sit at exactly that column, falling back to the old "deeper than `inputs:`" rule only for an empty `inputs:` block with no keys to align to. Array-item lines (`- value`, bare `-`) are excluded, since they belong to a parameter's value, not a name slot. |
| Cursor column | [completionInputContext.ts](../src/providers/completionInputContext.ts), [completionProvider.ts](../src/providers/completionProvider.ts) | `findCompletionInputContextAtLine` takes an optional `column`; when supplied, the cursor must sit at or beyond the slot indent (`column >= currentIndent`), never left of it. The caller now passes `position.character` through. Omitting `column` preserves the cursor-agnostic behaviour the unit tests use. |
| Regression tests | [completionInputContext.test.ts](../tests/unit/completionInputContext.test.ts) | Added cases: array-item line → null; slot one column shallower → null; slot deeper/nested → null; slot aligned with the keys → detected; cursor moved left of the slot indent → null; cursor at the slot indent → detected. |

## Validation
### Local checks
- [x] `npm run compile` (`tsc --noEmit` clean)
- [x] `npm test` (261 passing)
- [x] `npm run lint` clean

### Manual test notes
- Reproduced in a `.gitlab-ci.yml` with a multi-line array input followed by a scalar input: completions previously appeared on the array's `- item` lines, one column either side of the keys, and after typing the right indent then moving the cursor left. After the fix, suggestions appear only when the cursor sits in a properly-aligned name slot.

## Breaking Changes
- [x] No breaking changes
- [ ] Breaking changes (describe below)

## Release Notes Draft
- Fix: GitLab component input suggestions now appear only in a correctly-aligned input slot, not on array values or when the cursor is moved left of the indent.
