### PR TITLE
fix: re-requesting input suggestions after typing part of a new input name returns nothing

### DIFF
--- a/src/providers/completionInputContext.ts
+++ b/src/providers/completionInputContext.ts
@@ -48,12 +48,17 @@ export function findCompletionInputContextAtLine(
   lineIndex: number,
   column?: number
 ): CompletionInputContext | null {
-  const parsed = parseYaml(text);
+  const lines = text.split('\n');
+  if (lines[lineIndex] === undefined) return null;
+
+  // A half-typed input name on the cursor line — `env` with no `:` yet — is a bare scalar where its sibling input
+  // keys are mappings, which makes the whole document invalid YAML. That would parse to `null` and offer nothing
+  // exactly while the user is typing the name. Blank the cursor line before parsing: it contributes nothing to the
+  // existing-input set (it *is* the slot being typed), and the positional scans below read `lines`, not the parse.
+  const parsed = parseInputDocument(text, lines, lineIndex);
   if (!isYamlNode(parsed) || !parsed.include) return null;
 
   const includes = Array.isArray(parsed.include) ? parsed.include : [parsed.include];
-  const lines = text.split('\n');
-  if (lines[lineIndex] === undefined) return null;
 
   const closest = findClosestInclude(includes, lines, lineIndex);
   if (!closest) return null;
@@ -89,6 +94,33 @@ export function findCompletionInputContextAtLine(
     includeKind: closest.includeKind,
     existingInputNames: closest.existingInputNames,
   };
+}
+
+/**
+ * Parse `text` as a YAML mapping, tolerating an in-progress input name on the cursor line.
+ *
+ * The document parses normally first. If that fails (or yields a non-mapping), and the cursor line looks like a
+ * partially-typed name — leading whitespace then a bare token with no `:` — the line is blanked and the document
+ * re-parsed. That token is the slot being typed; as a bare scalar beside its mapping siblings it makes the whole
+ * document invalid, so blanking it lets the surrounding structure parse while the user types.
+ *
+ * @param text - The full YAML document text to parse.
+ * @param lines - `text` split into lines, so the cursor line can be blanked without re-splitting.
+ * @param lineIndex - 0-based index of the cursor line, the one blanked on the retry.
+ * @returns the parsed value (from the original text where valid, otherwise the cursor-line-blanked retry), or the
+ *   original parse result when the cursor line isn't an in-progress name.
+ */
+function parseInputDocument(text: string, lines: string[], lineIndex: number): unknown {
+  const parsed = parseYaml(text, true);
+  if (isYamlNode(parsed) && parsed.include) return parsed;
+
+  const cursorLine = lines[lineIndex];
+  const isInProgressName = /^\s*[^\s:#-][^:]*$/.test(cursorLine);
+  if (!isInProgressName) return parsed;
+
+  const blanked = [...lines];
+  blanked[lineIndex] = '';
+  return parseYaml(blanked.join('\n'), true);
 }
 
 /**
@@ -230,7 +262,7 @@ function quoteYamlIfUnsafe(value: string, flow = false): string {
     return asDoubleQuoted(value);
   }
   try {
-    const parsed = parseYaml(`probe: ${value}`);
+    const parsed = parseYaml(`probe: ${value}`, true);
     if (isYamlNode(parsed) && parsed.probe === value) {
       return value;
     }

--- a/src/providers/componentBrowserEdit.ts
+++ b/src/providers/componentBrowserEdit.ts
@@ -121,7 +121,7 @@ export function findComponentLineRange(
 export function parseExistingComponentText(componentText: string): unknown {
   try {
     const wrappedYaml = `include:\n${componentText}`;
-    const parsed = parseYaml(wrappedYaml) as { include?: unknown } | null;
+    const parsed = parseYaml(wrappedYaml, true) as { include?: unknown } | null;
     if (!parsed || parsed.include === undefined) return null;
     if (Array.isArray(parsed.include)) {
       return parsed.include[0] ?? null;

--- a/src/providers/hoverInputContext.ts
+++ b/src/providers/hoverInputContext.ts
@@ -45,7 +45,8 @@ export function findInputContextAtLine(text: string, lineIndex: number): InputCo
   const inputName = inputMatch[2];
 
   // Need a parsed `include:` array to know which includes are in scope; if YAML doesn't parse, bail.
-  const parsed = parseYaml(text);
+  // Silent: hover runs against the live, often mid-edit document, where a parse failure is expected and handled.
+  const parsed = parseYaml(text, true);
   if (!isYamlNode(parsed) || !parsed.include) return null;
   const includes = Array.isArray(parsed.include) ? parsed.include : [parsed.include];
 

--- a/src/providers/validationProvider.ts
+++ b/src/providers/validationProvider.ts
@@ -131,7 +131,9 @@ export class ValidationProvider implements vscode.CodeActionProvider {
 
         const diagnostics: vscode.Diagnostic[] = [];
         const diagnosticKeys = new Set<string>(); // Track unique diagnostics to prevent duplicates
-        const parsedYaml = parseYaml(text);
+        // Silent: validation runs on every edit against the live, often mid-edit document; a parse failure is
+        // expected and handled below (diagnostics cleared), so it should not log to the debug console.
+        const parsedYaml = parseYaml(text, true);
 
         if (!isYamlNode(parsedYaml) || !parsedYaml.include) {
             this.diagnosticCollection.set(document.uri, diagnostics);

--- a/src/utils/yamlParser.ts
+++ b/src/utils/yamlParser.ts
@@ -12,7 +12,16 @@ export function isYamlNode(value: unknown): value is YamlNode {
 const parseCache = new Map<string, { content: string; parsed: unknown; timestamp: number }>();
 const CACHE_TTL = 5000; // 5 seconds TTL for parse cache
 
-export function parseYaml(text: string): unknown {
+/**
+ * Parse a YAML document.
+ *
+ * @param text - The YAML source to parse.
+ * @param silent - Suppress the `console.error` on a parse failure. Use when a parse failure is expected and
+ *   handled by the caller (e.g. probing a document that is invalid mid-edit), to avoid log noise on a hot path.
+ * @returns the parsed YAML value (a mapping, sequence, scalar, or `undefined` for empty input), or `null` if the
+ *   text fails to parse. Callers narrow object results with {@link isYamlNode} before reading fields.
+ */
+export function parseYaml(text: string, silent = false): unknown {
   try {
     // Generate a simple hash of the content for caching
     const contentHash = text.length + text.substring(0, 100) + text.substring(text.length - 100);
@@ -35,7 +44,9 @@ export function parseYaml(text: string): unknown {
 
     return parsed;
   } catch (e) {
-    console.error('Error parsing YAML:', e);
+    if (!silent) {
+      console.error('Error parsing YAML:', e);
+    }
     return null;
   }
 }

--- a/tests/unit/completionInputContext.test.ts
+++ b/tests/unit/completionInputContext.test.ts
@@ -70,6 +70,48 @@ suite('findCompletionInputContextAtLine', () => {
     assert.deepStrictEqual(findCompletionInputContextAtLine(text, 4, 6)?.existingInputNames, ['environment']);
   });
 
+  test('detects the slot while a new input name is being typed (bare token would otherwise break the parse)', () => {
+    // `env` with no `:` yet is a bare scalar beside the `environment` mapping, so the raw document is invalid YAML.
+    // Slot detection tolerates the in-progress name and still reports the already-present inputs.
+    const text = `include:
+  - component: ${FULL_PIPELINE_URL}
+    inputs:
+      environment: "dev"
+      env`;
+    const ctx = findCompletionInputContextAtLine(text, 4, 9);
+    assert.deepStrictEqual(ctx, {
+      componentUrl: FULL_PIPELINE_URL,
+      includeKind: 'component',
+      existingInputNames: ['environment'],
+    });
+  });
+
+  test('detects the slot for the first input while its name is being typed', () => {
+    // The in-progress name is the only thing under `inputs:`, so there are no existing inputs yet.
+    const text = `include:
+  - component: ${FULL_PIPELINE_URL}
+    inputs:
+      env`;
+    const ctx = findCompletionInputContextAtLine(text, 3, 9);
+    assert.deepStrictEqual(ctx, {
+      componentUrl: FULL_PIPELINE_URL,
+      includeKind: 'component',
+      existingInputNames: [],
+    });
+  });
+
+  test('detects the in-progress name slot when it is not at end of document', () => {
+    const text = `include:
+  - component: ${FULL_PIPELINE_URL}
+    inputs:
+      environment: "dev"
+      env
+stages:
+  - build`;
+    const ctx = findCompletionInputContextAtLine(text, 4, 9);
+    assert.deepStrictEqual(ctx?.existingInputNames, ['environment']);
+  });
+
   test('returns null inside a multi-line array input, where a `- item` line is a value not a name slot', () => {
     // An array item nested under an input is deeper-indented than `inputs:` and has no `:`, but it is part of a
     // parameter value — completing input names there would interrupt the array.


### PR DESCRIPTION
## Summary
- Fixes manually re-requesting input-name completions (Ctrl+Space) returning nothing after part of a new input's name has been typed. A half-typed name (`env` with no `:` yet) is a bare scalar beside its sibling input mappings, which makes the whole document invalid YAML; `parseYaml` returned `null`, so slot detection bailed. The auto-triggered popup on a blank slot still works — the failure is specific to re-invoking completion once characters are on the line.
- Slot detection now tolerates an in-progress name: when the raw parse fails and the cursor line looks like a partially-typed name, it re-parses with that one line blanked, so the surrounding structure parses and the already-present inputs are still reported.
- Also stops the editor-interaction providers spamming the debug console with `Error parsing YAML:` on every keystroke. The in-progress-name fix parses an intentionally-invalid mid-edit document, and the existing completion/hover/validation providers already parse the live (often mid-edit) document and handle a `null` result themselves — none of them want the log. `parseYaml` gains an opt-in `silent` flag and these callers pass it.
- Link related issue(s): Fixes #191

## Change Type
- [ ] feat
- [x] fix
- [ ] refactor
- [ ] docs
- [ ] test
- [ ] chore

## Context
### User-facing impact
- Re-requesting input-name suggestions (Ctrl+Space) after typing part of a name now returns the suggestions, filtered to the partial text, instead of an empty list.
- The "GitLab Component Helper" debug console is no longer flooded with `Error parsing YAML:` messages while editing a `.gitlab-ci.yml`.

### GitLab scope
- [ ] gitlab.com
- [ ] self-managed GitLab
- [x] both (local slot detection and parse logging only; no GitLab interaction)

### Affected areas
- [x] Component Browser
- [x] Hover provider
- [x] Completion provider
- [x] Validation provider
- [ ] Cache and refresh behavior
- [ ] GitLab API calls/auth/token storage
- [ ] Docs only

## What changed by bucket

| Bucket | Files | Approach |
|---|---|---|
| Parse resilience | [completionInputContext.ts](../src/providers/completionInputContext.ts) | New `parseInputDocument` helper: parses the document normally; if that yields no usable `include` mapping and the cursor line matches an in-progress name (leading whitespace, then a bare token with no `:`), it re-parses with the cursor line blanked. That line is the slot being typed — it contributes nothing to the existing-input set — and the positional scans read the original `lines`, so blanking it only unblocks the structural parse. When the cursor line isn't an in-progress name, the original (failed) parse result is returned unchanged, so unrelated syntax errors aren't masked. |
| Silent parse option | [yamlParser.ts](../src/utils/yamlParser.ts) | `parseYaml` gains an opt-in `silent` flag (defaults to `false`, so existing behaviour is unchanged) that suppresses the `console.error` on a parse failure. |
| Quieter editor providers | [completionInputContext.ts](../src/providers/completionInputContext.ts), [hoverInputContext.ts](../src/providers/hoverInputContext.ts), [validationProvider.ts](../src/providers/validationProvider.ts), [componentBrowserEdit.ts](../src/providers/componentBrowserEdit.ts) | The parses on editor-interaction paths now pass `silent: true`: the two in `parseInputDocument`, the `quoteYamlIfUnsafe` round-trip probe (which intentionally parses values that may be invalid YAML), hover and validation parsing the live mid-edit document, and the captured-include-block parse in the browser. Each already handles a `null` result, so none relied on the log; surfacing real YAML errors to the user is the validation provider's job (via diagnostics), not the debug console. |
| Regression tests | [completionInputContext.test.ts](../tests/unit/completionInputContext.test.ts) | Added cases: typing a new name beside an existing input → slot detected, existing input reported; typing the first input's name (no existing inputs) → slot detected, empty existing set; in-progress name not at end of document → slot detected. |

## Validation
### Local checks
- [x] `npm run compile` (`tsc --noEmit` clean)
- [x] `npm test` (264 passing)
- [x] `npm run lint` clean

### Manual test notes
- Reproduced in a `.gitlab-ci.yml` with an existing input followed by a half-typed new input name: dismissing the popup, typing `env`, and pressing Ctrl+Space previously returned nothing. After the fix the re-requested list returns and filters to the typed text.
- Watched the "GitLab Component Helper" debug console while editing: previously it streamed `Error parsing YAML:` on most keystrokes (mid-edit documents and the value-quoting probe). After the fix the console stays quiet during editing.

## Breaking Changes
- [x] No breaking changes
- [ ] Breaking changes (describe below)

## Release Notes Draft
- Fix: re-requesting GitLab component input suggestions after typing part of a new input name now returns the matching suggestions; the debug console no longer logs YAML parse errors while editing.
