### PR TITLE
fix: enum input values aren't offered, and an enum input with a default never shows its dropdown

### DIFF
--- a/src/providers/completionInputContext.ts
+++ b/src/providers/completionInputContext.ts
@@ -10,14 +10,22 @@ import type { ComponentParameter } from '../types/git-component';
 
 /**
  * The completion slot a YAML cursor position resolves to.
+ *
+ * `slot` discriminates the two positions completion fires in: a `name` slot is where a parameter key is typed (the
+ * caller offers the missing input names); a `value` slot is the value position after a known `inputName:` (the caller
+ * offers that input's allowed values). The fields below carry whichever extra context each slot needs.
  */
 export interface CompletionInputContext {
   /** URL or local path of the include that owns the surrounding `inputs:` block. */
   componentUrl: string;
   /** Which include flavour matched: `component` for remote URLs, `local` for in-repo includes. */
   includeKind: 'component' | 'local';
+  /** Which position the cursor resolved to. */
+  slot: 'name' | 'value';
   /** Names of inputs already written under this include, so the caller can filter them out of the suggestions. */
   existingInputNames: string[];
+  /** For a `value` slot, the name of the input whose value is being completed; absent for a `name` slot. */
+  inputName?: string;
 }
 
 interface ClosestInclude {
@@ -66,32 +74,46 @@ export function findCompletionInputContextAtLine(
   const section = findInputsSection(lines, closest.componentLineIndex, lineIndex);
   if (!section) return null;
 
-  // Containment in the inputs block is already established above; here we only check the line looks like a
-  // parameter-name slot. A name slot must line up at the same column as the existing input keys
-  // (`section.childIndent`) — one column shallower is a sibling of `inputs:`, deeper is a value nested under
-  // another input. When the block has no keys yet, fall back to "deeper than `inputs:`". It must also not be an
-  // array-item line (`- value`, part of a parameter value) nor an already-complete `key: value`.
+  // Containment in the inputs block is already established above. The line must line up at the same column as the
+  // existing input keys (`section.childIndent`) — one column shallower is a sibling of `inputs:`, deeper is a value
+  // nested under another input. When the block has no keys yet, fall back to "deeper than `inputs:`".
   const currentLine = lines[lineIndex];
   const currentLineText = currentLine.trim();
   const currentIndent = indentOf(currentLine);
   const indentMatches =
     section.childIndent !== null ? currentIndent === section.childIndent : currentIndent > section.inputsIndent;
-  // When a cursor column is supplied, the cursor must sit at the slot's indent column or within the name being
-  // typed after it — never left of the indent. Typing the right indentation then moving the cursor left leaves
-  // the line's whitespace intact, so the indent check above still matches; but the cursor is no longer in the
-  // name slot, so we must not offer completions there.
+  if (!indentMatches || currentLineText.startsWith('- ') || currentLineText === '-') return null;
+
+  // A `key:` line splits into a name slot (left of the colon) and a value slot (right of it). When the cursor sits
+  // past the colon and the key is a real input name, offer that input's allowed values instead of input names.
+  const colonIndex = currentLine.indexOf(':');
+  if (colonIndex !== -1) {
+    const inputName = currentLine.slice(0, colonIndex).trim();
+    const cursorInValue = column !== undefined && column > colonIndex;
+    if (inputName && cursorInValue) {
+      return {
+        componentUrl: closest.componentUrl,
+        includeKind: closest.includeKind,
+        slot: 'value',
+        existingInputNames: closest.existingInputNames,
+        inputName,
+      };
+    }
+  }
+
+  // Otherwise it's a name slot: a bare/partial key with no value yet. When a cursor column is supplied it must sit
+  // at the slot's indent column or within the name being typed — never left of the indent (typing the indentation
+  // then moving the cursor left leaves the whitespace intact, so the indent check above still matches, but the
+  // cursor is no longer in the name slot). A completed `key: value` line is not a name slot.
   const cursorAtSlot = column === undefined || column >= currentIndent;
-  const isParameterContext =
-    indentMatches &&
-    cursorAtSlot &&
-    !currentLineText.startsWith('- ') &&
-    currentLineText !== '-' &&
-    (!currentLineText.includes(':') || currentLineText.endsWith(':'));
-  if (!isParameterContext) return null;
+  const isNameSlot =
+    cursorAtSlot && (!currentLineText.includes(':') || currentLineText.endsWith(':'));
+  if (!isNameSlot) return null;
 
   return {
     componentUrl: closest.componentUrl,
     includeKind: closest.includeKind,
+    slot: 'name',
     existingInputNames: closest.existingInputNames,
   };
 }
@@ -273,6 +295,30 @@ function quoteYamlIfUnsafe(value: string, flow = false): string {
 }
 
 /**
+ * Render a single `options:` entry as the YAML to insert for it.
+ *
+ * Numbers and booleans stay bare so they aren't turned into strings; string entries stay bare where a bare scalar
+ * round-trips and are double-quoted only where bare YAML would reinterpret them (see {@link quoteYamlIfUnsafe}).
+ *
+ * @param value - One allowed value from an input's `options:` list.
+ * @returns The YAML text for that value, bare or double-quoted as required.
+ */
+export function renderOptionValue(value: string | number | boolean): string {
+  return typeof value === 'string' ? quoteYamlIfUnsafe(value) : String(value);
+}
+
+/**
+ * Narrow a parameter default to the scalar shapes an `options:` entry can take (string/number/boolean), excluding
+ * the `null` and array forms a default may also hold.
+ *
+ * @param value - A parameter default of any allowed shape.
+ * @returns `true` when `value` is a string, number, or boolean.
+ */
+function isOptionScalar(value: unknown): value is string | number | boolean {
+  return typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean';
+}
+
+/**
  * Build the value portion of the snippet inserted after `param.name: ` when an input is accepted from completion.
  *
  * Returns a TextMate snippet body (with `${1...}` tab-stops) the caller wraps in a `vscode.SnippetString`.
@@ -280,13 +326,29 @@ function quoteYamlIfUnsafe(value: string, flow = false): string {
  * Values are inserted bare where a bare YAML scalar round-trips to the same string — GitLab CI parses a bare scalar
  * by the input's declared type, so a string input is a bare scalar, not a quoted one. Strings that bare YAML would
  * reinterpret (indicators, embedded `: `/` #`, type-like tokens, etc.) are double-quoted; see {@link quoteYamlIfUnsafe}.
- * Precedence: an explicit `default` is rendered as the YAML it represents; otherwise an `options:` enum becomes a
- * choice; otherwise a type-appropriate placeholder.
+ * Precedence: an `options:` enum becomes a `${1|...|}` choice (with the default, if any, pre-selected first) so the
+ * allowed values stay one keystroke away; otherwise an explicit `default` is rendered as the YAML it represents;
+ * otherwise a type-appropriate placeholder.
  *
  * @param param - The input parameter spec (type, optional default, optional `options` enum, requiredness).
- * @returns The snippet body to insert after `param.name: ` — a rendered value, a `${1|...|}` choice, or a `${1:...}` placeholder.
+ * @returns The snippet body to insert after `param.name: ` — a `${1|...|}` choice, a rendered value, or a `${1:...}` placeholder.
  */
 export function buildInputInsertValue(param: ComponentParameter): string {
+  if (param.options && param.options.length > 0) {
+    // Offer the allowed values (`options:`) as a choice. Entries stay unquoted so a number/boolean option isn't
+    // turned into a string; string entries are quoted only when bare YAML would reinterpret them. When the input
+    // also has a default, float the matching option to the front — VS Code pre-selects the first choice entry, so
+    // accepting the input keeps the default while leaving the alternatives one arrow-key away.
+    const rendered = param.options.map(renderOptionValue);
+    // Only a scalar default can name one of the options; a null or array default has no matching entry.
+    const defaultRendered = isOptionScalar(param.default) ? renderOptionValue(param.default) : undefined;
+    const ordered =
+      defaultRendered !== undefined && rendered.includes(defaultRendered)
+        ? [defaultRendered, ...rendered.filter((v) => v !== defaultRendered)]
+        : rendered;
+    return `\${1|${ordered.join(',')}|}`;
+  }
+
   if (param.default !== undefined) {
     // Render the default as the YAML the input expects: arrays as flow sequences (`[a, b]`),
     // strings bare-or-quoted by round-trip safety, everything else as its bare scalar form.
@@ -294,16 +356,6 @@ export function buildInputInsertValue(param: ComponentParameter): string {
       return `[${param.default.map((v) => (typeof v === 'string' ? quoteYamlIfUnsafe(v, true) : String(v))).join(', ')}]`;
     }
     return typeof param.default === 'string' ? quoteYamlIfUnsafe(param.default) : String(param.default);
-  }
-
-  if (param.options && param.options.length > 0) {
-    // Offer the allowed values (`options:`) as a choice. Entries stay unquoted so a number/boolean
-    // option isn't turned into a string; string entries are quoted only when bare YAML would
-    // reinterpret them.
-    const optionValues = param.options
-      .map((val) => (typeof val === 'string' ? quoteYamlIfUnsafe(val) : String(val)))
-      .join(',');
-    return `\${1|${optionValues}|}`;
   }
 
   switch (param.type) {

--- a/src/providers/completionProvider.ts
+++ b/src/providers/completionProvider.ts
@@ -5,7 +5,7 @@ import { getVariableCompletions, containsGitLabVariables, expandComponentUrl } f
 import { Logger } from '../utils/logger';
 import { isGitLabCIFile } from '../utils/gitlabCiFileMatcher';
 import { resolveLocalComponent } from './localComponentResolver';
-import { findCompletionInputContextAtLine, buildInputInsertValue } from './completionInputContext';
+import { findCompletionInputContextAtLine, buildInputInsertValue, renderOptionValue } from './completionInputContext';
 import type { ComponentParameter } from '../types/git-component';
 import type { CachedComponent } from '../types/cache';
 
@@ -372,7 +372,7 @@ export class CompletionProvider implements vscode.CompletionItemProvider {
       const { componentUrl, includeKind, existingInputNames } = context;
       const isLocal = includeKind === 'local';
 
-      this.logger.debug(`[CompletionProvider] In inputs slot for ${componentUrl} (local=${isLocal})`, 'CompletionProvider');
+      this.logger.debug(`[CompletionProvider] In inputs ${context.slot} slot for ${componentUrl} (local=${isLocal})`, 'CompletionProvider');
 
       // Get the component details - local includes resolve from the workspace file, others from cache.
       const component = isLocal
@@ -384,6 +384,25 @@ export class CompletionProvider implements vscode.CompletionItemProvider {
       }
 
       this.logger.debug(`[CompletionProvider] Found component ${component.name} with ${component.parameters.length} parameters; existing inputs: ${existingInputNames.join(', ') || 'none'}`, 'CompletionProvider');
+
+      // A value slot (cursor after a known `inputName:`) offers that input's allowed values, independent of whether
+      // it also declares a default — the default is just the pre-filled choice, not a reason to hide the others.
+      if (context.slot === 'value') {
+        const param = component.parameters.find((p: ComponentParameter) => p.name === context.inputName);
+        if (!param?.options?.length) {
+          this.logger.debug(`[CompletionProvider] Value slot for ${context.inputName} has no options to offer`, 'CompletionProvider');
+          return null;
+        }
+        return param.options.map((value, index) => {
+          const rendered = renderOptionValue(value);
+          const item = new vscode.CompletionItem(String(value), vscode.CompletionItemKind.EnumMember);
+          item.insertText = rendered;
+          item.detail = `${param.type || 'string'} option`;
+          // Preserve the declared order of `options:` in the dropdown.
+          item.sortText = String(index).padStart(4, '0');
+          return item;
+        });
+      }
 
       // Filter out already provided inputs
       const existing = new Set(existingInputNames);

--- a/tests/extension-host/suite/enumOptionsCompletion.test.ts
+++ b/tests/extension-host/suite/enumOptionsCompletion.test.ts
@@ -1,0 +1,107 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+const EXTENSION_ID = 'eFAILution.gitlab-component-helper';
+
+// __dirname is <repo>/out-test/suite at runtime; fixtures live under tests/fixtures.
+const FIXTURE_DIR = path.resolve(__dirname, '..', '..', 'tests', 'fixtures', 'enum-options');
+const FIXTURE = path.join(FIXTURE_DIR, '.gitlab-ci.yml');
+
+async function ensureActive(): Promise<void> {
+  const ext = vscode.extensions.getExtension(EXTENSION_ID);
+  assert.ok(ext);
+  if (!ext.isActive) await ext.activate();
+}
+
+/** 0-indexed line whose trimmed text starts with `<name>:`. */
+function lineStartingWith(doc: vscode.TextDocument, name: string): number {
+  const lines = doc.getText().split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].trim().startsWith(`${name}:`)) return i;
+  }
+  throw new Error(`fixture missing a line starting with ${name}:`);
+}
+
+function labels(list: vscode.CompletionList | undefined): string[] {
+  return (list?.items ?? []).map((i) => (typeof i.label === 'string' ? i.label : i.label.label));
+}
+
+function itemNamed(list: vscode.CompletionList | undefined, label: string): vscode.CompletionItem | undefined {
+  return (list?.items ?? []).find((i) => (typeof i.label === 'string' ? i.label : i.label.label) === label);
+}
+
+/** Like {@link itemNamed} but fails the test (and narrows away `undefined`) when no item has that label. */
+function requireItem(list: vscode.CompletionList, label: string): vscode.CompletionItem {
+  const item = itemNamed(list, label);
+  if (!item) {
+    throw new assert.AssertionError({
+      message: `expected a '${label}' completion item. Got: ${JSON.stringify(labels(list))}`,
+    });
+  }
+  return item;
+}
+
+function snippetText(item: vscode.CompletionItem): string {
+  const insert = item.insertText;
+  if (typeof insert === 'string') return insert;
+  if (insert instanceof vscode.SnippetString) return insert.value;
+  return '';
+}
+
+async function completionsAt(doc: vscode.TextDocument, position: vscode.Position): Promise<vscode.CompletionList> {
+  const list = await vscode.commands.executeCommand<vscode.CompletionList>(
+    'vscode.executeCompletionItemProvider',
+    doc.uri,
+    position
+  );
+  assert.ok(list, 'executeCompletionItemProvider returned no completion list');
+  return list;
+}
+
+// Drives VS Code's own completion engine (executeCompletionItemProvider) against a local include whose
+// `environment` input declares `options:` AND a `default:`. Covers both completion slots: the value position
+// (after `environment:`) must offer the allowed values directly, and the name slot must still insert the
+// name + value-choice snippet.
+suite('Enum options completion for an include input', () => {
+  suiteSetup(ensureActive);
+
+  test('value slot after `region:` offers the allowed values as bare scalars', async () => {
+    const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(FIXTURE));
+    await vscode.window.showTextDocument(doc);
+
+    const line = lineStartingWith(doc, 'region');
+    // End of the `      region: ` line — the value position a user fills.
+    const position = new vscode.Position(line, doc.lineAt(line).text.length);
+    const list = await completionsAt(doc, position);
+
+    const eu = requireItem(list, 'eu-west-1');
+    const us = requireItem(list, 'us-east-1');
+    // Values insert as the bare scalar, not a name: value snippet.
+    assert.strictEqual(snippetText(eu), 'eu-west-1');
+    assert.strictEqual(snippetText(us), 'us-east-1');
+  });
+
+  test('name slot offers the ${1|...|} value choice for an enum input that also has a default (default first)', async () => {
+    const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(FIXTURE));
+    await vscode.window.showTextDocument(doc);
+
+    // `environment` is an enum input WITH a default (`staging`) and isn't set yet. Accepting it by name must offer
+    // the value choice — not silently insert the bare default — with the default floated to the front.
+    const keyIndent = doc.lineAt(lineStartingWith(doc, 'job_name')).firstNonWhitespaceCharacterIndex;
+    let slotLine = -1;
+    for (let i = 0; i < doc.lineCount; i++) {
+      const t = doc.lineAt(i).text;
+      if (t.trim() === '' && t.length >= keyIndent && /^\s+$/.test(t)) {
+        slotLine = i;
+        break;
+      }
+    }
+    assert.ok(slotLine !== -1, 'fixture is missing a whitespace-only name slot at the input-key indent');
+    const position = new vscode.Position(slotLine, keyIndent);
+    const list = await completionsAt(doc, position);
+
+    const envItem = requireItem(list, 'environment');
+    assert.strictEqual(snippetText(envItem), 'environment: ${1|staging,production|}');
+  });
+});

