### PR TITLE
fix: Improve expired token user experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@
 
 Add a private project or group with a personal access token — once per GitLab instance, then it's reused for that instance. Tokens are stored with VS Code **SecretStorage** (encrypted, never in plain text or files) and used only for API calls to the instance you added.
 
+Create the token with the **`read_api`** scope, and ensure its user has at least **Reporter** access to the project.
+
 > ⚠️ The legacy `gitlabComponentHelper.gitlabToken` setting stores tokens in plain text in `settings.json` and is **deprecated**. Use **GitLab CI: Add Component Project/Group** instead, then clear the field.
 
 ---
@@ -138,6 +140,7 @@ Debugging commands are also available: **Debug Cache (Detailed)**, **Show Perfor
 ## 🆘 Troubleshooting
 
 - **No components showing?** Confirm the file's language mode is YAML and that component sources are configured.
+- **HTTP 401 / "token expired" errors?** The token is expired or invalid — re-add it via **GitLab CI: Add Component Project/Group**, or the **Update Token** action in the error view. Confirm it has the **`read_api`** scope and at least **Reporter** access.
 - **Version dropdown not loading?** Check connectivity to the GitLab instance, verify token/permissions, and refresh the cache.
 - **Still stuck?** Set `gitlabComponentHelper.logLevel` to `DEBUG`, reproduce, and open an issue with the output and your configuration.
 

