### PR TITLE
docs: refresh, slim, and split the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,58 +2,50 @@
 
 [![AICaC](https://img.shields.io/badge/AICaC-Comprehensive-success.svg)](https://github.com/eFAILution/AICaC)
 
+> Browse, insert, and manage reusable GitLab CI/CD components in VS Code — from any GitLab instance, public or private.
 
-> Turbocharge your GitLab CI/CD workflow in VS Code! Instantly browse, insert, and manage reusable components from any GitLab instance—public or private.
-
-### 🎬 See it in Action: Component Browser
+### Component Browser
 ![componentBrowser](https://github.com/user-attachments/assets/6e4ad12e-d3f5-4165-8b72-c59bda51ae38)
 
 ---
 
-## ✨ Key Features
+## ✨ Features
 
-- **Component Browser**: Explore and insert components from any GitLab project or group
-- **Smart Completion**: Context-aware suggestions for components and versions as you type
-- **Hover Docs**: See full documentation and parameter hints instantly
-- **Input Validation**: Real-time validation of component inputs with intelligent Quick Fix suggestions
-- **Local Includes**: Same hover, completion, and validation for `include: - local:` entries that declare a `spec.inputs` block
-- **Version/Tag Picker**: Always use the right version—no more guessing
-- **Upgrade Hints**: Flags components pinned to an out-of-date semantic version, with one-click updates—single component or the whole file
-- **Variable Expansion**: Full support for GitLab CI/CD variables in URLs and parameters
-- **Lightning Fast**: Caching, batch API calls, and performance optimizations for huge catalogs
-- **Private Access**: 🔑 Add private projects/groups with a token (per GitLab instance)
+- **Component Browser** — explore and insert components from any GitLab project or group
+- **Smart Completion** — context-aware suggestions for components and versions as you type
+- **Hover Docs** — full documentation and parameter hints inline
+- **Input Validation** — real-time checking of component inputs, with Quick Fix suggestions
+- **Local Includes** — the same hover, completion, and validation for `include: - local:` entries that declare a `spec.inputs` block
+- **Version Picker & Upgrade Hints** — pick the right tag, and get flagged when a pinned semver falls behind (with one-click updates)
+- **Variable Expansion** — resolves GitLab CI/CD variables (`$CI_SERVER_FQDN`, `$CI_PROJECT_PATH`, …) in component URLs
+- **Private Access** — add private projects/groups with a token, stored encrypted per instance
+- **Fast** — caching and batched API calls keep large catalogs responsive
 
-### 🎬 Smart Autocomplete in Action
 ![componentAutofill](https://github.com/user-attachments/assets/a76ba19a-240b-4799-a08f-88a78a5cf004)
 
 ---
 
 ## 🛠️ Quick Start
 
-1. **Install**: Search "GitLab Component Helper" in VS Code Extensions and click Install
-2. **Browse Components**: `Ctrl+Shift+P` → "GitLab: Browse Components"
-3. **Add Project/Group**: `Ctrl+Shift+P` → "GitLab CI: Add Component Project/Group" (add public or private sources, with or without a token)
-4. **Insert & Complete**: Type `component:` in `.gitlab-ci.yml` and get instant, real versioned suggestions
-5. **Hover for Docs**: Hover any component URL for instant documentation
+1. **Install** "GitLab Component Helper" from the VS Code Extensions view.
+2. **Browse** — `Ctrl+Shift+P` → **GitLab CI: Browse Components**.
+3. **Add a source** — **GitLab CI: Add Component Project/Group** (public or private; token optional).
+4. **Author** — type `component:` in a `.gitlab-ci.yml` and accept the versioned suggestions.
+5. **Hover** any component URL for instant documentation.
 
-### 🎬 Hover Documentation Demo
 ![hoverContext](https://github.com/user-attachments/assets/3c92f336-db04-4a68-80cf-43732d96b6f1)
 
 ---
 
-## 🔒 Private Components? No Problem!
+## 🔒 Private Components
 
-Add any private project or group with a personal access token—just once per GitLab instance! The extension will use your token for all future requests to that instance.
+Add a private project or group with a personal access token — once per GitLab instance, then it's reused for that instance. Tokens are stored with VS Code **SecretStorage** (encrypted, never in plain text or files) and used only for API calls to the instance you added.
 
-**Your security matters:**
-- Tokens are stored securely using VS Code's built-in SecretStorage—never in plain text or files.
-- Tokens are only used for authenticated API calls to your specified GitLab instance and are never sent to third parties.
-
-> ⚠️ The legacy `gitlabComponentHelper.gitlabToken` setting stores tokens in plain text in `settings.json` and is **deprecated**. Use the **GitLab CI: Add Component Project/Group** command instead — it stores tokens encrypted via SecretStorage. If you still have a token in that setting, copy it through the command and clear the field.
+> ⚠️ The legacy `gitlabComponentHelper.gitlabToken` setting stores tokens in plain text in `settings.json` and is **deprecated**. Use **GitLab CI: Add Component Project/Group** instead, then clear the field.
 
 ---
 
-## ⚡ Example Usage
+## ⚡ Example
 
 ```yaml
 include:
@@ -61,10 +53,9 @@ include:
     inputs:
       terraform_version: "1.5.0"
       workspace: "default"
-      apply: true
 ```
 
-Local templates work too — point a `- local:` entry at any workspace YAML that declares a `spec.inputs` block and you get the same hover, completion, and validation as a catalog component:
+Local templates work the same way — point a `- local:` entry at a workspace YAML that declares a `spec.inputs` block and you get the same hover, completion, and validation:
 
 ```yaml
 include:
@@ -74,361 +65,139 @@ include:
       job_type: nightly
 ```
 
-### 🎬 Adding Component Inputs
 ![insertInputs](https://github.com/user-attachments/assets/098f4eaf-3c4a-45a8-9caf-9a1351730b93)
-
-### 🎬 Input Validation & Quick Fixes
 ![inputsValidation](https://github.com/user-attachments/assets/54d4b2ce-ad84-4bbc-8cd7-911a01565536)
 
 ---
 
-## 📝 Template Header Spec (Optional Context)
+## 🆙 Stay on the Latest Version
 
-To provide consistent context in the Component Browser, you can add **spec-compliant header comments** at the top of a template file. Only these keys are displayed; all other comments are ignored.
+When a component is pinned to a semantic version (`X.Y.Z`), the extension checks whether a newer **stable** release exists and helps you upgrade:
 
-**Supported keys (must be at top of file):**
-- `summary`
-- `usage`
-- `note`
+- **Hover** shows the latest available version next to the one you're on — `✓ up to date` or `⚠️ update available`.
+- An outdated pin gets a **warning squiggle** on the version ref, with an **Update to `X.Y.Z`** quick fix (`Ctrl+.`).
+- **GitLab CI: Update All Component Versions to Latest** rewrites every outdated pin in the active file at once.
 
-**Full format:**
+Only clean `X.Y.Z` pins (optionally `v`-prefixed) are checked — floating refs (`main`, `latest`, `~latest`), partial pins (`1`, `1.2`), and commit SHAs are left untouched, and pre-release tags are never suggested. The check runs when a CI file is opened or saved (not on every keystroke) and reuses the version cache. Toggle it with `gitlabComponentHelper.versionCheck.enabled`; soften the squiggle to an informational underline with `gitlabComponentHelper.versionCheck.severity`.
+
+---
+
+## ⚙️ Configuration
+
+Point the extension at your component sources in VS Code settings:
+
+```json
+"gitlabComponentHelper.componentSources": [
+  { "name": "OpenTofu Components", "path": "components/opentofu", "gitlabInstance": "gitlab.com" },
+  { "name": "Internal CI Components", "path": "devops/ci-components", "gitlabInstance": "gitlab.company.com" }
+]
+```
+
+To recognise CI files kept outside the defaults (`.gitlab-ci.yml`, `.gitlab-ci.yaml`, and anything under `.gitlab/`), add globs — they're merged with the built-in defaults and match at any depth:
+
+```jsonc
+"gitlabComponentHelper.additionalFileGlobs": ["**/ci/*.yml", "**/pipelines/**/*.yaml"]
+```
+
+**Advanced setups** have their own guides:
+- [Component discovery tuning](https://github.com/eFAILution/gitlab-component-helper/blob/main/docs/discovery.md) — scan custom directories or depths for repos that pre-date the [GitLab Components spec](https://docs.gitlab.com/ci/components/#directory-structure).
+- [Monorepo tag conventions](https://github.com/eFAILution/gitlab-component-helper/blob/main/docs/monorepo-tags.md) — scope per-component tags in a tag-per-component monorepo.
+
+Every setting is listed in the [Settings Reference](#-settings-reference) below and editable from the VS Code Settings UI.
+
+---
+
+## 📝 Template Header Spec (Optional)
+
+Add spec-compliant header comments to the top of a template to surface consistent context in the Component Browser. Supported keys: `summary`, `usage`, `note`.
+
 ```yaml
 # @gitlab-component-helper: summary: Push a Helm chart to Sonic
 # @gitlab-component-helper: usage: include + set SONIC_TARGET_* variables
 # @gitlab-component-helper: note: Requires a protected ref for publish
 ```
 
-**Short format:**
-```yaml
-# @gch: summary: Push a Helm chart to Sonic
-# @gch: usage: include + set SONIC_TARGET_* variables
-# @gch: note: Requires a protected ref for publish
-```
-
-Notes:
-- Header comments must appear **before any non-comment content**.
-- Multiple `note` entries are supported.
-- If no header is present, the Context section stays hidden.
-
----
-
-## 📄 Raw YAML Toggle
-
-Component details include a **Raw YAML** toggle so you can inspect the original template when needed. This is available regardless of whether header comments are present.
-
----
-
-## 🆙 Stay on the Latest Version
-
-When a component is pinned to a semantic version (`X.Y.Z`), the extension checks whether a newer stable release exists and helps you upgrade:
-
-- **Hover** shows the latest available version next to the one you're on — `✓ up to date` or `⚠️ update available`.
-- An **outdated pin gets a warning squiggle** on the version ref, with an **Update to `X.Y.Z`** quick fix (`Ctrl+.`) that bumps just that component.
-- **GitLab CI: Update All Component Versions to Latest** rewrites every out-of-date pin in the active file in one step.
-
-The check runs when a CI file is opened or saved (not on every keystroke) and reuses the per-project tag cache, so it stays light on the GitLab API. Components referenced via variables like `$CI_SERVER_FQDN/...@1.2.3` are resolved the same way the rest of the extension resolves them — no extra configuration needed.
-
-**Scope:** only clean `X.Y.Z` pins (optionally `v`-prefixed) are checked. Floating refs (`main`, `latest`, `~latest`), partial pins (`1`, `1.2`), and commit SHAs are left untouched, and pre-release tags are never suggested as the target. Toggle the whole feature with `gitlabComponentHelper.versionCheck.enabled`, or drop the squiggle to an informational underline with `gitlabComponentHelper.versionCheck.severity`.
-
----
-
-## ⚙️ Configuration
-
-Add your favorite sources in VS Code settings:
-
-```json
-"gitlabComponentHelper.componentSources": [
-  {
-    "name": "OpenTofu Components",
-    "path": "components/opentofu",
-    "gitlabInstance": "gitlab.com"
-  },
-  {
-    "name": "Internal CI Components",
-    "path": "devops/ci-components",
-    "gitlabInstance": "gitlab.company.com"
-  }
-]
-```
-
-### 📁 Recognising non-canonical CI files
-
-Out of the box the extension activates on `.gitlab-ci.yml`, `.gitlab-ci.yaml`, and anything under a `.gitlab/` directory. If your project keeps included CI configs elsewhere, add their globs to `gitlabComponentHelper.additionalFileGlobs` — these are merged with the built-in defaults:
-
-```jsonc
-"gitlabComponentHelper.additionalFileGlobs": [
-  "**/ci/*.yml",
-  "**/pipelines/**/*.yaml"
-]
-```
-
-Patterns use VS Code's GlobPattern syntax.
-
----
-
-## 🗂️ Component Discovery
-
-By default the extension follows the [GitLab CI Components spec](https://docs.gitlab.com/ci/components/#directory-structure) when scanning a source repository — it looks for templates in `templates/` and one subdirectory level deep, matching `*.yml` and `*.yaml`. **No configuration is required for spec-compliant repos.**
-
-For repositories that pre-date the spec, use a custom directory layout, or store templates outside `templates/`, you can override discovery behavior either globally or per source.
-
-### Global defaults
-
-```jsonc
-"gitlabComponentHelper.discovery.templateRoots": ["templates", "ci/components"],
-"gitlabComponentHelper.discovery.maxDepth": 2,
-"gitlabComponentHelper.discovery.filePatterns": ["*.yml", "*.yaml"],
-"gitlabComponentHelper.discovery.templateFileNames": ["template.yml", "template.yaml"]
-```
-
-These four settings are also editable from the **VS Code Settings UI** (search for "GitLab Component Helper Discovery").
-
-### Per-source override
-
-Need different rules for one repository? Add a `discovery` block to that source — its values override the global defaults for that source only.
-
-```jsonc
-"gitlabComponentHelper.componentSources": [
-  {
-    "name": "Standard CI Components",
-    "path": "components/opentofu",
-    "gitlabInstance": "gitlab.com"
-    // uses global discovery defaults
-  },
-  {
-    "name": "Legacy Internal Components",
-    "path": "infra/legacy-ci",
-    "gitlabInstance": "gitlab.company.com",
-    "discovery": {
-      "templateRoots": ["ci/components", "shared/pipelines"],
-      "maxDepth": 2
-    }
-  }
-]
-```
-
-### Limits
-
-To keep the extension fast and predictable:
-
-| Field | Limit |
-|---|---|
-| `templateRoots` | Up to 5 roots per source |
-| `maxDepth` | 0–3 (0 = root only, 1 = one subdirectory level, the spec default) |
-| `filePatterns` | Filename globs only — no path globs (e.g. `*.yml` ✅, `foo/*.yml` ❌) |
-| `templateFileNames` | Filenames only — no slashes |
-
----
-
-## 🏷️ Monorepo tag conventions
-
-When a single repository holds **many components**, each component is usually released under its own tags that embed the component name — e.g. `deploy-app-1.1.0`, `deploy-app-2`, `build-image-4.0.0`. Without any hint, the version dropdown for *every* component would list *every* tag in the repo.
-
-Set a **tag pattern** on the source to tell the extension how tags map to components. Each component's dropdown is then scoped to its own tags, and the labels are shown without the prefix (e.g. `1.1.0`, not `deploy-app-1.1.0`). The full tag is still what gets inserted, so the GitLab include resolves correctly.
-
-```jsonc
-"gitlabComponentHelper.componentSources": [
-  {
-    "name": "Shared CI Monorepo",
-    "path": "infrastructure/shared-ci",
-    "gitlabInstance": "gitlab.com",
-    "tagPattern": "{name}-{version}"
-  }
-]
-```
-
-The template uses two tokens:
-
-| Token | Meaning |
-|---|---|
-| `{name}` | The component (= `templates/` directory) name. |
-| `{version}` | The version shown in the dropdown. Matches anything starting with a digit. |
-
-Everything else in the pattern is literal text, so other conventions work too:
-
-| Tag style | Pattern |
-|---|---|
-| `deploy-app-1.1.0` | `{name}-{version}` |
-| `apps/web/v2.0.0` | `apps/{name}/v{version}` |
-| `web_1.0.0` | `{name}_{version}` |
-
-> **Sibling names:** because `{version}` must start with a digit, a component named `build-image` won't pick up a sibling's `build-image-extra-1.0.0` tags. If you need pre-release-only tags with no leading digit (e.g. `web-rc1`), write a stricter custom pattern for that source.
-
-Leave `tagPattern` unset for ordinary single-component repos — their tags are listed as-is.
+The short prefix `# @gch:` works too. Headers must appear before any non-comment content; multiple `note` lines are allowed, and the section stays hidden if no header is present. Component details also include a **Raw YAML** toggle for inspecting the original template.
 
 ---
 
 ## 🧩 Commands
-#### Use the Command Palette (`Ctrl+Shift+P`) to access:
-- **GitLab CI: Browse Components** — Explore and insert from all your sources
-- **GitLab CI: Add Component Project/Group** — Add any project/group (with optional token for private access)
-- **GitLab CI: Update All Component Versions to Latest** — Bump every out-of-date semver-pinned component in the active file
-- **GitLab CI: Refresh Components Cache** — Refresh cached data
-- **GitLab CI: Update Cache** / **Reset Cache** — Force a full re-fetch, or clear all cached data
-- **GitLab CI: Show Cache Status** — See cache info and stats
 
-> Also available (for debugging): **Debug Cache (Detailed)**, **Show Performance Statistics**, and **Test Providers**.
+Run from the Command Palette (`Ctrl+Shift+P`):
+
+- **GitLab CI: Browse Components** — explore and insert from your sources
+- **GitLab CI: Add Component Project/Group** — add a project/group (optional token for private access)
+- **GitLab CI: Update All Component Versions to Latest** — bump outdated semver pins in the active file
+- **GitLab CI: Refresh Components Cache** / **Update Cache** / **Reset Cache** — refresh, force a full re-fetch, or clear cached data
+- **GitLab CI: Show Cache Status** — cache info and stats
+
+Debugging commands are also available: **Debug Cache (Detailed)**, **Show Performance Statistics**, and **Test Providers**.
 
 ---
 
 ## 🆘 Troubleshooting
 
-**Component browser not showing components?**
-- Check file language mode is set to YAML
-- Verify component sources are configured
-
-**Version dropdown not loading?**
-- Check network connectivity to GitLab instance
-- Verify project permissions and access tokens
-- Review cache status and refresh if needed
-
-If you encounter issues:
-1. Enable debug output and check for error messages
-2. Verify your configuration matches the examples above
-3. Test with a simple, known-working component source
-4. Submit an issue with debug output and configuration details
+- **No components showing?** Confirm the file's language mode is YAML and that component sources are configured.
+- **Version dropdown not loading?** Check connectivity to the GitLab instance, verify token/permissions, and refresh the cache.
+- **Still stuck?** Set `gitlabComponentHelper.logLevel` to `DEBUG`, reproduce, and open an issue with the output and your configuration.
 
 ---
 
-## 🔌 API Reference
+## ⚙️ Settings Reference
 
-The extension exposes the following API for other extensions to consume:
+Add these to `settings.json` or configure them via the Settings UI.
 
-```typescript
-interface GitLabComponentAPI {
-    getComponentList(): Promise<Component[]>;
-    getComponentDetails(name: string, version?: string): Promise<ComponentDetails>;
-    validateComponent(component: Component): ValidationResult;
-    expandGitLabVariables(text: string, context?: VariableContext): string;
-    openComponentBrowser(context?: ComponentContext): Promise<void>;
-}
+| Setting | Type | Default | Description |
+|--------|------|---------|-------------|
+| `gitlabComponentHelper.componentSources` | array | _see [Configuration](#-configuration)_ | GitLab repositories with reusable components. Each item takes `name`, `path`, `gitlabInstance`, and optionally a `discovery` block or a `tagPattern` (see the advanced guides). |
+| `gitlabComponentHelper.additionalFileGlobs` | array | `[]` | Extra GitLab CI file globs, merged with the built-in defaults. Patterns match at any depth (e.g. `ci/*.yml` → `**/ci/*.yml`). |
+| `gitlabComponentHelper.versionCheck.enabled` | boolean | `true` | Warn when a component pinned to a semantic version has a newer stable release. Checked on open/save. |
+| `gitlabComponentHelper.versionCheck.severity` | string | `warning` | Severity of the "newer version available" diagnostic. One of `warning`, `information`. |
+| `gitlabComponentHelper.cacheTime` | number | `3600` | Component cache lifetime, in seconds. |
+| `gitlabComponentHelper.logLevel` | string | `ERROR` | Logging level. One of `DEBUG`, `INFO`, `WARN`, `ERROR`. |
+| `gitlabComponentHelper.autoShowOutput` | boolean | `false` | Show the output channel automatically when the log level changes. |
+| `gitlabComponentHelper.httpTimeout` | number | `10000` | HTTP request timeout, in milliseconds. |
+| `gitlabComponentHelper.retryAttempts` | number | `3` | Retry attempts for failed HTTP requests. |
+| `gitlabComponentHelper.batchSize` | number | `5` | Components processed in parallel per batch. |
+| `gitlabComponentHelper.discovery.templateRoots` | array | `["templates"]` | Directories scanned for components (up to 5). See [discovery tuning](https://github.com/eFAILution/gitlab-component-helper/blob/main/docs/discovery.md). |
+| `gitlabComponentHelper.discovery.maxDepth` | number | `1` | Subdirectory depth to recurse under each root. Range `0`–`3`. |
+| `gitlabComponentHelper.discovery.filePatterns` | array | `["*.yml", "*.yaml"]` | Filename globs for template files (filename only — no path globs). |
+| `gitlabComponentHelper.discovery.templateFileNames` | array | `["template.yml", "template.yaml"]` | Filenames recognised inside per-component subfolders. |
+| `gitlabComponentHelper.gitlabToken` | string | `""` | ⚠️ **Deprecated** — stores tokens in plain text. Use **GitLab CI: Add Component Project/Group** instead. |
 
-interface Component {
-    name: string;
-    description: string;
-    parameters: ComponentParameter[];
-    version?: string;
-    source?: string;
-    gitlabInstance?: string;
-    sourcePath?: string;
-    availableVersions?: string[];
-    originalUrl?: string;
-}
+---
 
-interface ComponentParameter {
-    name: string;
-    description?: string;
-    required: boolean;
-    type?: string;
-    default?: any;
-}
-```
+## 🔌 API
 
-Access through:
-
-```typescript
-const api = await vscode.extensions.getExtension('eFAILution.gitlab-component-helper')?.activate();
-if (api) {
-    const components = await api.getComponentList();
-    // Use components...
-}
-```
+The extension is designed to expose a programmatic API for other extensions to consume — see [docs/api.md](https://github.com/eFAILution/gitlab-component-helper/blob/main/docs/api.md). **Status: not yet exposed** (`activate()` does not return the API today); the doc describes the intended contract.
 
 ---
 
 ## 🧑‍💻 Development
 
-**Prerequisites:**
-- VS Code 1.120.0 or higher
-- Node.js 22.x or higher
-- npm
+**Prerequisites:** VS Code 1.120.0+, Node.js 22.x+, npm.
 
-**Setup:**
 ```bash
 git clone https://github.com/eFAILution/gitlab-component-helper.git
 cd gitlab-component-helper
 npm install
-```
-
-**Build:**
-```bash
 npm run compile
 ```
 
-**Debug:**
-1. Open the project in VSCode
-2. Press F5 to start debugging
-3. A new VSCode window will open with the extension loaded
+Press `F5` to launch an Extension Development Host with the extension loaded.
 
 ---
 
 ## 🤝 Contributing
 
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes using [conventional commits](https://www.conventionalcommits.org/):
-   - `feat:` for new features
-   - `fix:` for bug fixes
-   - `docs:` for documentation changes
-   - `chore:` for maintenance tasks
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
+1. Fork and branch (`git checkout -b feat/your-feature`).
+2. Commit using [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `chore:`, …).
+3. Open a Pull Request.
 
-### Automated Releases
-
-This project uses [semantic-release](https://semantic-release.gitbook.io/) for automated versioning and releases. When your PR is merged to `main`:
-
-- Version is automatically bumped based on commit messages
-- CHANGELOG.md is updated
-- GitHub release is created with packaged extension
-- No manual versioning needed!
-
-See [SEMANTIC_RELEASE.md](./SEMANTIC_RELEASE.md) for more details.
+Releases are automated with [semantic-release](https://semantic-release.gitbook.io/) — version, `CHANGELOG.md`, and the GitHub release are derived from commit messages on merge. See [SEMANTIC_RELEASE.md](./SEMANTIC_RELEASE.md).
 
 ---
 
 ## 📄 License
 
-Distributed under the MIT License. See `LICENSE` for more information.
-
----
-
-## ⚙️ User Settings Reference
-
-The following settings are available for the GitLab Component Helper extension. Add these to your VS Code `settings.json` or configure via the Settings UI:
-
-| Setting | Type | Default | Description |
-|--------|------|---------|-------------|
-| `gitlabComponentHelper.gitlabToken` | string | `""` | ⚠️ **Deprecated** — stores tokens in plain text. Use the **GitLab CI: Add Component Project/Group** command instead, which encrypts via SecretStorage. |
-| `gitlabComponentHelper.cacheTime` | number | `3600` | Cache time for components in seconds |
-| `gitlabComponentHelper.logLevel` | string | `ERROR` | Logging level for component service. One of: `DEBUG`, `INFO`, `WARN`, `ERROR` |
-| `gitlabComponentHelper.autoShowOutput` | boolean | `false` | Automatically show output channel when log level changes |
-| `gitlabComponentHelper.httpTimeout` | number | `10000` | HTTP request timeout in milliseconds |
-| `gitlabComponentHelper.retryAttempts` | number | `3` | Number of retry attempts for failed HTTP requests |
-| `gitlabComponentHelper.batchSize` | number | `5` | Number of components to process in parallel batches |
-| `gitlabComponentHelper.componentSources` | array | See below | GitLab repositories containing reusable CI/CD components. Each item supports an optional `discovery` block (override discovery defaults) and, for [monorepos](#-monorepo-tag-conventions), a `tagPattern` string. |
-| `gitlabComponentHelper.discovery.templateRoots` | array | `["templates"]` | Repository directories scanned for components. Up to 5 entries. |
-| `gitlabComponentHelper.discovery.maxDepth` | number | `1` | Subdirectory depth to recurse under each root. Range `0`–`3`. |
-| `gitlabComponentHelper.discovery.filePatterns` | array | `["*.yml", "*.yaml"]` | Filename globs identifying component template files. Filename only — no path globs. |
-| `gitlabComponentHelper.discovery.templateFileNames` | array | `["template.yml", "template.yaml"]` | Filenames recognised inside per-component subfolders (e.g. `templates/foo/template.yml`). |
-| `gitlabComponentHelper.additionalFileGlobs` | array | `[]` | Extra GitLab CI file globs, merged with the built-in defaults, so the extension activates on non-canonical CI files. Patterns match at any depth (e.g. `ci/*.yml` → `**/ci/*.yml`). |
-| `gitlabComponentHelper.versionCheck.enabled` | boolean | `true` | Warn when a component pinned to a semantic version has a newer stable release. Checked on open/save. |
-| `gitlabComponentHelper.versionCheck.severity` | string | `warning` | Severity of the "newer version available" diagnostic. One of: `warning`, `information`. |
-
-### Example `componentSources` value:
-```json
-"gitlabComponentHelper.componentSources": [
-  {
-    "name": "GitLab CI Examples",
-    "path": "gitlab-org/gitlab-foss",
-    "gitlabInstance": "gitlab.com"
-  },
-  {
-    "name": "OpenTofu Components",
-    "path": "components/opentofu",
-    "gitlabInstance": "gitlab.com"
-  }
-]
-```
-
-> For more details on each setting, see the extension's package.json or the VS Code Settings UI.
+MIT — see [`LICENSE`](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 - **Input Validation**: Real-time validation of component inputs with intelligent Quick Fix suggestions
 - **Local Includes**: Same hover, completion, and validation for `include: - local:` entries that declare a `spec.inputs` block
 - **Version/Tag Picker**: Always use the right version—no more guessing
+- **Upgrade Hints**: Flags components pinned to an out-of-date semantic version, with one-click updates—single component or the whole file
 - **Variable Expansion**: Full support for GitLab CI/CD variables in URLs and parameters
 - **Lightning Fast**: Caching, batch API calls, and performance optimizations for huge catalogs
 - **Private Access**: 🔑 Add private projects/groups with a token (per GitLab instance)
@@ -57,7 +58,7 @@ Add any private project or group with a personal access token—just once per Gi
 ```yaml
 include:
   - component: https://gitlab.com/components/terraform@v1.0.0
-    with:
+    inputs:
       terraform_version: "1.5.0"
       workspace: "default"
       apply: true
@@ -114,6 +115,20 @@ Notes:
 ## 📄 Raw YAML Toggle
 
 Component details include a **Raw YAML** toggle so you can inspect the original template when needed. This is available regardless of whether header comments are present.
+
+---
+
+## 🆙 Stay on the Latest Version
+
+When a component is pinned to a semantic version (`X.Y.Z`), the extension checks whether a newer stable release exists and helps you upgrade:
+
+- **Hover** shows the latest available version next to the one you're on — `✓ up to date` or `⚠️ update available`.
+- An **outdated pin gets a warning squiggle** on the version ref, with an **Update to `X.Y.Z`** quick fix (`Ctrl+.`) that bumps just that component.
+- **GitLab CI: Update All Component Versions to Latest** rewrites every out-of-date pin in the active file in one step.
+
+The check runs when a CI file is opened or saved (not on every keystroke) and reuses the per-project tag cache, so it stays light on the GitLab API. Components referenced via variables like `$CI_SERVER_FQDN/...@1.2.3` are resolved the same way the rest of the extension resolves them — no extra configuration needed.
+
+**Scope:** only clean `X.Y.Z` pins (optionally `v`-prefixed) are checked. Floating refs (`main`, `latest`, `~latest`), partial pins (`1`, `1.2`), and commit SHAs are left untouched, and pre-release tags are never suggested as the target. Toggle the whole feature with `gitlabComponentHelper.versionCheck.enabled`, or drop the squiggle to an informational underline with `gitlabComponentHelper.versionCheck.severity`.
 
 ---
 
@@ -247,8 +262,12 @@ Leave `tagPattern` unset for ordinary single-component repos — their tags are 
 #### Use the Command Palette (`Ctrl+Shift+P`) to access:
 - **GitLab CI: Browse Components** — Explore and insert from all your sources
 - **GitLab CI: Add Component Project/Group** — Add any project/group (with optional token for private access)
-- **GitLab CI: Refresh Component Cache** — Refreshes cached data
+- **GitLab CI: Update All Component Versions to Latest** — Bump every out-of-date semver-pinned component in the active file
+- **GitLab CI: Refresh Components Cache** — Refresh cached data
+- **GitLab CI: Update Cache** / **Reset Cache** — Force a full re-fetch, or clear all cached data
 - **GitLab CI: Show Cache Status** — See cache info and stats
+
+> Also available (for debugging): **Debug Cache (Detailed)**, **Show Performance Statistics**, and **Test Providers**.
 
 ---
 
@@ -308,7 +327,7 @@ interface ComponentParameter {
 Access through:
 
 ```typescript
-const api = await vscode.extensions.getExtension('username.gitlab-component-helper')?.activate();
+const api = await vscode.extensions.getExtension('eFAILution.gitlab-component-helper')?.activate();
 if (api) {
     const components = await api.getComponentList();
     // Use components...
@@ -320,20 +339,20 @@ if (api) {
 ## 🧑‍💻 Development
 
 **Prerequisites:**
-- VSCode 1.102.0 or higher
+- VS Code 1.120.0 or higher
 - Node.js 22.x or higher
-- Yarn or npm
+- npm
 
 **Setup:**
 ```bash
-git clone https://github.com/username/gitlab-component-helper.git
+git clone https://github.com/eFAILution/gitlab-component-helper.git
 cd gitlab-component-helper
-yarn install # or npm install
+npm install
 ```
 
 **Build:**
 ```bash
-yarn compile # or npm run compile
+npm run compile
 ```
 
 **Debug:**
@@ -392,6 +411,9 @@ The following settings are available for the GitLab Component Helper extension. 
 | `gitlabComponentHelper.discovery.maxDepth` | number | `1` | Subdirectory depth to recurse under each root. Range `0`–`3`. |
 | `gitlabComponentHelper.discovery.filePatterns` | array | `["*.yml", "*.yaml"]` | Filename globs identifying component template files. Filename only — no path globs. |
 | `gitlabComponentHelper.discovery.templateFileNames` | array | `["template.yml", "template.yaml"]` | Filenames recognised inside per-component subfolders (e.g. `templates/foo/template.yml`). |
+| `gitlabComponentHelper.additionalFileGlobs` | array | `[]` | Extra GitLab CI file globs, merged with the built-in defaults, so the extension activates on non-canonical CI files. Patterns match at any depth (e.g. `ci/*.yml` → `**/ci/*.yml`). |
+| `gitlabComponentHelper.versionCheck.enabled` | boolean | `true` | Warn when a component pinned to a semantic version has a newer stable release. Checked on open/save. |
+| `gitlabComponentHelper.versionCheck.severity` | string | `warning` | Severity of the "newer version available" diagnostic. One of: `warning`, `information`. |
 
 ### Example `componentSources` value:
 ```json

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,45 @@
+# Extension API
+
+> **Status: not yet exposed.** `activate()` does not currently return this API, so `getExtension(...).activate()` resolves to `undefined`. This documents the *intended* contract for other extensions to consume; track its implementation before depending on it. See the [README](../README.md) for user-facing features.
+
+## Intended interface
+
+```typescript
+interface GitLabComponentAPI {
+    getComponentList(): Promise<Component[]>;
+    getComponentDetails(name: string, version?: string): Promise<ComponentDetails>;
+    validateComponent(component: Component): ValidationResult;
+    expandGitLabVariables(text: string, context?: VariableContext): string;
+    openComponentBrowser(context?: ComponentContext): Promise<void>;
+}
+
+interface Component {
+    name: string;
+    description: string;
+    parameters: ComponentParameter[];
+    version?: string;
+    source?: string;
+    gitlabInstance?: string;
+    sourcePath?: string;
+    availableVersions?: string[];
+    originalUrl?: string;
+}
+
+interface ComponentParameter {
+    name: string;
+    description?: string;
+    required: boolean;
+    type?: string;
+    default?: unknown;
+}
+```
+
+## Intended usage
+
+```typescript
+const api = await vscode.extensions.getExtension('eFAILution.gitlab-component-helper')?.activate();
+if (api) {
+    const components = await api.getComponentList();
+    // Use components...
+}
+```

--- a/docs/discovery.md
+++ b/docs/discovery.md
@@ -1,0 +1,53 @@
+# Component Discovery
+
+> Advanced configuration for how the extension scans a source repository for components. Most users need none of this — see the [README](../README.md) for the basics.
+
+By default the extension follows the [GitLab CI Components spec](https://docs.gitlab.com/ci/components/#directory-structure) when scanning a source repository: it looks for templates in `templates/` and one subdirectory level deep, matching `*.yml` and `*.yaml`. **No configuration is required for spec-compliant repos.**
+
+For repositories that pre-date the spec, use a custom layout, or store templates outside `templates/`, override discovery either globally or per source.
+
+## Global defaults
+
+```jsonc
+"gitlabComponentHelper.discovery.templateRoots": ["templates", "ci/components"],
+"gitlabComponentHelper.discovery.maxDepth": 2,
+"gitlabComponentHelper.discovery.filePatterns": ["*.yml", "*.yaml"],
+"gitlabComponentHelper.discovery.templateFileNames": ["template.yml", "template.yaml"]
+```
+
+These four settings are also editable from the **VS Code Settings UI** (search for "GitLab Component Helper Discovery").
+
+## Per-source override
+
+Need different rules for one repository? Add a `discovery` block to that source — its values override the global defaults for that source only.
+
+```jsonc
+"gitlabComponentHelper.componentSources": [
+  {
+    "name": "Standard CI Components",
+    "path": "components/opentofu",
+    "gitlabInstance": "gitlab.com"
+    // uses global discovery defaults
+  },
+  {
+    "name": "Legacy Internal Components",
+    "path": "infra/legacy-ci",
+    "gitlabInstance": "gitlab.company.com",
+    "discovery": {
+      "templateRoots": ["ci/components", "shared/pipelines"],
+      "maxDepth": 2
+    }
+  }
+]
+```
+
+## Limits
+
+To keep the extension fast and predictable:
+
+| Field | Limit |
+|---|---|
+| `templateRoots` | Up to 5 roots per source |
+| `maxDepth` | 0–3 (0 = root only, 1 = one subdirectory level, the spec default) |
+| `filePatterns` | Filename globs only — no path globs (e.g. `*.yml` ✅, `foo/*.yml` ❌) |
+| `templateFileNames` | Filenames only — no slashes |

--- a/docs/monorepo-tags.md
+++ b/docs/monorepo-tags.md
@@ -1,0 +1,39 @@
+# Monorepo Tag Conventions
+
+> How to scope per-component versions in a tag-per-component monorepo. Skip this for ordinary single-component repos — their tags are listed as-is. See the [README](../README.md) for the basics.
+
+When a single repository holds **many components**, each component is usually released under its own tags that embed the component name — e.g. `deploy-app-1.1.0`, `deploy-app-2`, `build-image-4.0.0`. Without any hint, the version dropdown for *every* component would list *every* tag in the repo.
+
+Set a **tag pattern** on the source to tell the extension how tags map to components. Each component's dropdown is then scoped to its own tags, and labels are shown without the prefix (e.g. `1.1.0`, not `deploy-app-1.1.0`). The full tag is still what gets inserted, so the GitLab include resolves correctly.
+
+```jsonc
+"gitlabComponentHelper.componentSources": [
+  {
+    "name": "Shared CI Monorepo",
+    "path": "infrastructure/shared-ci",
+    "gitlabInstance": "gitlab.com",
+    "tagPattern": "{name}-{version}"
+  }
+]
+```
+
+The template uses two tokens:
+
+| Token | Meaning |
+|---|---|
+| `{name}` | The component (= `templates/` directory) name. |
+| `{version}` | The version shown in the dropdown. Matches anything starting with a digit. |
+
+Everything else in the pattern is literal text, so other conventions work too:
+
+| Tag style | Pattern |
+|---|---|
+| `deploy-app-1.1.0` | `{name}-{version}` |
+| `apps/web/v2.0.0` | `apps/{name}/v{version}` |
+| `web_1.0.0` | `{name}_{version}` |
+
+> **Sibling names:** because `{version}` must start with a digit, a component named `build-image` won't pick up a sibling's `build-image-extra-1.0.0` tags. If you need pre-release-only tags with no leading digit (e.g. `web-rc1`), write a stricter custom pattern for that source.
+
+Leave `tagPattern` unset for ordinary single-component repos.
+
+> **Note:** the [version-check feature](../README.md#-stay-on-the-latest-version) only compares clean `X.Y.Z` refs, so components pinned to a full monorepo tag (e.g. `deploy-app@deploy-app-1.1.0`) are not currently flagged as outdated. Scoped monorepo comparison is planned.


### PR DESCRIPTION
## Summary

Refreshes the README for accuracy, then slims it to a focused Marketplace listing and moves the deep technical material into `docs/`. Two commits:

**1 — content fixes** (`docs(readme): refresh stale content and document version-check`)
- Documents the version-check feature (hover Latest line, outdated squiggle + quick-fix, "Update All Component Versions to Latest" command).
- Adds the 3 missing settings to the reference table (`additionalFileGlobs`, `versionCheck.enabled`, `versionCheck.severity`).
- Fixes the example include: `with:` → `inputs:` (GitLab, not GitHub Actions).
- Corrects dev prerequisites (VS Code `1.120.0`, npm) and the `username/...` placeholder URLs/extension id → `eFAILution`.

**2 — slim + split** (`docs(readme): slim the listing and move advanced guides to docs/`)
- ~430 → ~200 lines. De-duplicates settings (one reference table; drops the thrice-repeated `componentSources` example), tones down the marketing copy, merges overlapping Quick Start / Features.
- Moves the deep technical sections to user guides under `docs/` (human-readable markdown, not `.ai/` which is for machine-readable AICaC):
  - `docs/discovery.md` — discovery tuning
  - `docs/monorepo-tags.md` — monorepo tag conventions
  - `docs/api.md` — intended extension API, **flagged not-yet-exposed**

## Marketplace-safe choices
- Links to the guides use **absolute** GitHub URLs (relative links don't resolve on the Marketplace listing).
- Kept everything expanded — the Marketplace renderer doesn't honor collapsible `<details>`.

## Note on the API
`docs/api.md` documents an API that `activate()` does not currently return. It's preserved (with a clear status banner) rather than dropped — decide whether to implement it or remove the doc.

Refs #193