--- a/tests/extension-host/tsconfig.json
+++ b/tests/extension-host/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.test.json"
+}

--- a/tests/fixtures/enum-options/.gitlab-ci.yml
+++ b/tests/fixtures/enum-options/.gitlab-ci.yml
@@ -1,0 +1,6 @@
+include:
+  - local: "enum-options/templates/deploy.yml"
+    inputs:
+      job_name: deploy
+      region: 
+      

--- a/tests/fixtures/enum-options/templates/deploy.yml
+++ b/tests/fixtures/enum-options/templates/deploy.yml
@@ -1,0 +1,22 @@
+spec:
+  inputs:
+    environment:
+      description: Target environment
+      type: string
+      default: staging
+      options:
+        - staging
+        - production
+    region:
+      description: Target region (no default)
+      type: string
+      options:
+        - eu-west-1
+        - us-east-1
+    job_name:
+      description: The name of the CI job
+      type: string
+---
+$[[ inputs.job_name ]]:
+  script:
+    - echo "deploy $[[ inputs.job_name ]] to $[[ inputs.environment ]]/$[[ inputs.region ]]"

--- a/tests/unit/completionInputContext.test.ts
+++ b/tests/unit/completionInputContext.test.ts
@@ -29,6 +29,7 @@ suite('findCompletionInputContextAtLine', () => {
     assert.deepStrictEqual(ctx, {
       componentUrl: FULL_PIPELINE_URL,
       includeKind: 'component',
+      slot: 'name',
       existingInputNames: ['environment'],
     });
   });