--- a/src/errors/guards.ts
+++ b/src/errors/guards.ts
@@ -1,0 +1,48 @@
+/**
+ * Runtime predicates over caught error values.
+ *
+ * These narrow the error classes declared in `./types` — kept separate so `types.ts` stays purely
+ * declarative (enum, classes, type aliases) and behaviour lives here.
+ */
+
+import { ErrorCode, GitLabComponentError, NetworkError } from './types';
+
+/**
+ * Extract an HTTP status code from an unknown thrown value.
+ *
+ * Prefers the typed `NetworkError.details.statusCode`, then falls back to a `statusCode` property on
+ * any error-shaped object so non-`NetworkError` throws (e.g. raw fetch errors) are still recognised.
+ *
+ * @param error  The caught value (typed `unknown` at catch sites).
+ * @returns      The HTTP status code if one can be safely extracted, otherwise `undefined`.
+ */
+export function extractStatusCode(error: unknown): number | undefined {
+  if (error instanceof NetworkError && error.details?.statusCode) {
+    return error.details.statusCode;
+  }
+  if (typeof error === 'object' && error !== null && 'statusCode' in error) {
+    const candidate = (error as { statusCode: unknown }).statusCode;
+    if (typeof candidate === 'number') {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Whether a caught value represents a GitLab authentication failure (expired/invalid/missing token).
+ *
+ * Recognises both the typed `UNAUTHORIZED` error code and a raw 401/403 status, so callers don't have
+ * to special-case how deep in the stack the error was constructed.
+ *
+ * @param error  The caught value (typed `unknown` at catch sites).
+ * @returns      `true` if the error is an `UNAUTHORIZED` GitLab error or carries a 401/403 status,
+ *               otherwise `false`.
+ */
+export function isAuthError(error: unknown): boolean {
+  if (error instanceof GitLabComponentError && error.code === ErrorCode.UNAUTHORIZED) {
+    return true;
+  }
+  const status = extractStatusCode(error);
+  return status === 401 || status === 403;
+}

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -13,6 +13,11 @@ export {
 } from './types';
 
 export {
+  extractStatusCode,
+  isAuthError
+} from './guards';
+
+export {
   ErrorHandler,
   ErrorHandlerOptions,
   getErrorHandler,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -132,6 +132,7 @@ export function activate(context: vscode.ExtensionContext) {
     logger.debug('[Extension] Registering addProjectToken command...', 'Extension');
     const service = getComponentService();
     service.setSecretStorage(context.secrets);
+    context.subscriptions.push(service);
     registerAddProjectTokenCommand(context, service);
 
     // Register component browser command

--- a/src/providers/componentBrowserProvider.ts
+++ b/src/providers/componentBrowserProvider.ts
@@ -130,6 +130,10 @@ export class ComponentBrowserProvider {
               'gitlabComponentHelper.componentSources'
             );
             return;
+          case 'updateToken':
+            await vscode.commands.executeCommand('gitlabComponentHelper.addProjectToken');
+            await this.loadComponents(true);
+            return;
           case 'fetchVersion':
             await this.fetchAndCacheVersion(message.componentName, message.sourcePath, message.gitlabInstance, message.version);
             return;
@@ -320,10 +324,7 @@ export class ComponentBrowserProvider {
 
       // If no components found but we have cache errors, show errors
       if (allComponents.length === 0 && Object.keys(cacheErrors).length > 0) {
-        const errorMessages = Object.entries(cacheErrors).map(([source, error]) =>
-          `${source}: ${error}`
-        );
-        this.panel.webview.html = this.getErrorsHtml(errorMessages);
+        this.panel.webview.html = this.getErrorsHtml(cacheErrors);
         return;
       }
 
@@ -706,16 +707,22 @@ export class ComponentBrowserProvider {
     const versionDataJson = JSON.stringify(versionData);
 
     // Build error section HTML
+    const hasAuthError = Object.values(cacheErrors).some(error => this.classifySourceError(error).isAuth);
     const errorSectionHtml = hasErrors ? `
       <div class="error-section">
         <div class="error-header">⚠️ Cache Errors</div>
-        ${Object.entries(cacheErrors).map(([source, error], index) => `
+        ${Object.entries(cacheErrors).map(([source, error], index) => {
+          const { summary } = this.classifySourceError(error);
+          return `
           <div class="error-item">
-            <div class="error-source">${source}</div>
+            <div class="error-source">${this.escapeHtml(source)}</div>
+            <div class="error-summary">${this.escapeHtml(summary)}</div>
             <button class="error-toggle" onclick="toggleError('error-${index}')">Show Details</button>
-            <div class="error-details" id="error-${index}" style="display: none;">${error}</div>
+            <div class="error-details" id="error-${index}" style="display: none;">${this.escapeHtml(error)}</div>
           </div>
-        `).join('')}
+          `;
+        }).join('')}
+        ${hasAuthError ? '<button class="update-token-btn" onclick="updateToken()">Update Token</button>' : ''}
       </div>
     ` : '';
 
@@ -881,6 +888,19 @@ export class ComponentBrowserProvider {
           .error-source {
             font-weight: bold;
             color: var(--vscode-errorForeground);
+          }
+          .error-summary {
+            color: var(--vscode-errorForeground);
+            margin: 4px 0;
+          }
+          .update-token-btn {
+            background-color: var(--vscode-button-background);
+            color: var(--vscode-button-foreground);
+            border: none;
+            padding: 6px 14px;
+            border-radius: 2px;
+            cursor: pointer;
+            margin-top: 6px;
           }
           .error-toggle {
             background: none;
@@ -1128,6 +1148,10 @@ export class ComponentBrowserProvider {
             } else {
               errorDiv.style.display = 'none';
             }
+          }
+
+          function updateToken() {
+            vscode.postMessage({ command: 'updateToken' });
           }
 
           function toggleSource(sourceId) {
@@ -2127,6 +2151,35 @@ export class ComponentBrowserProvider {
     `;
   }
 
+  /**
+   * Classify a per-source error message so the error views can tell an expired/invalid token apart
+   * from a generic failure. Auth errors get a plain-language summary and an "Update Token" action;
+   * everything else falls back to the raw message. The raw text is always preserved for the details
+   * disclosure so we never hide what GitLab actually returned.
+   *
+   * @param rawError  The error message stored for a source (e.g. `HTTP 401: {"error":"invalid_token",…}`).
+   * @returns         `isAuth` — whether the message looks like a 401/403/token failure; `summary` — a
+   *                  plain-language message for auth errors, or the unchanged `rawError` otherwise.
+   */
+  private classifySourceError(rawError: string): { isAuth: boolean; summary: string } {
+    const lower = rawError.toLowerCase();
+    const isAuth =
+      /\bhttp\s*40[13]\b/.test(lower) ||
+      lower.includes('invalid_token') ||
+      lower.includes('token is expired') ||
+      lower.includes('unauthorized') ||
+      lower.includes('forbidden');
+
+    if (!isAuth) {
+      return { isAuth: false, summary: rawError };
+    }
+
+    const summary = lower.includes('expired')
+      ? 'Your GitLab access token has expired. Update it to reload these components.'
+      : 'GitLab rejected the access token for this source. Update it to reload these components.';
+    return { isAuth: true, summary };
+  }
+
   private escapeHtml(value: string): string {
     return value
       .replace(/&/g, '&amp;')
@@ -2229,7 +2282,32 @@ export class ComponentBrowserProvider {
     `;
   }
 
-  private getErrorsHtml(errors: string[]): string {
+  /**
+   * Build the full-screen error view shown when no components could be loaded but sources reported
+   * errors. Each source is rendered with a plain-language summary (auth errors are humanised via
+   * {@link classifySourceError}) and its raw message behind a "Show details" toggle. An "Update Token"
+   * button is added when any source failed with an auth error.
+   *
+   * @param errors  Map of source name to its error message (as stored by the cache manager).
+   * @returns       A complete HTML document string for the webview panel.
+   */
+  private getErrorsHtml(errors: Record<string, string>): string {
+    const entries = Object.entries(errors);
+    const hasAuthError = entries.some(([, error]) => this.classifySourceError(error).isAuth);
+
+    const errorItemsHtml = entries.map(([source, error], index) => {
+      const { summary } = this.classifySourceError(error);
+      const detailsId = `error-details-${index}`;
+      return `
+        <div class="error-item">
+          <div class="error-source">${this.escapeHtml(source)}</div>
+          <div class="error-summary">${this.escapeHtml(summary)}</div>
+          <button class="link-button" onclick="toggleDetails('${detailsId}', this)">Show details</button>
+          <pre class="error-raw" id="${detailsId}" style="display: none;">${this.escapeHtml(error)}</pre>
+        </div>
+      `;
+    }).join('');
+
     return `
       <!DOCTYPE html>
       <html lang="en">
@@ -2245,7 +2323,6 @@ export class ComponentBrowserProvider {
             background-color: var(--vscode-editor-background);
           }
           .errors {
-            color: var(--vscode-errorForeground);
             background-color: var(--vscode-inputValidation-errorBackground);
             border: 1px solid var(--vscode-inputValidation-errorBorder);
             padding: 10px;
@@ -2253,7 +2330,27 @@ export class ComponentBrowserProvider {
             margin: 20px 0;
           }
           .error-item {
-            margin: 8px 0;
+            margin: 12px 0;
+          }
+          .error-item:not(:last-child) {
+            border-bottom: 1px solid var(--vscode-inputValidation-errorBorder);
+            padding-bottom: 12px;
+          }
+          .error-source {
+            font-weight: 600;
+            margin-bottom: 4px;
+          }
+          .error-summary {
+            color: var(--vscode-errorForeground);
+          }
+          .error-raw {
+            margin: 8px 0 0;
+            padding: 8px;
+            white-space: pre-wrap;
+            word-break: break-word;
+            font-size: 0.85em;
+            background-color: var(--vscode-textCodeBlock-background);
+            border-radius: 3px;
           }
           button {
             background-color: var(--vscode-button-background);
@@ -2264,6 +2361,13 @@ export class ComponentBrowserProvider {
             cursor: pointer;
             margin-right: 8px;
           }
+          .link-button {
+            background: none;
+            color: var(--vscode-textLink-foreground);
+            padding: 0;
+            margin: 4px 0 0;
+            text-decoration: underline;
+          }
         </style>
       </head>
       <body>
@@ -2272,10 +2376,11 @@ export class ComponentBrowserProvider {
         <p>There were errors loading components from the configured sources:</p>
 
         <div class="errors">
-          ${errors.map((error: string) => `<div class="error-item">• ${error}</div>`).join('')}
+          ${errorItemsHtml}
         </div>
 
         <div>
+          ${hasAuthError ? '<button onclick="updateToken()">Update Token</button>' : ''}
           <button onclick="refresh()">Try Again</button>
           <button onclick="openSettings()">Open Settings</button>
         </div>
@@ -2289,6 +2394,17 @@ export class ComponentBrowserProvider {
 
           function openSettings() {
             vscode.postMessage({ command: 'openSettings' });
+          }
+
+          function updateToken() {
+            vscode.postMessage({ command: 'updateToken' });
+          }
+
+          function toggleDetails(id, btn) {
+            const el = document.getElementById(id);
+            const showing = el.style.display !== 'none';
+            el.style.display = showing ? 'none' : 'block';
+            btn.textContent = showing ? 'Show details' : 'Hide details';
           }
         </script>
       </body>
@@ -2398,8 +2514,18 @@ ${sourceErrors.size > 0 ? '\nErrors:\n' + Array.from(sourceErrors.entries()).map
   }
 
 
+  /**
+   * Build the catch-all error view shown when loading the component browser throws (as opposed to a
+   * per-source failure). Auth errors are humanised via {@link classifySourceError} and get an "Update
+   * Token" button with the raw message behind a "Show details" toggle; other errors show the message
+   * directly. Both keep "Try Again" and "Open Settings".
+   *
+   * @param error  The thrown value caught while loading components (typed `unknown` at the catch site).
+   * @returns      A complete HTML document string for the webview panel.
+   */
   private getErrorHtml(error: unknown): string {
     const message = error instanceof Error ? error.message : String(error);
+    const { isAuth, summary } = this.classifySourceError(message);
     return `
       <!DOCTYPE html>
       <html lang="en">
@@ -2422,6 +2548,15 @@ ${sourceErrors.size > 0 ? '\nErrors:\n' + Array.from(sourceErrors.entries()).map
             border-radius: 5px;
             margin: 20px 0;
           }
+          .error-raw {
+            margin: 8px 0 0;
+            padding: 8px;
+            white-space: pre-wrap;
+            word-break: break-word;
+            font-size: 0.85em;
+            background-color: var(--vscode-textCodeBlock-background);
+            border-radius: 3px;
+          }
           button {
             background-color: var(--vscode-button-background);
             color: var(--vscode-button-foreground);
@@ -2431,16 +2566,28 @@ ${sourceErrors.size > 0 ? '\nErrors:\n' + Array.from(sourceErrors.entries()).map
             cursor: pointer;
             margin-right: 8px;
           }
+          .link-button {
+            background: none;
+            color: var(--vscode-textLink-foreground);
+            padding: 0;
+            margin: 4px 0 0;
+            text-decoration: underline;
+          }
         </style>
       </head>
       <body>
         <h1>Component Loading Error</h1>
 
         <div class="error">
-          <strong>Error:</strong> ${message}
+          ${isAuth
+            ? `${this.escapeHtml(summary)}
+               <button class="link-button" onclick="toggleDetails('error-raw', this)">Show details</button>
+               <pre class="error-raw" id="error-raw" style="display: none;">${this.escapeHtml(message)}</pre>`
+            : `<strong>Error:</strong> ${this.escapeHtml(message)}`}
         </div>
 
         <div>
+          ${isAuth ? '<button onclick="updateToken()">Update Token</button>' : ''}
           <button onclick="refresh()">Try Again</button>
           <button onclick="openSettings()">Open Settings</button>
         </div>
@@ -2454,6 +2601,17 @@ ${sourceErrors.size > 0 ? '\nErrors:\n' + Array.from(sourceErrors.entries()).map
 
           function openSettings() {
             vscode.postMessage({ command: 'openSettings' });
+          }
+
+          function updateToken() {
+            vscode.postMessage({ command: 'updateToken' });
+          }
+
+          function toggleDetails(id, btn) {
+            const el = document.getElementById(id);
+            const showing = el.style.display !== 'none';
+            el.style.display = showing ? 'none' : 'block';
+            btn.textContent = showing ? 'Show details' : 'Hide details';
           }
         </script>
       </body>

--- a/src/providers/validationMetadata.ts
+++ b/src/providers/validationMetadata.ts
@@ -40,6 +40,11 @@ export interface ComponentFetchFailedMetadata extends ComponentRefBase {
   code: 'component-fetch-failed';
 }
 
+/** Metadata attached to `code: 'component-auth-failed'` diagnostics (401/403 — token expired/invalid). */
+export interface ComponentAuthFailedMetadata extends ComponentRefBase {
+  code: 'component-auth-failed';
+}
+
 /** Metadata attached to `code: 'unknown-input'` diagnostics (input name not in the component's spec). */
 export interface UnknownInputMetadata {
   code: 'unknown-input';
@@ -87,6 +92,7 @@ export interface OutdatedComponentVersionMetadata {
 export type DiagnosticMetadata =
   | UnresolvedVariablesMetadata
   | ComponentFetchFailedMetadata
+  | ComponentAuthFailedMetadata
   | UnknownInputMetadata
   | MissingRequiredInputMetadata
   | OutdatedComponentVersionMetadata;

--- a/src/providers/validationProvider.ts
+++ b/src/providers/validationProvider.ts
@@ -9,6 +9,7 @@ import { isGitLabCIFile } from '../utils/gitlabCiFileMatcher';
 import { spawn } from 'child_process';
 import { resolveLocalComponent, isUnsupportedLocalPath } from './localComponentResolver';
 import { attachDiagnosticMetadata, readDiagnosticMetadata } from './validationMetadata';
+import { isAuthError } from '../errors';
 import type { MissingRequiredInputMetadata } from './validationMetadata';
 import type { GitApi, GitRepository } from '../types/vscode-git';
 import type { CachedComponent } from '../types/cache';
@@ -88,6 +89,16 @@ export class ValidationProvider implements vscode.CodeActionProvider {
                 }
                 this.diagnosticCollection.delete(doc.uri);
                 this.versionDiagnostics.delete(doc.uri);
+            })
+        );
+
+        // A newly-saved token can turn a `component-auth-failed` (or generic fetch failure) into a
+        // successful fetch, so re-run validation on open documents to clear the stale diagnostics.
+        this.logger.debug('[ValidationProvider] Subscribing to token changes', 'ValidationProvider');
+        context.subscriptions.push(
+            getComponentService().onDidChangeToken(() => {
+                this.logger.debug('[ValidationProvider] Token changed - revalidating open documents', 'ValidationProvider');
+                this.revalidateOpenDocuments();
             })
         );
 
@@ -266,8 +277,10 @@ export class ValidationProvider implements vscode.CodeActionProvider {
                 // First try to find the component in cache (using expanded URL)
                 let component = await this.findComponentInCache(expandedUrl);
 
-                // Track if component fetch failed
+                // Track if component fetch failed, and whether the failure was an auth/token error
+                // (which gets a distinct diagnostic + "update token" quick fix).
                 let componentFetchFailed = false;
+                let componentAuthFailed = false;
 
                 // If not found in cache, fetch from API and cache it (using expanded URL)
                 if (!component) {
@@ -307,33 +320,52 @@ export class ValidationProvider implements vscode.CodeActionProvider {
                     } catch (error) {
                         this.logger.debug(`[ValidationProvider] Error fetching component ${expandedUrl}: ${error}`, 'ValidationProvider');
                         componentFetchFailed = true;
+                        componentAuthFailed = isAuthError(error);
                     }
                 } else {
                     this.logger.debug(`[ValidationProvider] Using cached component: ${component.name}`, 'ValidationProvider');
                 }
 
                 // If component fetch failed, add a single diagnostic about the fetch failure
-                // instead of showing "unknown input" warnings for all inputs
+                // instead of showing "unknown input" warnings for all inputs. An auth failure gets a
+                // distinct message + "update token" quick fix; everything else stays generic.
                 if (componentFetchFailed) {
                     const line = this.findLineForComponent(document, includes, includeIndex);
                     const range = new vscode.Range(line, 0, line, document.lineAt(line).text.length);
 
-                    const diagnostic = new vscode.Diagnostic(
-                        range,
-                        `Unable to fetch component '${componentUrl}'. Component may not exist, be inaccessible, or the URL may be incorrect.`,
-                        vscode.DiagnosticSeverity.Warning
-                    );
+                    const diagnostic = componentAuthFailed
+                        ? new vscode.Diagnostic(
+                            range,
+                            `GitLab token for '${componentUrl}' is missing, invalid, or expired. Update it to validate this component.`,
+                            vscode.DiagnosticSeverity.Warning
+                          )
+                        : new vscode.Diagnostic(
+                            range,
+                            `Unable to fetch component '${componentUrl}'. Component may not exist, be inaccessible, or the URL may be incorrect.`,
+                            vscode.DiagnosticSeverity.Warning
+                          );
 
-                    diagnostic.code = 'component-fetch-failed';
-                    diagnostic.source = 'gitlab-component-helper';
-                    attachDiagnosticMetadata(diagnostic, {
-                        code: 'component-fetch-failed',
-                        componentUrl: componentUrl,
-                        expandedUrl: expandedUrl,
-                        includeInputs: include.inputs || {}
-                    });
+                    if (componentAuthFailed) {
+                        diagnostic.code = 'component-auth-failed';
+                        diagnostic.source = 'gitlab-component-helper';
+                        attachDiagnosticMetadata(diagnostic, {
+                            code: 'component-auth-failed',
+                            componentUrl: componentUrl,
+                            expandedUrl: expandedUrl,
+                            includeInputs: include.inputs || {}
+                        });
+                    } else {
+                        diagnostic.code = 'component-fetch-failed';
+                        diagnostic.source = 'gitlab-component-helper';
+                        attachDiagnosticMetadata(diagnostic, {
+                            code: 'component-fetch-failed',
+                            componentUrl: componentUrl,
+                            expandedUrl: expandedUrl,
+                            includeInputs: include.inputs || {}
+                        });
+                    }
 
-                    this.logger.debug(`[ValidationProvider] Created component fetch failure diagnostic for ${componentUrl}`, 'ValidationProvider');
+                    this.logger.debug(`[ValidationProvider] Created component ${componentAuthFailed ? 'auth' : 'fetch'} failure diagnostic for ${componentUrl}`, 'ValidationProvider');
                     diagnostics.push(diagnostic);
 
                     // Skip input validation for failed component fetches
@@ -698,6 +730,21 @@ export class ValidationProvider implements vscode.CodeActionProvider {
                         arguments: [vscode.Uri.parse('https://docs.gitlab.com/ee/ci/components/')]
                     };
                     actions.push(validateUrlAction);
+                }
+            }
+            else if (diagnosticMetadata?.code === 'component-auth-failed') {
+                const updateTokenTitle = `Update GitLab token`;
+                if (!actionTitles.has(updateTokenTitle)) {
+                    actionTitles.add(updateTokenTitle);
+
+                    const updateTokenAction = new vscode.CodeAction(updateTokenTitle, vscode.CodeActionKind.QuickFix);
+                    updateTokenAction.command = {
+                        title: updateTokenTitle,
+                        command: 'gitlabComponentHelper.addProjectToken'
+                    };
+                    updateTokenAction.diagnostics = [diagnostic];
+                    updateTokenAction.isPreferred = true;
+                    actions.push(updateTokenAction);
                 }
             }
             else if (diagnosticMetadata?.code === 'missing-required-input') {

--- a/src/providers/validationProvider.ts
+++ b/src/providers/validationProvider.ts
@@ -333,37 +333,20 @@ export class ValidationProvider implements vscode.CodeActionProvider {
                     const line = this.findLineForComponent(document, includes, includeIndex);
                     const range = new vscode.Range(line, 0, line, document.lineAt(line).text.length);
 
-                    const diagnostic = componentAuthFailed
-                        ? new vscode.Diagnostic(
-                            range,
-                            `GitLab token for '${componentUrl}' is missing, invalid, or expired. Update it to validate this component.`,
-                            vscode.DiagnosticSeverity.Warning
-                          )
-                        : new vscode.Diagnostic(
-                            range,
-                            `Unable to fetch component '${componentUrl}'. Component may not exist, be inaccessible, or the URL may be incorrect.`,
-                            vscode.DiagnosticSeverity.Warning
-                          );
+                    const code = componentAuthFailed ? 'component-auth-failed' : 'component-fetch-failed';
+                    const message = componentAuthFailed
+                        ? `GitLab token for '${componentUrl}' is missing, invalid, or expired. Update it to validate this component.`
+                        : `Unable to fetch component '${componentUrl}'. Component may not exist, be inaccessible, or the URL may be incorrect.`;
 
-                    if (componentAuthFailed) {
-                        diagnostic.code = 'component-auth-failed';
-                        diagnostic.source = 'gitlab-component-helper';
-                        attachDiagnosticMetadata(diagnostic, {
-                            code: 'component-auth-failed',
-                            componentUrl: componentUrl,
-                            expandedUrl: expandedUrl,
-                            includeInputs: include.inputs || {}
-                        });
-                    } else {
-                        diagnostic.code = 'component-fetch-failed';
-                        diagnostic.source = 'gitlab-component-helper';
-                        attachDiagnosticMetadata(diagnostic, {
-                            code: 'component-fetch-failed',
-                            componentUrl: componentUrl,
-                            expandedUrl: expandedUrl,
-                            includeInputs: include.inputs || {}
-                        });
-                    }
+                    const diagnostic = new vscode.Diagnostic(range, message, vscode.DiagnosticSeverity.Warning);
+                    diagnostic.code = code;
+                    diagnostic.source = 'gitlab-component-helper';
+                    attachDiagnosticMetadata(diagnostic, {
+                        code,
+                        componentUrl: componentUrl,
+                        expandedUrl: expandedUrl,
+                        includeInputs: include.inputs || {}
+                    });
 
                     this.logger.debug(`[ValidationProvider] Created component ${componentAuthFailed ? 'auth' : 'fetch'} failure diagnostic for ${componentUrl}`, 'ValidationProvider');
                     diagnostics.push(diagnostic);

--- a/src/services/component/commands.ts
+++ b/src/services/component/commands.ts
@@ -14,6 +14,7 @@ export function registerAddProjectTokenCommand(
     vscode.commands.registerCommand('gitlabComponentHelper.addProjectToken', async () => {
       // Prompt for the full GitLab URL
       const url = await vscode.window.showInputBox({
+        title: 'GitLab Component Helper',
         prompt: 'Enter the full GitLab project or group URL (e.g. https://gitlab.com/mygroup/myproject)',
         ignoreFocusOut: true,
         placeHolder: 'https://gitlab.com/mygroup/myproject'
@@ -35,7 +36,8 @@ export function registerAddProjectTokenCommand(
 
       // Prompt for token (optional)
       const token = await vscode.window.showInputBox({
-        prompt: `Enter GitLab personal access token for ${gitlabInstance} (leave blank for public access)`,
+        title: 'GitLab Component Helper',
+        prompt: `Enter GitLab personal access token for ${gitlabInstance} (needs the read_api scope; leave blank for public access)`,
         password: true,
         ignoreFocusOut: true
       });

--- a/src/services/component/componentFetcher.ts
+++ b/src/services/component/componentFetcher.ts
@@ -11,6 +11,7 @@ import type { GitLabProjectInfo, GitLabTreeItem } from '../../types/api';
 import { HttpClient } from '../../utils/httpClient';
 import { Logger } from '../../utils/logger';
 import { GitLabSpecParser, ComponentVariable } from '../../parsers/specParser';
+import { isAuthError } from '../../errors';
 import { TokenManager } from './tokenManager';
 import { UrlParser } from './urlParser';
 import {
@@ -20,25 +21,41 @@ import {
 } from './componentFetcherTemplates';
 
 /**
- * Helper function to prompt user for token if needed
+ * Prompt the user for a GitLab personal access token for `gitlabInstance`.
+ *
+ * The two reasons we reach a 401 need different wording: a stored token that GitLab rejected
+ * (expired/invalid — *replace* it) versus no token at all (private source needs *first-time* auth).
+ *
+ * @param context        Extension context (currently unused; reserved for context-scoped secrets).
+ * @param tokenManager   Stores the entered token, keyed by `gitlabInstance`.
+ * @param gitlabInstance The GitLab host the token is for (e.g. `gitlab.com`).
+ * @param hadToken       Whether a token was already stored for this instance — selects which of the
+ *                       two messages above is shown.
+ * @returns              The trimmed token if the user entered one (also persisted), or `undefined`
+ *                       if they left it blank (public access) or dismissed the prompt.
  */
 async function promptForTokenIfNeeded(
   context: vscode.ExtensionContext | undefined,
   tokenManager: TokenManager,
-  gitlabInstance: string
+  gitlabInstance: string,
+  hadToken: boolean
 ): Promise<string | undefined> {
-  const tokenPrompt = `This project/group requires a GitLab personal access token for ${gitlabInstance}. Please enter one to continue.`;
+  const tokenPrompt = hadToken
+    ? `Your GitLab token for ${gitlabInstance} is invalid or has expired. Enter a new personal access token (needs the read_api scope) to continue.`
+    : `This project/group requires a GitLab personal access token for ${gitlabInstance} (needs the read_api scope). Enter one to continue, or leave blank for public access.`;
   const token = await vscode.window.showInputBox({
+    title: 'GitLab Component Helper',
     prompt: tokenPrompt,
+    placeHolder: hadToken ? 'New personal access token' : 'Personal access token (blank for public access)',
     password: true,
     ignoreFocusOut: true
   });
   if (token && token.trim()) {
     await tokenManager.setTokenForProject(gitlabInstance, token.trim());
-    vscode.window.showInformationMessage(`Token saved for ${gitlabInstance}`);
+    vscode.window.showInformationMessage(`GitLab Component Helper: token saved for ${gitlabInstance}`);
     return token.trim();
   } else if (token === '') {
-    vscode.window.showInformationMessage('No token entered. Public access will be used.');
+    vscode.window.showInformationMessage('GitLab Component Helper: no token entered. Public access will be used.');
     return undefined;
   }
   return undefined;
@@ -217,43 +234,31 @@ export class ComponentFetcher {
 
       this.logger.debug(`Using token for ${gitlabInstance}: ${token ? 'YES' : 'NO'}`);
 
-      // Fetch project info and template in parallel
-      let projectInfo: PromiseSettledResult<GitLabProjectInfo>;
-      let templateResult: PromiseSettledResult<Awaited<ReturnType<typeof this.fetchTemplate>>>;
-      try {
+      // Fetch project info and template in parallel. `allSettled` never rejects, so an auth failure
+      // surfaces as a rejected `projectInfo` rather than a thrown error — handle it explicitly below.
+      let [projectInfo, templateResult] = await Promise.allSettled([
+        this.httpClient.fetchJson<GitLabProjectInfo>(projectApiUrl, fetchOptions),
+        this.fetchTemplate(apiBaseUrl, encodedProjectPath, componentName, version, fetchOptions)
+      ]);
+
+      // On a 401/403 fetching project info, prompt for a token once and retry. If the user declines
+      // (or it still fails), rethrow the original auth error so callers can surface a clear prompt
+      // instead of degrading into an empty-parameter component.
+      if (projectInfo.status === 'rejected' && isAuthError(projectInfo.reason)) {
+        token = await promptForTokenIfNeeded(context, this.tokenManager, gitlabInstance, !!token);
+        if (!token) {
+          throw projectInfo.reason;
+        }
+        fetchOptions = { headers: { 'PRIVATE-TOKEN': token } };
         [projectInfo, templateResult] = await Promise.allSettled([
           this.httpClient.fetchJson<GitLabProjectInfo>(projectApiUrl, fetchOptions),
           this.fetchTemplate(apiBaseUrl, encodedProjectPath, componentName, version, fetchOptions)
         ]);
-      } catch (err: unknown) {
-        const status = (err && typeof err === 'object' && 'status' in err)
-          ? (err as { status?: number }).status
-          : undefined;
-        if (status === 401 || status === 403) {
-          // Prompt for token and retry
-          token = await promptForTokenIfNeeded(context, this.tokenManager, gitlabInstance);
-          if (token) {
-            fetchOptions = { headers: { 'PRIVATE-TOKEN': token } };
-            [projectInfo, templateResult] = await Promise.allSettled([
-              this.httpClient.fetchJson<GitLabProjectInfo>(projectApiUrl, fetchOptions),
-              this.fetchTemplate(
-                apiBaseUrl,
-                encodedProjectPath,
-                componentName,
-                version,
-                fetchOptions
-              )
-            ]);
-          } else {
-            throw err;
-          }
-        } else {
-          throw err;
-        }
       }
 
       if (projectInfo.status === 'rejected') {
-        throw new Error(`Failed to fetch project info: ${projectInfo.reason}`);
+        // Preserve the original error (and its status) so auth failures stay recognisable upstream.
+        throw projectInfo.reason;
       }
 
       const project = projectInfo.value;
@@ -296,7 +301,13 @@ export class ComponentFetcher {
     } catch (error) {
       this.logger.error(`Error fetching component metadata: ${error}`);
 
-      // Still provide a minimal component rather than failing
+      // Auth failures must propagate: a minimal empty-parameter component would make every provided
+      // input look "unknown" during validation. Let callers surface a token prompt instead.
+      if (isAuthError(error)) {
+        throw error;
+      }
+
+      // For other failures, still provide a minimal component rather than failing outright.
       const urlParts = url.split('/');
       const lastPart = urlParts[urlParts.length - 1];
       const componentName = lastPart.includes('@') ? lastPart.split('@')[0] : lastPart;
@@ -432,9 +443,9 @@ export class ComponentFetcher {
       // Handle authentication errors and retry if needed
       if (projectInfoResult.status === 'rejected') {
         const err = projectInfoResult.reason;
-        if (err && (err.status === 401 || err.status === 403)) {
+        if (isAuthError(err)) {
           // Prompt for token and retry
-          token = await promptForTokenIfNeeded(context, this.tokenManager, cleanGitlabInstance);
+          token = await promptForTokenIfNeeded(context, this.tokenManager, cleanGitlabInstance, !!token);
           if (token) {
             fetchOptions = { headers: { 'PRIVATE-TOKEN': token } };
             const [retryProjectInfo] = await Promise.allSettled([

--- a/src/services/component/componentService.ts
+++ b/src/services/component/componentService.ts
@@ -60,6 +60,11 @@ export class ComponentService implements ComponentSource {
     this.tokenManager.setSecretStorage(secretStorage);
   }
 
+  /** Release the token manager's resources (its change-event emitter). */
+  public dispose(): void {
+    this.tokenManager.dispose();
+  }
+
   public async getTokenForProject(gitlabInstance: string): Promise<string | undefined> {
     return this.tokenManager.getTokenForProject(gitlabInstance);
   }

--- a/src/services/component/componentService.ts
+++ b/src/services/component/componentService.ts
@@ -50,6 +50,12 @@ export class ComponentService implements ComponentSource {
   }
 
   // Token management delegation
+
+  /** Fires (with the instance hostname) after a token is stored, so consumers can revalidate. */
+  public get onDidChangeToken(): vscode.Event<string> {
+    return this.tokenManager.onDidChangeToken;
+  }
+
   public setSecretStorage(secretStorage: vscode.SecretStorage): void {
     this.tokenManager.setSecretStorage(secretStorage);
   }

--- a/src/services/component/tokenManager.ts
+++ b/src/services/component/tokenManager.ts
@@ -4,7 +4,7 @@ import { Logger } from '../../utils/logger';
 /**
  * Manages GitLab personal access tokens using VS Code's SecretStorage
  */
-export class TokenManager {
+export class TokenManager implements vscode.Disposable {
   private logger = Logger.getInstance();
   private secretStorage: vscode.SecretStorage | undefined;
 
@@ -19,6 +19,10 @@ export class TokenManager {
 
   public setSecretStorage(secretStorage: vscode.SecretStorage): void {
     this.secretStorage = secretStorage;
+  }
+
+  public dispose(): void {
+    this.onDidChangeTokenEmitter.dispose();
   }
 
   /**

--- a/src/services/component/tokenManager.ts
+++ b/src/services/component/tokenManager.ts
@@ -8,6 +8,13 @@ export class TokenManager {
   private logger = Logger.getInstance();
   private secretStorage: vscode.SecretStorage | undefined;
 
+  private readonly onDidChangeTokenEmitter = new vscode.EventEmitter<string>();
+  /**
+   * Fires after a token is stored for a GitLab instance, with the instance hostname. Lets consumers
+   * (e.g. the validation provider) re-run work that previously failed for lack of a valid token.
+   */
+  public readonly onDidChangeToken = this.onDidChangeTokenEmitter.event;
+
   constructor() {}
 
   public setSecretStorage(secretStorage: vscode.SecretStorage): void {
@@ -43,6 +50,7 @@ export class TokenManager {
     this.logger.debug(`Storing token with key: ${key}`);
     await this.secretStorage.store(key, token);
     this.logger.debug(`Token stored successfully for ${gitlabInstance}`);
+    this.onDidChangeTokenEmitter.fire(gitlabInstance);
   }
 
   /**

--- a/src/utils/httpClient.ts
+++ b/src/utils/httpClient.ts
@@ -4,7 +4,7 @@ import * as vscode from 'vscode';
 import { Logger } from './logger';
 import { getRequestDeduplicator, RequestDeduplicator } from './requestDeduplicator';
 import { getPerformanceMonitor } from './performanceMonitor';
-import { NetworkError, getErrorHandler } from '../errors';
+import { NetworkError, getErrorHandler, extractStatusCode } from '../errors';
 import { API_PER_PAGE_LIMIT, MAX_PAGINATION_PAGES } from '../constants/timing';
 
 interface RequestOptions {
@@ -12,28 +12,6 @@ interface RequestOptions {
   retryAttempts?: number;
   headers?: Record<string, string>;
   retryDelay?: number;
-}
-
-/**
- * Extract an HTTP status code from an unknown thrown value.
- *
- * Prefers the typed `NetworkError.details.statusCode`, then falls back to a `statusCode` property on
- * the value itself (some Node networking errors expose one ad hoc). Anything else returns `undefined`
- * so callers can treat the failure as a non-HTTP error and route through the retry/backoff path.
- *
- * @param error  The value caught in a `try`/`catch` block. Accepted as `unknown` so callers don't
- *               need to narrow before passing it in.
- * @returns      The HTTP status code if one can be safely extracted, otherwise `undefined`.
- */
-function extractStatusCode(error: unknown): number | undefined {
-  if (error instanceof NetworkError && error.details?.statusCode) {
-    return error.details.statusCode;
-  }
-  if (typeof error === 'object' && error !== null && 'statusCode' in error) {
-    const candidate = (error as { statusCode: unknown }).statusCode;
-    return typeof candidate === 'number' ? candidate : undefined;
-  }
-  return undefined;
 }
 
 /**

--- a/tests/unit/authError.test.ts
+++ b/tests/unit/authError.test.ts
@@ -1,0 +1,58 @@
+// @mocha
+/**
+ * Tests for the auth-error helpers used to keep an expired/invalid GitLab token from degrading into
+ * spurious "unknown input" diagnostics. `isAuthError`/`extractStatusCode` are the single source of
+ * truth that the HTTP client, component fetcher, and validation provider all branch on.
+ */
+
+import * as assert from 'node:assert/strict';
+import { extractStatusCode, isAuthError } from '../../src/errors/guards';
+import { NetworkError, GitLabComponentError, ErrorCode } from '../../src/errors/types';
+
+suite('extractStatusCode', () => {
+  test('reads statusCode from a NetworkError', () => {
+    assert.equal(extractStatusCode(new NetworkError('nope', { statusCode: 401 })), 401);
+  });
+
+  test('reads a statusCode property off a plain error-shaped object', () => {
+    assert.equal(extractStatusCode({ statusCode: 403 }), 403);
+  });
+
+  test('returns undefined when no status is present', () => {
+    assert.equal(extractStatusCode(new Error('boom')), undefined);
+    assert.equal(extractStatusCode('just a string'), undefined);
+    assert.equal(extractStatusCode(undefined), undefined);
+  });
+});
+
+suite('isAuthError', () => {
+  test('true for a 401 NetworkError', () => {
+    assert.equal(isAuthError(new NetworkError('expired', { statusCode: 401 })), true);
+  });
+
+  test('true for a 403 NetworkError', () => {
+    assert.equal(isAuthError(new NetworkError('forbidden', { statusCode: 403 })), true);
+  });
+
+  test('true for an UNAUTHORIZED GitLabComponentError without a status', () => {
+    assert.equal(isAuthError(new GitLabComponentError(ErrorCode.UNAUTHORIZED, 'no token')), true);
+  });
+
+  test('true for a raw object carrying a 401 statusCode', () => {
+    assert.equal(isAuthError({ statusCode: 401 }), true);
+  });
+
+  test('false for a 404 NetworkError', () => {
+    assert.equal(isAuthError(new NetworkError('missing', { statusCode: 404 })), false);
+  });
+
+  test('false for a 500 NetworkError', () => {
+    assert.equal(isAuthError(new NetworkError('server', { statusCode: 500 })), false);
+  });
+
+  test('false for a generic error and non-error values', () => {
+    assert.equal(isAuthError(new Error('boom')), false);
+    assert.equal(isAuthError('401'), false);
+    assert.equal(isAuthError(undefined), false);
+  });
+});


### PR DESCRIPTION
## Summary
- Overhauls the expired/invalid GitLab token (HTTP 401/403) experience so failures are clear and recoverable: the component browser and CI-file diagnostics now show a plain-language message with a one-click recovery action, and open documents revalidate once a new token is saved.
- The underlying fix is to stop swallowing the 401 in `componentFetcher` (it had returned a `parameters: []` component, which made every input look unknown) and instead propagate auth failures so each caller can surface an actionable prompt.
- Link related issue(s): Fixes #197

## Change Type
- [ ] feat
- [x] fix
- [ ] refactor
- [ ] docs
- [ ] test
- [ ] chore

## Context
### User-facing impact
- **Component browser:** auth errors now render a plain-language message ("Your GitLab access token has expired. Update it to reload these components.") with an **Update Token** button that re-authenticates and refreshes; the raw GitLab response is preserved behind a "Show details" toggle. Applies to all three error views.
- **CI file validation:** a 401/403 now produces a single `component-auth-failed` diagnostic on the include line ("token is missing, invalid, or expired — update it") with an **Update GitLab token** Quick Fix, instead of one spurious `Unknown input` per input.
- **Token prompt:** distinguishes expired-vs-missing, names the extension in the title, and states the required `read_api` scope.
- **After saving a token:** open documents revalidate automatically, clearing the stale diagnostics.

### GitLab scope
- [ ] gitlab.com
- [ ] self-managed GitLab
- [x] both

### Affected areas
- [x] Component Browser
- [ ] Hover provider
- [ ] Completion provider
- [x] Validation provider
- [ ] Cache and refresh behavior
- [x] GitLab API calls/auth/token storage
- [ ] Docs only

## What changed by bucket

| Bucket | Files | Approach |
|---|---|---|
| Auth-error detection (shared) | [errors/guards.ts](../src/errors/guards.ts), [errors/index.ts](../src/errors/index.ts), [httpClient.ts](../src/utils/httpClient.ts) | New `extractStatusCode()` and `isAuthError()` predicates — the single source of truth for "is this a 401/403", recognising both the typed `UNAUTHORIZED` code and a raw status. Live in `guards.ts` so `types.ts` stays purely declarative; re-exported via `errors/index.ts`. `httpClient` now reuses the shared `extractStatusCode` instead of its private copy. |
| Propagate auth failures | [componentFetcher.ts](../src/services/component/componentFetcher.ts) | The project-info path detects a rejected-with-auth `allSettled` result, prompts for a token once and retries, and rethrows the **original** error (status preserved) if it still fails. The outer catch rethrows auth errors instead of returning the empty-parameter fallback (which had made every input look "unknown"). Fixed the catalog-fetch path's broken `err.status` check to use `isAuthError`. |
| Diagnostic + Quick Fix | [validationProvider.ts](../src/providers/validationProvider.ts), [validationMetadata.ts](../src/providers/validationMetadata.ts) | On an auth failure, emit a distinct `component-auth-failed` diagnostic (clear message, skip input validation) instead of `unknown-input` spam, with an **Update GitLab token** Quick Fix wired to `gitlabComponentHelper.addProjectToken`. New `ComponentAuthFailedMetadata` variant in the discriminated union. |
| Browser error views | [componentBrowserProvider.ts](../src/providers/componentBrowserProvider.ts) | New `classifySourceError()` produces a friendly summary for auth errors. All three error views (`getErrorsHtml`, the inline banner in `getComponentBrowserHtml`, `getErrorHtml`) render auth errors with the summary + collapsible raw detail + an **Update Token** button; new `updateToken` webview command runs `addProjectToken` then refreshes. Error/source strings are now HTML-escaped (previously injected raw). |
| Clearer token prompt | [componentFetcher.ts](../src/services/component/componentFetcher.ts), [commands.ts](../src/services/component/commands.ts) | `promptForTokenIfNeeded` takes a `hadToken` flag and adapts the message (expired-vs-missing), adds a `title: 'GitLab Component Helper'`, a placeholder, and the `read_api` scope hint. Both call sites pass `!!token`. The `addProjectToken` command prompts gain the same title + scope hint. |
| Revalidate on token change | [tokenManager.ts](../src/services/component/tokenManager.ts), [componentService.ts](../src/services/component/componentService.ts), [validationProvider.ts](../src/providers/validationProvider.ts) | `TokenManager.setTokenForProject` fires a new `onDidChangeToken` event (exposed via a `ComponentService` getter). The validation provider subscribes and calls the existing `revalidateOpenDocuments()`, so a newly-saved token clears the stale diagnostics across all three save paths (inline prompt, Quick Fix, browser button). |
| Docs | [README.md](../README.md) | New "Token scope" note (`read_api` scope + Reporter access) and an HTTP 401 / token-expired troubleshooting entry. |
| Tests | [authError.test.ts](../tests/unit/authError.test.ts) | New unit suite for `extractStatusCode`/`isAuthError` covering 401/403, the `UNAUTHORIZED` code without a status, raw status objects, and non-auth/non-error inputs. |

## Validation
### Local checks
- [x] `npm run compile` (`tsc --noEmit` clean, both configs)
- [x] `npm test` (274 passing, incl. 10 new)
- [ ] Manual verification in VS Code Extension Host

### Manual test notes
- Reproduced with an expired token against a private source. **Browser:** the raw 401 blob is replaced by the friendly summary + working **Update Token** button. **CI file:** the per-input `Unknown input` spam is replaced by a single auth diagnostic with the **Update GitLab token** Quick Fix. **Prompt:** reads "invalid or has expired" with the extension name in the title and the `read_api` scope. **After updating:** confirmed the document revalidates and the squiggles clear without re-editing.

## Breaking Changes
- [x] No breaking changes
- [ ] Breaking changes (describe below)

## Screenshots / Recordings (if UI behavior changed)
- Before: raw `HTTP 401: {"error":"invalid_token",...}` in the browser; one `Unknown input '<name>'` per input in the editor.
- After: friendly summary + **Update Token** button; single auth diagnostic + **Update GitLab token** Quick Fix; prompt naming the extension and required scope.

## Risk and Rollback
- Main risks: auth errors now throw where they previously returned a degraded component — non-auth failures keep the existing empty-component fallback, so only the 401/403 path changes. The new token-change event triggers a revalidation pass on open documents (cheap; `validate()` early-outs for non-CI files).
- Rollback strategy: revert the branch; no persisted state or settings changes.

## Release Notes Draft
- Expired/invalid GitLab tokens now show a clear message with a one-click "Update Token" action and a Quick Fix, instead of a raw 401 blob and spurious "unknown input" warnings; diagnostics refresh automatically after re-authenticating.

## Checklist
- [ ] Branch is up to date with target branch
- [ ] Commit messages follow conventional commits
- [x] Added/updated docs for behavior or settings changes
- [x] Added/updated tests for new behavior
- [x] No secrets or tokens in code, logs, screenshots, or test fixtures
