### PR TITLE
feat(version-check): detect outdated component versions (semver upgrade hints)

### DIFF
--- a/package.json
+++ b/package.json
@@ -220,6 +220,20 @@
           },
           "default": [],
           "description": "Extra GitLab CI file globs, merged with the built-in defaults. Patterns match at any directory depth (e.g. 'ci/*.yml' is treated as '**/ci/*.yml')."
+        },
+        "gitlabComponentHelper.versionCheck.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Warn when a component pinned to a semantic version (X.Y.Z) has a newer stable release available. Checked when a GitLab CI file is opened or saved."
+        },
+        "gitlabComponentHelper.versionCheck.severity": {
+          "type": "string",
+          "enum": [
+            "warning",
+            "information"
+          ],
+          "default": "warning",
+          "description": "Severity of the 'newer component version available' diagnostic."
         }
       }
     },
@@ -259,6 +273,10 @@
       {
         "command": "gitlab-component-helper.showPerformanceStats",
         "title": "GitLab CI: Show Performance Statistics"
+      },
+      {
+        "command": "gitlab-component-helper.updateAllComponentVersions",
+        "title": "GitLab CI: Update All Component Versions to Latest"
       }
     ],
     "menus": {
@@ -266,6 +284,11 @@
         {
           "when": "gitlabComponentHelper.isCiFile",
           "command": "gitlab-component-helper.browseComponents",
+          "group": "navigation"
+        },
+        {
+          "when": "gitlabComponentHelper.isCiFile",
+          "command": "gitlab-component-helper.updateAllComponentVersions",
           "group": "navigation"
         }
       ]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -618,6 +618,31 @@ export function activate(context: vscode.ExtensionContext) {
     // Initialize the validation provider
     const validationProvider = new ValidationProvider(context);
 
+    // Register command to update every outdated component in the active file to its latest stable version.
+    logger.debug('[Extension] Registering updateAllComponentVersions command...', 'Extension');
+    context.subscriptions.push(
+      vscode.commands.registerCommand('gitlab-component-helper.updateAllComponentVersions', async () => {
+        const editor = vscode.window.activeTextEditor;
+        if (!editor) {
+          vscode.window.showErrorMessage('Open a GitLab CI file to update component versions.');
+          return;
+        }
+        try {
+          const updated = await validationProvider.updateAllComponentVersions(editor.document);
+          if (updated === 0) {
+            vscode.window.showInformationMessage('All components are already on their latest version.');
+          } else {
+            vscode.window.showInformationMessage(
+              `Updated ${updated} component${updated === 1 ? '' : 's'} to the latest version.`
+            );
+          }
+        } catch (error) {
+          logger.error(`[Extension] Failed to update component versions: ${error}`, 'Extension');
+          vscode.window.showErrorMessage(`Failed to update component versions: ${error}`);
+        }
+      })
+    );
+
     // Keep the `gitlabComponentHelper.isCiFile` context key in sync with `isGitLabCIFile` so the editor context menu
     // shows the Browse Components command on exactly the same files the providers activate on.
     const updateCiFileContext = (editor: vscode.TextEditor | undefined): void => {

--- a/src/providers/componentVersionCheck.ts
+++ b/src/providers/componentVersionCheck.ts
@@ -1,0 +1,124 @@
+/**
+ * Pure detection of out-of-date component version refs in a `.gitlab-ci.yml`.
+ *
+ * Given the document text and a resolver that yields the available versions for a component's project, this finds
+ * every `component:` include pinned to a clean semver ref that has a newer stable release available, and returns the
+ * ref's location (line + column span) so the provider can place a precise diagnostic squiggle and the "update" flows
+ * can rewrite exactly the version ref.
+ *
+ * Only clean stable semver refs are considered (see {@link isCleanSemver}); floating refs and monorepo
+ * tag-pattern refs (e.g. `my-comp-1.2.3`) are not clean semver and are skipped. Kept free of `vscode` imports for
+ * unit-testability — the provider supplies the (async) version resolver and converts findings into vscode types.
+ */
+
+import { isCleanSemver, getLatestStableSemver, isOutdated } from '../utils/semver';
+
+/** A component include whose pinned semver ref is behind the latest available stable release. */
+export interface OutdatedComponentRef {
+  /** Full component URL as written, including the `@version` suffix. */
+  componentUrl: string;
+  /** Project + component base URL (the `@version` stripped) — the key version lookups are cached under. */
+  baseUrl: string;
+  /** Short component name (last path segment of the base URL), for diagnostic messages. */
+  componentName: string;
+  /** 0-based document line of the `component:` entry. */
+  line: number;
+  /** Column (0-based) where the version ref starts — just past the `@`. */
+  refStart: number;
+  /** Column (0-based, exclusive) where the version ref ends. */
+  refEnd: number;
+  /** The pinned ref currently in the document. */
+  currentVersion: string;
+  /** The latest stable semver available for the component. */
+  latestVersion: string;
+}
+
+/**
+ * A `component:` include line: leading indent, an optional `- ` list marker, the `component:` key, and the URL value
+ * (optionally quoted). Group 1 is everything up to and including the opening quote, so its length is the column the
+ * URL value starts at.
+ */
+const COMPONENT_LINE = /^(\s*(?:-\s*)?component:\s*['"]?)(\S+?)['"]?\s*$/;
+
+/**
+ * Split a component URL into its base and `@version` ref.
+ *
+ * @param url The full component URL (e.g. `https://gitlab.com/g/p/c@1.2.3`).
+ * @returns The base URL and the version ref, or `version: undefined` when the URL carries no `@ref`.
+ */
+export function splitComponentRef(url: string): { baseUrl: string; version: string | undefined } {
+  const at = url.lastIndexOf('@');
+  if (at === -1) return { baseUrl: url, version: undefined };
+  return { baseUrl: url.slice(0, at), version: url.slice(at + 1) };
+}
+
+/**
+ * Collect the base URLs of every component include pinned to a clean semver ref.
+ *
+ * The provider uses this to fetch each project's versions once (deduplicated) before running the synchronous
+ * {@link findOutdatedComponentRefs} pass.
+ *
+ * @param text The full document text.
+ * @returns Unique base URLs, in first-seen document order.
+ */
+export function collectSemverComponentBases(text: string): string[] {
+  const bases = new Set<string>();
+  for (const lineText of text.split('\n')) {
+    const match = COMPONENT_LINE.exec(lineText);
+    if (!match) continue;
+    const { baseUrl, version } = splitComponentRef(match[2]);
+    if (version && isCleanSemver(version)) {
+      bases.add(baseUrl);
+    }
+  }
+  return [...bases];
+}
+
+/**
+ * Find every component include whose pinned semver ref is behind the latest stable release.
+ *
+ * @param text The full document text.
+ * @param availableVersionsFor Resolver returning the known refs (tags/branches) for a component's base URL, or
+ *   `undefined` when they couldn't be determined (offline, unknown project) — those components are skipped.
+ * @returns One {@link OutdatedComponentRef} per outdated include, in document order.
+ */
+export function findOutdatedComponentRefs(
+  text: string,
+  availableVersionsFor: (baseUrl: string) => readonly string[] | undefined,
+): OutdatedComponentRef[] {
+  const findings: OutdatedComponentRef[] = [];
+  const lines = text.split('\n');
+
+  for (let line = 0; line < lines.length; line++) {
+    const match = COMPONENT_LINE.exec(lines[line]);
+    if (!match) continue;
+
+    const valueStart = match[1].length; // column the URL value begins at (past any opening quote)
+    const componentUrl = match[2];
+    const { baseUrl, version } = splitComponentRef(componentUrl);
+
+    // Only clean stable semver refs are eligible; everything else is left untouched.
+    if (!version || !isCleanSemver(version)) continue;
+
+    const versions = availableVersionsFor(baseUrl);
+    if (!versions || versions.length === 0) continue;
+
+    const latestVersion = getLatestStableSemver(versions);
+    if (!latestVersion || !isOutdated(version, latestVersion)) continue;
+
+    // The ref sits at the tail of the URL value: <value-start> + <base> + '@'.
+    const refStart = valueStart + baseUrl.length + 1;
+    findings.push({
+      componentUrl,
+      baseUrl,
+      componentName: baseUrl.split('/').filter(Boolean).pop() ?? baseUrl,
+      line,
+      refStart,
+      refEnd: refStart + version.length,
+      currentVersion: version,
+      latestVersion,
+    });
+  }
+
+  return findings;
+}

--- a/src/providers/hoverContentBuilder.ts
+++ b/src/providers/hoverContentBuilder.ts
@@ -6,6 +6,7 @@
 
 import type { Component } from './componentDetector';
 import { templateFileUrlForResolved } from '../utils/templateFileUrl';
+import { isOutdated } from '../utils/semver';
 
 /**
  * The position context the "Open in Detailed View" command needs to round-trip the cursor location back to the
@@ -28,12 +29,21 @@ export interface HoverContext {
  *     `<gitlabInstance>/<path>` plain text, otherwise the bare `component.source` string. Skipped entirely if
  *     none of those are present.
  *  5. `**Version:** <version>` when set.
- *  6. Parameters table (header + separator + one row per `parameters[]`), or omitted when there are no parameters.
+ *  6. `**Latest:** <latestVersion>` when `latestVersion` is provided — annotated with whether an update is
+ *     available (current ref behind latest) or the pin is already current. Omitted when `latestVersion` is absent
+ *     (non-semver refs, or versions couldn't be resolved).
+ *  7. Parameters table (header + separator + one row per `parameters[]`), or omitted when there are no parameters.
  *
- * @param component The resolved component to render.
- * @param context   Cursor + document location used to build the detach-command URL.
+ * @param component     The resolved component to render.
+ * @param context       Cursor + document location used to build the detach-command URL.
+ * @param latestVersion The latest stable semver available for the component, when known. Compared against
+ *                      `component.version` to label the line as an available update or as up-to-date.
  */
-export function buildComponentHoverMarkdown(component: Component, context: HoverContext): string {
+export function buildComponentHoverMarkdown(
+  component: Component,
+  context: HoverContext,
+  latestVersion?: string,
+): string {
   let md = '';
 
   md += `## ${component.name}\n\n`;
@@ -67,6 +77,14 @@ export function buildComponentHoverMarkdown(component: Component, context: Hover
 
   if (component.version) {
     md += `**Version:** ${component.version}\n\n`;
+  }
+
+  if (latestVersion) {
+    const annotation =
+      component.version && isOutdated(component.version, latestVersion)
+        ? ' — ⚠️ update available'
+        : ' — ✓ up to date';
+    md += `**Latest:** ${latestVersion}${annotation}\n\n`;
   }
 
   if (component.parameters && component.parameters.length > 0) {

--- a/src/providers/hoverProvider.ts
+++ b/src/providers/hoverProvider.ts
@@ -1,10 +1,13 @@
 import * as vscode from 'vscode';
-import { detectIncludeComponent } from './componentDetector';
+import { detectIncludeComponent, Component } from './componentDetector';
 import { Logger } from '../utils/logger';
 import { getVariableInfo } from '../utils/gitlabVariables';
 import { isGitLabCIFile } from '../utils/gitlabCiFileMatcher';
 import { findInputContextAtLine } from './hoverInputContext';
 import { buildComponentHoverMarkdown } from './hoverContentBuilder';
+import { getComponentCacheManager } from '../services/cache/componentCacheManager';
+import { isCleanSemver, getLatestStableSemver } from '../utils/semver';
+import type { CachedComponent } from '../types/cache';
 
 export class HoverProvider implements vscode.HoverProvider {
   private logger = Logger.getInstance();
@@ -75,11 +78,13 @@ export class HoverProvider implements vscode.HoverProvider {
       this.logger.debug(`[HoverProvider] Component source: ${component.context?.gitlabInstance || component.source || 'unknown'}`, 'HoverProvider');
       this.logger.debug(`[HoverProvider] Component has ${component.parameters?.length || 0} parameters`, 'HoverProvider');
 
+      const latestVersion = await this.getLatestStableVersion(component);
+
       const hoverContent = new vscode.MarkdownString(
         buildComponentHoverMarkdown(component, {
           documentUri: document.uri.toString(),
           position: { line: position.line, character: position.character },
-        }),
+        }, latestVersion),
       );
       hoverContent.isTrusted = true;
       hoverContent.supportThemeIcons = true;
@@ -89,6 +94,48 @@ export class HoverProvider implements vscode.HoverProvider {
 
     this.logger.debug(`[HoverProvider] No component found at cursor position`, 'HoverProvider');
     return null;
+  }
+
+  /**
+   * Resolve the latest stable semver available for a hovered component, for the hover's "Latest" line.
+   *
+   * Only runs for components pinned to a clean semver ref — floating refs (`main`, `latest`, …) are deliberately
+   * left without an upgrade hint. Reuses the per-project version cache (so repeated hovers are cheap) and fails
+   * soft to `undefined` on any lookup error, so a hover never breaks because versions couldn't be fetched.
+   *
+   * @param component The resolved component under the cursor.
+   * @returns The latest stable semver ref, or `undefined` when the ref isn't semver or versions can't be resolved.
+   */
+  private async getLatestStableVersion(component: Component): Promise<string | undefined> {
+    if (!component.version || !isCleanSemver(component.version) || !component.context) {
+      return undefined;
+    }
+    // Hoist the narrowed context into a local so the closure below sees it as non-null without a `!` assertion.
+    const { context } = component;
+    try {
+      const cacheManager = getComponentCacheManager();
+      const cached = (await cacheManager.getComponents()).find(
+        c =>
+          c.gitlabInstance === context.gitlabInstance &&
+          c.sourcePath === context.path &&
+          c.name === component.name,
+      );
+      const lookup: CachedComponent = cached ?? {
+        name: component.name,
+        description: component.description ?? '',
+        parameters: [],
+        source: component.source ?? `${context.gitlabInstance}/${context.path}`,
+        sourcePath: context.path,
+        gitlabInstance: context.gitlabInstance,
+        version: component.version,
+        url: '',
+      };
+      const versions = await cacheManager.fetchComponentVersions(lookup);
+      return getLatestStableSemver(versions) ?? undefined;
+    } catch (error) {
+      this.logger.debug(`[HoverProvider] Could not resolve latest version for ${component.name}: ${error}`, 'HoverProvider');
+      return undefined;
+    }
   }
 
   /**

--- a/src/providers/validationMetadata.ts
+++ b/src/providers/validationMetadata.ts
@@ -72,12 +72,24 @@ export interface MissingRequiredInputMetadata {
   providedInputs: string[];
 }
 
+/** Metadata attached to `code: 'outdated-component-version'` diagnostics (a newer stable semver is available). */
+export interface OutdatedComponentVersionMetadata {
+  code: 'outdated-component-version';
+  /** Full component URL as it appears in the document, including the `@version` suffix. */
+  componentUrl: string;
+  /** The semver ref currently pinned in the document. */
+  currentVersion: string;
+  /** The latest stable semver available — the quick-fix replaces the ref with this. */
+  latestVersion: string;
+}
+
 /** All diagnostic metadata variants the validation provider attaches. */
 export type DiagnosticMetadata =
   | UnresolvedVariablesMetadata
   | ComponentFetchFailedMetadata
   | UnknownInputMetadata
-  | MissingRequiredInputMetadata;
+  | MissingRequiredInputMetadata
+  | OutdatedComponentVersionMetadata;
 
 /**
  * `vscode.Diagnostic` extended with the (optional) typed metadata payload. Used at write sites so

--- a/src/providers/validationProvider.ts
+++ b/src/providers/validationProvider.ts
@@ -11,6 +11,12 @@ import { resolveLocalComponent, isUnsupportedLocalPath } from './localComponentR
 import { attachDiagnosticMetadata, readDiagnosticMetadata } from './validationMetadata';
 import type { MissingRequiredInputMetadata } from './validationMetadata';
 import type { GitApi, GitRepository } from '../types/vscode-git';
+import type { CachedComponent } from '../types/cache';
+import {
+    collectSemverComponentBases,
+    findOutdatedComponentRefs,
+    type OutdatedComponentRef,
+} from './componentVersionCheck';
 import {
     type IncludeEntry,
     type LocalInclude,
@@ -22,6 +28,10 @@ import {
 
 export class ValidationProvider implements vscode.CodeActionProvider {
     private diagnosticCollection: vscode.DiagnosticCollection;
+    // Separate collection for "newer component version available" warnings. Kept apart from input/structure
+    // diagnostics so the on-save version check and the on-edit input validation never clobber each other's
+    // squiggles (VS Code merges diagnostics across collections natively).
+    private versionDiagnostics: vscode.DiagnosticCollection;
     private logger = Logger.getInstance();
     private cacheManager = getComponentCacheManager();
     private validationTimeouts = new Map<string, NodeJS.Timeout>(); // Throttle validation per document
@@ -37,6 +47,9 @@ export class ValidationProvider implements vscode.CodeActionProvider {
 
         this.diagnosticCollection = vscode.languages.createDiagnosticCollection('gitlab-component-helper');
         context.subscriptions.push(this.diagnosticCollection);
+
+        this.versionDiagnostics = vscode.languages.createDiagnosticCollection('gitlab-component-versions');
+        context.subscriptions.push(this.versionDiagnostics);
 
         // Register code action provider for the languages the providers run against.
         this.logger.debug('[ValidationProvider] Registering code action provider for yaml, gitlab-ci, and shellscript', 'ValidationProvider');
@@ -56,10 +69,15 @@ export class ValidationProvider implements vscode.CodeActionProvider {
 
         this.logger.debug('[ValidationProvider] Registering document event listeners', 'ValidationProvider');
         context.subscriptions.push(
-            vscode.workspace.onDidOpenTextDocument(doc => this.validate(doc)),
+            vscode.workspace.onDidOpenTextDocument(doc => {
+                this.validate(doc);
+                // Version checks hit the GitLab tags API, so they run on open/save rather than on every keystroke.
+                this.checkComponentVersions(doc);
+            }),
             vscode.workspace.onDidChangeTextDocument(e => {
                 this.scheduleValidation(e.document);
             }),
+            vscode.workspace.onDidSaveTextDocument(doc => this.checkComponentVersions(doc)),
             vscode.workspace.onDidCloseTextDocument(doc => {
                 const documentId = doc.uri.toString();
                 // Clear any pending validation timeouts
@@ -69,6 +87,7 @@ export class ValidationProvider implements vscode.CodeActionProvider {
                     this.validationTimeouts.delete(documentId);
                 }
                 this.diagnosticCollection.delete(doc.uri);
+                this.versionDiagnostics.delete(doc.uri);
             })
         );
 
@@ -89,6 +108,7 @@ export class ValidationProvider implements vscode.CodeActionProvider {
         vscode.workspace.textDocuments.forEach(doc => {
             this.logger.debug(`[ValidationProvider] Found open document: ${doc.fileName} (${doc.languageId})`, 'ValidationProvider');
             this.validate(doc);
+            this.checkComponentVersions(doc);
         });
     }
 
@@ -776,6 +796,21 @@ export class ValidationProvider implements vscode.CodeActionProvider {
                             actions.push(showAllMissingAction);
                         }
                     }
+                }
+            }
+            else if (diagnosticMetadata?.code === 'outdated-component-version') {
+                const metadata = diagnosticMetadata;
+                const updateTitle = `Update to ${metadata.latestVersion}`;
+                if (!actionTitles.has(updateTitle)) {
+                    actionTitles.add(updateTitle);
+
+                    const updateAction = new vscode.CodeAction(updateTitle, vscode.CodeActionKind.QuickFix);
+                    updateAction.edit = new vscode.WorkspaceEdit();
+                    // diagnostic.range covers exactly the version ref, so replacing it bumps only the pinned version.
+                    updateAction.edit.replace(document.uri, diagnostic.range, metadata.latestVersion);
+                    updateAction.diagnostics = [diagnostic];
+                    updateAction.isPreferred = true;
+                    actions.push(updateAction);
                 }
             }
         }
@@ -1762,5 +1797,139 @@ export class ValidationProvider implements vscode.CodeActionProvider {
             this.logger.debug(`[ValidationProvider] Error parsing remote URL for detection: ${error}`, 'ValidationProvider');
             return null;
         }
+    }
+
+    /**
+     * Recompute the "newer version available" diagnostics for a document and publish them to the dedicated version
+     * diagnostic collection. Runs on open/save (not on every keystroke) since it queries the GitLab tags API; the
+     * per-project tag cache keeps repeated runs cheap. No-op — and clears existing markers — when the feature is
+     * disabled or the document isn't a GitLab CI file.
+     *
+     * @param document The document to check.
+     */
+    private async checkComponentVersions(document: vscode.TextDocument): Promise<void> {
+        if (!this.isDiagnosableDocument(document) || !isGitLabCIFile(document)) {
+            return;
+        }
+
+        const config = vscode.workspace.getConfiguration('gitlabComponentHelper');
+        if (!config.get<boolean>('versionCheck.enabled', true)) {
+            this.versionDiagnostics.delete(document.uri);
+            return;
+        }
+
+        const findings = await this.computeOutdatedRefs(document);
+
+        const severity = config.get<string>('versionCheck.severity', 'warning') === 'information'
+            ? vscode.DiagnosticSeverity.Information
+            : vscode.DiagnosticSeverity.Warning;
+
+        const diagnostics = findings.map(finding => {
+            const range = new vscode.Range(finding.line, finding.refStart, finding.line, finding.refEnd);
+            const diagnostic = new vscode.Diagnostic(
+                range,
+                `A newer version of '${finding.componentName}' is available: ${finding.latestVersion} (current: ${finding.currentVersion}).`,
+                severity,
+            );
+            diagnostic.code = 'outdated-component-version';
+            diagnostic.source = 'gitlab-component-helper';
+            attachDiagnosticMetadata(diagnostic, {
+                code: 'outdated-component-version',
+                componentUrl: finding.componentUrl,
+                currentVersion: finding.currentVersion,
+                latestVersion: finding.latestVersion,
+            });
+            return diagnostic;
+        });
+
+        this.versionDiagnostics.set(document.uri, diagnostics);
+        this.logger.debug(`[ValidationProvider] ${diagnostics.length} outdated-version diagnostics for ${document.fileName}`, 'ValidationProvider');
+    }
+
+    /**
+     * Resolve the outdated component refs in a document: collect each clean-semver component's project, fetch its
+     * available versions once (deduped, via the shared per-project cache), then run the pure detection pass.
+     *
+     * @param document The document to scan.
+     * @returns The outdated refs with their precise document locations; empty when nothing is behind.
+     */
+    private async computeOutdatedRefs(document: vscode.TextDocument): Promise<OutdatedComponentRef[]> {
+        const text = document.getText();
+        const bases = collectSemverComponentBases(text);
+        if (bases.length === 0) {
+            return [];
+        }
+
+        const versionsByBase = new Map<string, readonly string[] | undefined>();
+        await Promise.all(
+            bases.map(async baseUrl => {
+                versionsByBase.set(baseUrl, await this.fetchVersionsForBaseUrl(baseUrl));
+            }),
+        );
+
+        return findOutdatedComponentRefs(text, baseUrl => versionsByBase.get(baseUrl));
+    }
+
+    /**
+     * Fetch the available version refs (tags + branches) for a component's base URL via the shared per-project
+     * version cache. Reuses a cached component when one is known (so monorepo tag-pattern scoping applies),
+     * otherwise builds a minimal lookup from the parsed URL.
+     *
+     * @param baseUrl The component base URL (no `@version`).
+     * @returns The available refs, or `undefined` when the URL can't be parsed or the fetch fails.
+     */
+    private async fetchVersionsForBaseUrl(baseUrl: string): Promise<string[] | undefined> {
+        const parsed = this.parseComponentUrl(baseUrl);
+        if (!parsed) {
+            return undefined;
+        }
+
+        try {
+            const cached = (await this.cacheManager.getComponents()).find(
+                component =>
+                    component.gitlabInstance === parsed.gitlabInstance &&
+                    component.sourcePath === parsed.projectPath &&
+                    component.name === parsed.componentName,
+            );
+            const lookup: CachedComponent = cached ?? {
+                name: parsed.componentName,
+                description: '',
+                parameters: [],
+                source: `${parsed.gitlabInstance}/${parsed.projectPath}`,
+                sourcePath: parsed.projectPath,
+                gitlabInstance: parsed.gitlabInstance,
+                version: parsed.version,
+                url: baseUrl,
+            };
+            return await this.cacheManager.fetchComponentVersions(lookup);
+        } catch (error) {
+            this.logger.debug(`[ValidationProvider] Could not fetch versions for ${baseUrl}: ${error}`, 'ValidationProvider');
+            return undefined;
+        }
+    }
+
+    /**
+     * Bump every outdated component in `document` to its latest stable version in a single edit. Backs the
+     * "Update all component versions to latest" command.
+     *
+     * @param document The document to update.
+     * @returns The number of component refs updated (0 when everything is already current).
+     */
+    public async updateAllComponentVersions(document: vscode.TextDocument): Promise<number> {
+        const findings = await this.computeOutdatedRefs(document);
+        if (findings.length === 0) {
+            return 0;
+        }
+
+        const edit = new vscode.WorkspaceEdit();
+        for (const finding of findings) {
+            const range = new vscode.Range(finding.line, finding.refStart, finding.line, finding.refEnd);
+            edit.replace(document.uri, range, finding.latestVersion);
+        }
+        await vscode.workspace.applyEdit(edit);
+
+        // Refresh markers so the just-fixed squiggles clear immediately.
+        await this.checkComponentVersions(document);
+        return findings.length;
     }
 }

--- a/src/utils/semver.ts
+++ b/src/utils/semver.ts
@@ -1,0 +1,91 @@
+/**
+ * Minimal semantic-version helpers for the component version-check feature.
+ *
+ * Scope is deliberately narrow: only clean, stable `MAJOR.MINOR.PATCH` refs are recognised, with an optional
+ * leading `v` tolerated. Everything else is intentionally *not* clean semver here, so the version check leaves it
+ * untouched rather than guessing at an upgrade:
+ *  - floating refs (`main`, `latest`, `~latest`),
+ *  - partial refs (`1`, `1.2`),
+ *  - pre-release / build-metadata versions (`1.2.3-rc.1`, `1.2.3+build`),
+ *  - commit SHAs.
+ *
+ * Kept free of `vscode` imports so the unit suite can exercise it directly.
+ */
+
+/** A parsed clean semantic version. */
+export interface SemVer {
+  major: number;
+  minor: number;
+  patch: number;
+}
+
+/** A clean, stable `X.Y.Z` ref with an optional `v` prefix and nothing else. */
+const CLEAN_SEMVER = /^v?(\d+)\.(\d+)\.(\d+)$/;
+
+/**
+ * Parse a ref into its major/minor/patch parts.
+ *
+ * @param ref The ref string (surrounding whitespace is tolerated).
+ * @returns The parsed version, or `null` when `ref` isn't a clean stable semver.
+ */
+export function parseSemver(ref: string): SemVer | null {
+  const match = CLEAN_SEMVER.exec(ref.trim());
+  if (!match) return null;
+  return { major: Number(match[1]), minor: Number(match[2]), patch: Number(match[3]) };
+}
+
+/**
+ * Is `ref` a clean, stable semver (`X.Y.Z`, optional `v` prefix)?
+ *
+ * @param ref The ref to test.
+ */
+export function isCleanSemver(ref: string): boolean {
+  return parseSemver(ref) !== null;
+}
+
+/**
+ * Compare two clean semver refs numerically.
+ *
+ * @param a First ref.
+ * @param b Second ref.
+ * @returns A positive number when `a` > `b`, negative when `a` < `b`, `0` when equal, or `null` when either ref
+ *   isn't clean semver (so callers never treat an unknown comparison as ordered).
+ */
+export function compareSemver(a: string, b: string): number | null {
+  const pa = parseSemver(a);
+  const pb = parseSemver(b);
+  if (!pa || !pb) return null;
+  return pa.major - pb.major || pa.minor - pb.minor || pa.patch - pb.patch;
+}
+
+/**
+ * Pick the highest clean stable semver from a list of refs (e.g. a project's tags + branches), ignoring every entry
+ * that isn't clean semver.
+ *
+ * @param refs Candidate refs.
+ * @returns The winning ref string verbatim (preserving any `v` prefix as it appeared), or `null` when none of the
+ *   refs are clean semver.
+ */
+export function getLatestStableSemver(refs: readonly string[]): string | null {
+  let best: string | null = null;
+  for (const ref of refs) {
+    if (!isCleanSemver(ref)) continue;
+    if (best === null || (compareSemver(ref, best) ?? 0) > 0) {
+      best = ref;
+    }
+  }
+  return best;
+}
+
+/**
+ * Is `latest` strictly newer than the pinned `current` ref?
+ *
+ * @param current The currently pinned ref.
+ * @param latest The candidate latest ref.
+ * @returns `true` only when both are clean semver and `current` < `latest`; `false` otherwise (non-semver or
+ *   equal refs never report as outdated).
+ */
+export function isOutdated(current: string, latest: string): boolean {
+  const comparison = compareSemver(current, latest);
+  return comparison !== null && comparison < 0;
+}

--- a/tests/unit/componentVersionCheck.test.ts
+++ b/tests/unit/componentVersionCheck.test.ts
@@ -1,0 +1,94 @@
+// @mocha
+/**
+ * Unit tests for the pure version-check detection in src/providers/componentVersionCheck.ts. A map-based resolver
+ * stands in for the provider's async GitLab version lookup, so these exercise ref splitting, base collection, the
+ * clean-semver gate, latest-stable comparison, and the exact column span placed on the version ref.
+ */
+
+import * as assert from 'node:assert/strict';
+import {
+  splitComponentRef,
+  collectSemverComponentBases,
+  findOutdatedComponentRefs,
+} from '../../src/providers/componentVersionCheck';
+
+const BASE = 'https://gitlab.com/components/opentofu/full-pipeline';
+
+/** Build a resolver from a base-URL → versions map for the pure finder. */
+const resolver = (map: Record<string, string[]>) => (baseUrl: string) => map[baseUrl];
+
+suite('splitComponentRef', () => {
+  test('splits the trailing @version off the base URL', () => {
+    assert.deepEqual(splitComponentRef(`${BASE}@1.2.3`), { baseUrl: BASE, version: '1.2.3' });
+  });
+
+  test('reports no version when there is no @ref', () => {
+    assert.deepEqual(splitComponentRef(BASE), { baseUrl: BASE, version: undefined });
+  });
+});
+
+suite('collectSemverComponentBases', () => {
+  test('returns the bases of clean-semver component refs only, deduped', () => {
+    const text = [
+      'include:',
+      `  - component: ${BASE}@1.2.3`,
+      `  - component: ${BASE}@1.2.3`, // duplicate base -> collapsed
+      `  - component: https://gitlab.com/g/p/other@main`, // floating -> skipped
+      `  - component: https://gitlab.com/g/p/third@2.0.0`,
+    ].join('\n');
+    assert.deepEqual(collectSemverComponentBases(text), [BASE, 'https://gitlab.com/g/p/third']);
+  });
+});
+
+suite('findOutdatedComponentRefs', () => {
+  test('flags a component behind the latest stable release', () => {
+    const text = `include:\n  - component: ${BASE}@1.2.3`;
+    const findings = findOutdatedComponentRefs(text, resolver({ [BASE]: ['main', '1.2.3', '1.5.0', '2.0.0-rc.1'] }));
+
+    assert.equal(findings.length, 1);
+    const f = findings[0];
+    assert.equal(f.currentVersion, '1.2.3');
+    assert.equal(f.latestVersion, '1.5.0'); // rc ignored
+    assert.equal(f.componentName, 'full-pipeline');
+    assert.equal(f.line, 1);
+  });
+
+  test('places the range on exactly the version ref', () => {
+    const lineText = `  - component: ${BASE}@1.2.3`;
+    const text = `include:\n${lineText}`;
+    const [f] = findOutdatedComponentRefs(text, resolver({ [BASE]: ['1.5.0'] }));
+
+    const expectedStart = lineText.indexOf('@1.2.3') + 1; // just past the '@'
+    assert.equal(f.refStart, expectedStart);
+    assert.equal(f.refEnd, expectedStart + '1.2.3'.length);
+    // The exact slice the squiggle/quick-fix targets is the version only.
+    assert.equal(lineText.slice(f.refStart, f.refEnd), '1.2.3');
+  });
+
+  test('handles a quoted URL value', () => {
+    const lineText = `  - component: "${BASE}@1.2.3"`;
+    const text = `include:\n${lineText}`;
+    const [f] = findOutdatedComponentRefs(text, resolver({ [BASE]: ['1.5.0'] }));
+    assert.equal(lineText.slice(f.refStart, f.refEnd), '1.2.3');
+  });
+
+  test('does not flag when already on the latest stable', () => {
+    const text = `include:\n  - component: ${BASE}@1.5.0`;
+    assert.deepEqual(findOutdatedComponentRefs(text, resolver({ [BASE]: ['1.2.0', '1.5.0'] })), []);
+  });
+
+  test('skips floating and non-semver refs', () => {
+    const text = [
+      'include:',
+      `  - component: ${BASE}@main`,
+      `  - component: ${BASE}@~latest`,
+      `  - component: ${BASE}@1.2`,
+    ].join('\n');
+    assert.deepEqual(findOutdatedComponentRefs(text, resolver({ [BASE]: ['1.5.0'] })), []);
+  });
+
+  test('skips components whose versions could not be resolved', () => {
+    const text = `include:\n  - component: ${BASE}@1.2.3`;
+    assert.deepEqual(findOutdatedComponentRefs(text, resolver({})), []);
+  });
+});

--- a/tests/unit/semver.test.ts
+++ b/tests/unit/semver.test.ts
@@ -1,0 +1,85 @@
+// @mocha
+/**
+ * Unit tests for the clean-semver helpers in src/utils/semver.ts — the comparison core of the component
+ * version-check feature. Covers what counts as clean semver (and the many things that deliberately don't),
+ * numeric ordering, latest-stable selection, and the outdated predicate.
+ */
+
+import * as assert from 'node:assert/strict';
+import {
+  parseSemver,
+  isCleanSemver,
+  compareSemver,
+  getLatestStableSemver,
+  isOutdated,
+} from '../../src/utils/semver';
+
+suite('isCleanSemver', () => {
+  test('accepts X.Y.Z with and without a v prefix', () => {
+    assert.equal(isCleanSemver('1.2.3'), true);
+    assert.equal(isCleanSemver('v1.2.3'), true);
+    assert.equal(isCleanSemver('0.0.0'), true);
+    assert.equal(isCleanSemver('  1.2.3  '), true); // surrounding whitespace tolerated
+  });
+
+  test('rejects floating refs, partials, pre-releases, and SHAs', () => {
+    for (const ref of ['main', 'latest', '~latest', '1', '1.2', 'v1', '1.2.3-rc.1', '1.2.3+build', 'a1b2c3d', '']) {
+      assert.equal(isCleanSemver(ref), false, `${ref} should not be clean semver`);
+    }
+  });
+});
+
+suite('parseSemver', () => {
+  test('splits into numeric parts', () => {
+    assert.deepEqual(parseSemver('v2.10.4'), { major: 2, minor: 10, patch: 4 });
+  });
+
+  test('returns null for non-semver', () => {
+    assert.equal(parseSemver('1.2'), null);
+  });
+});
+
+suite('compareSemver', () => {
+  test('orders by major, then minor, then patch', () => {
+    assert.ok((compareSemver('2.0.0', '1.9.9') ?? 0) > 0);
+    assert.ok((compareSemver('1.2.0', '1.10.0') ?? 0) < 0); // numeric, not lexical
+    assert.ok((compareSemver('1.2.3', '1.2.4') ?? 0) < 0);
+  });
+
+  test('treats equal versions as equal regardless of v prefix', () => {
+    assert.equal(compareSemver('1.2.3', 'v1.2.3'), 0);
+  });
+
+  test('returns null when either side is not clean semver', () => {
+    assert.equal(compareSemver('1.2.3', 'main'), null);
+    assert.equal(compareSemver('latest', '1.2.3'), null);
+  });
+});
+
+suite('getLatestStableSemver', () => {
+  test('picks the highest clean semver, ignoring branches and pre-releases', () => {
+    const refs = ['main', '1.0.0', 'v1.4.2', '1.2.0', '2.0.0-rc.1', 'develop'];
+    assert.equal(getLatestStableSemver(refs), 'v1.4.2');
+  });
+
+  test('returns null when no clean semver is present', () => {
+    assert.equal(getLatestStableSemver(['main', 'latest', '1.2']), null);
+  });
+
+  test('returns the ref verbatim (preserving prefix style)', () => {
+    assert.equal(getLatestStableSemver(['1.0.0', 'v2.0.0']), 'v2.0.0');
+  });
+});
+
+suite('isOutdated', () => {
+  test('true only when current is strictly behind latest', () => {
+    assert.equal(isOutdated('1.2.3', '1.5.0'), true);
+    assert.equal(isOutdated('1.2.3', '1.2.3'), false);
+    assert.equal(isOutdated('2.0.0', '1.9.9'), false);
+  });
+
+  test('false when either ref is not clean semver', () => {
+    assert.equal(isOutdated('main', '1.5.0'), false);
+    assert.equal(isOutdated('1.2.3', 'latest'), false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the outdated-component-version feature from #193: detect when a `component:` include is pinned to a semantic version that has a newer **stable** release, and surface it in-editor.

Closes #193

## Change Type
- [x] feat

## User-facing impact
- **Hover** over a component pinned to `X.Y.Z` now shows a `**Latest:**` line — `✓ up to date` or `⚠️ update available`.
- On **open/save**, an outdated semver ref gets a warning squiggle ("A newer version of '<name>' is available: …") with an **Update to X** quick-fix on just the ref.
- New command **GitLab CI: Update All Component Versions to Latest** rewrites every outdated ref in the active file in one edit.

## GitLab scope
- [x] both (gitlab.com + self-managed — reuses the existing token/fetch paths)

## Affected areas
- [x] Hover provider
- [x] Validation provider
- [x] Cache and refresh behavior (reuses the per-project tag cache)

## Design decisions
- **Semver-only:** clean `X.Y.Z` (optional `v`). Floating/branch/SHA refs are left untouched; pre-releases are never suggested as the target.
- **"Latest" = highest stable release.**
- **In-house comparison** (`src/utils/semver.ts`) — no new runtime dependency.
- **On-save cadence** so the GitLab tags API isn't hit on every keystroke; version diagnostics live in their own `DiagnosticCollection` so they never clobber input/structure diagnostics.

## What's where
- New, pure, unit-tested: `src/utils/semver.ts`, `src/providers/componentVersionCheck.ts`.
- Wired into `ValidationProvider` (diagnostic + quick-fix + bulk command backend), `HoverProvider`, `package.json` (command, menu, two config keys: `versionCheck.enabled`, `versionCheck.severity`).

## Validation
- [x] `npm run compile` (type-check + bundle)
- [x] `npm test` — **285 passing** (+21 new across `semver` and `componentVersionCheck` suites)
- [ ] Manual verification in the VS Code Extension Host — **not yet run** (worth a manual pass before merge)

## Known limitations / follow-ups
- Monorepo tag-pattern refs (e.g. `my-comp-1.2.3`) aren't clean semver, so they're skipped for now (safe — no false positives). Scoped monorepo comparison is a natural follow-up.
- A bumped ref adopts the tag's prefix style (e.g. `1.2.3` → `v1.5.0` when the project's tags are `v`-prefixed).

## Breaking Changes
- [x] No breaking changes