@@ -46,6 +47,7 @@ suite('findCompletionInputContextAtLine', () => {
     assert.deepStrictEqual(ctx, {
       componentUrl: FULL_PIPELINE_URL,
       includeKind: 'component',
+      slot: 'name',
       existingInputNames: ['tags'],
     });
   });
@@ -82,6 +84,7 @@ suite('findCompletionInputContextAtLine', () => {
     assert.deepStrictEqual(ctx, {
       componentUrl: FULL_PIPELINE_URL,
       includeKind: 'component',
+      slot: 'name',
       existingInputNames: ['environment'],
     });
   });
@@ -96,6 +99,7 @@ suite('findCompletionInputContextAtLine', () => {
     assert.deepStrictEqual(ctx, {
       componentUrl: FULL_PIPELINE_URL,
       includeKind: 'component',
+      slot: 'name',
       existingInputNames: [],
     });
   });
@@ -161,6 +165,7 @@ stages:
     assert.deepStrictEqual(ctx, {
       componentUrl: FULL_PIPELINE_URL,
       includeKind: 'component',
+      slot: 'name',
       existingInputNames: ['environment'],
     });
   });
@@ -190,6 +195,7 @@ stages:
     assert.deepStrictEqual(ctx, {
       componentUrl: second,
       includeKind: 'component',
+      slot: 'name',
       existingInputNames: ['stage'],
     });
   });
