### PR TITLE
fix(version-check): expand GitLab variables before fetching versions

### DIFF
--- a/src/providers/validationProvider.ts
+++ b/src/providers/validationProvider.ts
@@ -1850,6 +1850,12 @@ export class ValidationProvider implements vscode.CodeActionProvider {
      * Resolve the outdated component refs in a document: collect each clean-semver component's project, fetch its
      * available versions once (deduped, via the shared per-project cache), then run the pure detection pass.
      *
+     * Component URLs that use GitLab variables (e.g. `$CI_SERVER_FQDN/group/comp@1.2.3`) are expanded the same way
+     * {@link validate} expands them — resolving the instance/project from the file's repo context — before their
+     * versions are fetched. The version map is keyed by the *raw* base URL (as written in the document), because
+     * the pure finder matches against the document text and places ranges there; only the lookup uses the expanded
+     * URL.
+     *
      * @param document The document to scan.
      * @returns The outdated refs with their precise document locations; empty when nothing is behind.
      */
@@ -1860,10 +1866,26 @@ export class ValidationProvider implements vscode.CodeActionProvider {
             return [];
         }
 
+        // Resolve workspace context once (git remote of the file's repo, or configured sources) only when some base
+        // URL actually uses variables — it can involve git lookups we don't want to pay for otherwise.
+        const workspaceContext = bases.some(base => containsGitLabVariables(base))
+            ? await this.getWorkspaceContext(document.uri)
+            : undefined;
+
         const versionsByBase = new Map<string, readonly string[] | undefined>();
         await Promise.all(
-            bases.map(async baseUrl => {
-                versionsByBase.set(baseUrl, await this.fetchVersionsForBaseUrl(baseUrl));
+            bases.map(async rawBase => {
+                let lookupUrl = rawBase;
+                if (containsGitLabVariables(rawBase)) {
+                    if (!workspaceContext?.gitlabInstance) {
+                        return; // can't resolve the instance for this file — leave the component unchecked
+                    }
+                    lookupUrl = expandComponentUrl(rawBase, workspaceContext);
+                    if (containsGitLabVariables(lookupUrl) || lookupUrl.includes('undefined')) {
+                        return; // expansion was incomplete — don't guess
+                    }
+                }
+                versionsByBase.set(rawBase, await this.fetchVersionsForBaseUrl(lookupUrl));
             }),
         );
 


### PR DESCRIPTION
## Summary

Follow-up to #194. The version check missed components whose URL uses GitLab variables (e.g. `$CI_SERVER_FQDN/group/comp@1.2.3`): no outdated-version squiggle appeared and **Update All Component Versions to Latest** skipped them.

Refs #193

## Cause

`computeOutdatedRefs` fed the raw base URL straight into version lookup, where `new URL("$CI_SERVER_FQDN/...")` throws — so versions came back empty and the component was silently skipped. The rest of the extension (hover, input validation) already expands these variables; the version-check path didn't.

## Fix

Expand variables via the file's repo context (the same `getWorkspaceContext` + `expandComponentUrl` path `validate()` uses) before fetching versions. The version map stays keyed by the **raw** base URL — only the lookup uses the expanded URL — so diagnostic ranges, the quick-fix, and the bulk command still land on the document text. With multiple instances configured, `$CI_SERVER_FQDN` resolves to the host of the repo the file lives in. Bases whose instance can't be resolved (or that expand incompletely) are left unchecked rather than guessed at.

## Validation
- [x] `npm run lint`
- [x] `npm run compile`
- [x] `npm test` (285 passing)
- [ ] Manual Extension Host check with a `$CI_SERVER_FQDN` component — recommended before merge

## Breaking Changes
- [x] No breaking changes