@@ -204,6 +210,7 @@ stages:
     assert.deepStrictEqual(ctx, {
       componentUrl: '/templates/nx-test.yml',
       includeKind: 'local',
+      slot: 'name',
       existingInputNames: ['stage'],
     });
   });
@@ -219,6 +226,7 @@ stages:
     assert.deepStrictEqual(ctx, {
       componentUrl: FULL_PIPELINE_URL,
       includeKind: 'component',
+      slot: 'name',
       existingInputNames: ['environment'],
     });
   });
@@ -234,8 +242,45 @@ stages:
     assert.deepStrictEqual(ctx, {
       componentUrl: FULL_PIPELINE_URL,
       includeKind: 'component',
+      slot: 'name',
       existingInputNames: ['environment'],
     });
+  });
+
+  test('detects a value slot when the cursor sits past the colon of a known input line', () => {
+    const text = `include:
+  - component: ${FULL_PIPELINE_URL}
+    inputs:
+      environment: `;
+    // Column 19 is just past `      environment:` (the colon is at column 17, the space at 18).
+    const ctx = findCompletionInputContextAtLine(text, 3, 19);
+    assert.deepStrictEqual(ctx, {
+      componentUrl: FULL_PIPELINE_URL,
+      includeKind: 'component',
+      slot: 'value',
+      existingInputNames: ['environment'],
+      inputName: 'environment',
+    });
+  });
+
+  test('detects a value slot mid-value while a partial value is being typed', () => {
+    const text = `include:
+  - component: ${FULL_PIPELINE_URL}
+    inputs:
+      environment: prod`;
+    const ctx = findCompletionInputContextAtLine(text, 3, 21);
+    assert.strictEqual(ctx?.slot, 'value');
+    assert.strictEqual(ctx?.inputName, 'environment');
+  });
+
+  test('stays a name slot when the cursor sits left of the colon on a key line', () => {
+    const text = `include:
+  - component: ${FULL_PIPELINE_URL}
+    inputs:
+      environment: `;
+    // Column 10 is within the key `environment`, before the colon — still a name slot.
+    const ctx = findCompletionInputContextAtLine(text, 3, 10);
+    assert.strictEqual(ctx?.slot, 'name');
   });
 
   test('returns null when the cursor is on a complete key: value line', () => {
@@ -328,6 +373,24 @@ suite('buildInputInsertValue', () => {
   test('quotes an options entry only when bare YAML would reinterpret it, leaving others bare', () => {
     assert.strictEqual(buildInputInsertValue({ ...base, options: ['ns:', 'plain'] }), '${1|"ns:",plain|}');
     assert.strictEqual(buildInputInsertValue({ ...base, options: ['true', 'aws'] }), '${1|"true",aws|}');
+  });
+
+  test('offers the options choice (not the bare default) when an input has both, with the default pre-selected first', () => {
+    // options + default: the choice wins so the alternatives stay reachable, and the default floats to the front.
+    assert.strictEqual(
+      buildInputInsertValue({ ...base, default: 'gcp', options: ['aws', 'gcp', 'azure'] }),
+      '${1|gcp,aws,azure|}'
+    );
+    // A default that isn't among the options leaves the declared order untouched.
+    assert.strictEqual(
+      buildInputInsertValue({ ...base, default: 'on-prem', options: ['aws', 'gcp'] }),
+      '${1|aws,gcp|}'
+    );
+    // Non-string scalar default still matches its option entry.
+    assert.strictEqual(
+      buildInputInsertValue({ ...base, type: 'boolean', default: true, options: [false, true] }),
+      '${1|true,false|}'
+    );
   });
 
   test('falls back to a TODO placeholder for a required untyped input', () => {


### PR DESCRIPTION
## Summary
- Offers an enum input's allowed values from completion in two cases that previously didn't work: in the **value position** (cursor after `inputName:`), and when accepting an enum input by **name where it also has a `default:`**.
- Value position: slot detection now distinguishes a name slot (left of the colon, where you type the key) from a value slot (right of the colon). In a value slot for an input with `options:`, completion returns one item per allowed value, inserting the bare scalar — so you pick the value at the point you're setting it, instead of getting the input-name list again.
- Enum + default: `buildInputInsertValue` now gives `options:` precedence over `default:`. When both are present it still emits the `${1|a,b,c|}` choice and floats the default to the front (VS Code pre-selects the first choice entry), so accepting the input keeps the default by default while leaving the alternatives one arrow-key away — rather than silently inserting the bare default with no dropdown.
- Link related issue(s): Fixes #204 

## Change Type
- [x] feat
- [ ] fix
- [ ] refactor
- [ ] docs
- [ ] test
- [ ] chore

## Context
### User-facing impact
- Completing an enum input's value (cursor after `inputName:`) now offers the allowed values as a dropdown; picking one inserts the bare value.
- Accepting an enum input by name now offers the value choice even when the input has a default, with the default pre-selected — the other allowed values are reachable instead of hidden.
- An enum input with no default is unchanged: accepting it by name still inserts the `${1|...|}` choice.

### GitLab scope
- [ ] gitlab.com
- [ ] self-managed GitLab
- [x] both (completion-side rendering only; no GitLab interaction)

### Affected areas
- [ ] Component Browser
- [ ] Hover provider
- [x] Completion provider
- [ ] Validation provider
- [ ] Cache and refresh behavior
- [ ] GitLab API calls/auth/token storage
- [ ] Docs only

## What changed by bucket

| Bucket | Files | Approach |
|---|---|---|
| Value-slot detection | [completionInputContext.ts](../src/providers/completionInputContext.ts) | `CompletionInputContext` gains a `slot: 'name' \| 'value'` discriminant (and `inputName` for value slots). `findCompletionInputContextAtLine` splits a `key:` line: when a cursor column is supplied and sits past the colon of a real input key, it resolves to a `value` slot carrying that input's name; otherwise the existing name-slot rules apply (bare/partial key, cursor at the indent, not a finished `key: value`). The column-agnostic form used by tests still resolves to name slots, so existing callers/tests keep their behaviour. |
| Value completion | [completionProvider.ts](../src/providers/completionProvider.ts) | `provideComponentInputCompletions` branches on `context.slot`. For a `value` slot it finds the param by name and, when it declares `options`, returns one `EnumMember` completion per allowed value (inserted as the bare scalar via the shared `renderOptionValue`, ordered to match the declared `options:`). Reads `options` regardless of `default`, so an enum input with a default still offers all values in the value position. |
| Enum/default precedence | [completionInputContext.ts](../src/providers/completionInputContext.ts) | `buildInputInsertValue` now checks `options` before `default`: an enum input always becomes a `${1\|...\|}` choice, and when it also has a (scalar) default that matches an option, the default is moved to the front so VS Code pre-selects it. A default not among the options leaves the declared order untouched; `null`/array defaults are excluded via an `isOptionScalar` type-guard. Extracted `renderOptionValue` (single-value YAML-safe rendering) so the choice snippet and the value-slot items quote identically. |
| Unit tests | [completionInputContext.test.ts](../tests/unit/completionInputContext.test.ts) | Value-slot detection (cursor past the colon → value slot + inputName; mid-value; cursor left of the colon stays a name slot), the new `slot` field on existing name-slot expectations, and `buildInputInsertValue` with both `options` and `default` (default floated first; unmatched default leaves order; non-string scalar default). |
| Extension-host tests | [enumOptionsCompletion.test.ts](../tests/extension-host/suite/enumOptionsCompletion.test.ts), [tests/fixtures/enum-options/](../tests/fixtures/enum-options/) | Drives VS Code's own completion engine (`executeCompletionItemProvider`) against a local include whose template declares two enum inputs (`environment` with a default, `region` without). Covers the value slot (offers the allowed values as bare scalars) and the name slot for an enum-with-default (offers the `${1\|...\|}` choice, default first). |
| IDE config | [tests/extension-host/tsconfig.json](../tests/extension-host/tsconfig.json) | Thin `tsconfig.json` that `extends` the root `tsconfig.test.json`, mirroring the existing `tests/unit/tsconfig.json` stub. It exists so the editor's TS server resolves the extension-host test files against the config that has the `node`/`vscode`/`mocha` types; the build still compiles via the root `tsconfig.test.json`. |

## Validation
### Local checks
- [x] `npm run compile` (`tsc --noEmit` clean)
- [x] `npm test` (299 passing)
- [x] `npm run test:extension-host` (19 passing)
- [x] `npm run lint` clean

### Manual test notes
- Verified live in an Extension Development Host by driving `executeCompletionItemProvider`:
  - Value slot after `region:` → returns `eu-west-1` / `us-east-1` as items inserting the bare scalar.
  - Name slot accepting `environment` (which has `default: staging` + `options`) → inserts `environment: ${1|staging,production|}` (default first), not the bare default.

## Breaking Changes
- [x] No breaking changes
- [ ] Breaking changes (describe below)

## Release Notes Draft
- Feature: GitLab component inputs that declare `options:` now offer their allowed values as a completion dropdown — both when filling the value after `inputName:` and when accepting the input by name. Enum inputs that also have a default now show the choice with the default pre-selected, instead of inserting the default with no dropdown.
