### PR TITLE
fix: no input suggestions for the second of two identical component includes

### DIFF
--- a/src/providers/completionInputContext.ts
+++ b/src/providers/completionInputContext.ts
@@ -6,6 +6,7 @@
  */
 
 import { parseYaml, isYamlNode } from '../utils/yamlParser';
+import { findIncludeLine } from '../utils/includeMatcher';
 import type { ComponentParameter } from '../types/git-component';
 
 /**
@@ -126,10 +127,24 @@ function parseInputDocument(text: string, lines: string[], lineIndex: number): u
 /**
  * Find the include entry whose source line is the closest one above `lineIndex`, matching the parsed includes
  * back to their position in the text.
+ *
+ * `includes` is in document order, so duplicate entries that share an identical key+URL (the same component included
+ * twice with different inputs) are disambiguated by occurrence ordinal: the Nth such entry anchors to the Nth
+ * matching line.
+ *
+ * @param includes - The parsed `include:` entries, in document order; non-mapping entries and those without a
+ *   string `component`/`local` are skipped.
+ * @param lines - The full document split into lines, used to locate each include's source line.
+ * @param lineIndex - 0-based cursor line; only includes whose source line sits strictly above it are considered.
+ * @returns The closest matching include's URL/kind, its source line index, and the names of inputs already present
+ *   under it; `null` when no include is declared above `lineIndex`.
  */
 function findClosestInclude(includes: unknown[], lines: string[], lineIndex: number): ClosestInclude | null {
   let closest: ClosestInclude | null = null;
   let closestDistance = Infinity;
+
+  // How many key+URL pairs identical to the current entry we have already passed in document order.
+  const occurrenceSeen = new Map<string, number>();
 
   for (const include of includes) {
     if (!isYamlNode(include)) continue;
@@ -145,13 +160,11 @@ function findClosestInclude(includes: unknown[], lines: string[], lineIndex: num
 
     const includeKey = isLocal ? 'local:' : 'component:';
 
-    let componentLineIndex = -1;
-    for (let i = 0; i < lines.length; i++) {
-      if (lines[i].includes(includeKey) && lines[i].includes(componentUrl)) {
-        componentLineIndex = i;
-        break;
-      }
-    }
+    const occurrenceKey = `${includeKey}\n${componentUrl}`;
+    const occurrence = (occurrenceSeen.get(occurrenceKey) ?? 0) + 1;
+    occurrenceSeen.set(occurrenceKey, occurrence);
+
+    const componentLineIndex = findIncludeLine(lines, includeKey, componentUrl, occurrence);
     if (componentLineIndex === -1 || componentLineIndex >= lineIndex) continue;
 
     const distance = lineIndex - componentLineIndex;

--- a/src/providers/hoverInputContext.ts
+++ b/src/providers/hoverInputContext.ts
@@ -5,6 +5,7 @@
  */
 
 import { parseYaml, isYamlNode } from '../utils/yamlParser';
+import { findIncludeLine } from '../utils/includeMatcher';
 
 /**
  * The component-input slot a YAML cursor position resolves to.
@@ -62,19 +63,22 @@ export function findInputContextAtLine(text: string, lineIndex: number): InputCo
   }
   if (candidates.length === 0) return null;
 
-  // Find the closest include line above the cursor that matches one of the parsed candidates.
+  // Find the closest include line above the cursor that matches one of the parsed candidates. `candidates` is in
+  // document order, so duplicate entries sharing an identical key+URL (the same component included twice with
+  // different inputs) are disambiguated by occurrence ordinal.
   let closestIncludeLine = -1;
   let closestCandidate: IncludeCandidate | null = null;
+  const occurrenceSeen = new Map<string, number>();
   for (const candidate of candidates) {
     const lineKey = `${candidate.key}:`;
-    for (let i = 0; i < lineIndex; i++) {
-      if (lines[i].includes(lineKey) && lines[i].includes(candidate.value)) {
-        if (i > closestIncludeLine) {
-          closestIncludeLine = i;
-          closestCandidate = candidate;
-        }
-        break;
-      }
+    const occurrenceKey = `${lineKey}\n${candidate.value}`;
+    const occurrence = (occurrenceSeen.get(occurrenceKey) ?? 0) + 1;
+    occurrenceSeen.set(occurrenceKey, occurrence);
+
+    const matchLine = findIncludeLine(lines, lineKey, candidate.value, occurrence);
+    if (matchLine !== -1 && matchLine < lineIndex && matchLine > closestIncludeLine) {
+      closestIncludeLine = matchLine;
+      closestCandidate = candidate;
     }
   }
   if (closestIncludeLine === -1 || closestCandidate === null) return null;

--- a/src/providers/validationProvider.ts
+++ b/src/providers/validationProvider.ts
@@ -25,6 +25,7 @@ import {
     isLocalInclude,
     includeKeyAndUrl,
     includeLineMatches,
+    findIncludeLine,
 } from '../utils/includeMatcher';
 
 export class ValidationProvider implements vscode.CodeActionProvider {
@@ -1031,15 +1032,10 @@ export class ValidationProvider implements vscode.CodeActionProvider {
         this.logger.debug(`[ValidationProvider] Looking for include URL: ${url} (occurrence ${targetOccurrence})`, 'ValidationProvider');
 
         const lines = document.getText().split('\n');
-        let seen = 0;
-        for (let i = 0; i < lines.length; i++) {
-            if (includeLineMatches(lines[i], key, url)) {
-                seen++;
-                if (seen === targetOccurrence) {
-                    this.logger.debug(`[ValidationProvider] Found include at line ${i}: ${lines[i].trim()}`, 'ValidationProvider');
-                    return i;
-                }
-            }
+        const line = findIncludeLine(lines, key, url, targetOccurrence);
+        if (line !== -1) {
+            this.logger.debug(`[ValidationProvider] Found include at line ${line}: ${lines[line].trim()}`, 'ValidationProvider');
+            return line;
         }
         this.logger.debug(`[ValidationProvider] Include URL not found, returning 0`, 'ValidationProvider');
         return 0;

--- a/src/utils/includeMatcher.ts
+++ b/src/utils/includeMatcher.ts
@@ -94,3 +94,33 @@ export function includeLineMatches(line: string, key: string, url: string): bool
     }
     return false;
 }
+
+/**
+ * The document line where the include identified by `key`+`url` makes its `occurrence`-th appearance.
+ *
+ * Two include entries can share an identical key+URL (e.g. the same component included twice with different inputs).
+ * Matching on key+URL alone returns the first occurrence for every duplicate, collapsing them onto one line. Callers
+ * that hold includes in document order pass the 1-based ordinal of the entry among its identical siblings, and this
+ * returns the correspondingly-numbered matching line. Matching uses {@link includeLineMatches}, so a versioned URL
+ * matches only at a token boundary, not as a prefix of a longer sibling.
+ *
+ * @param lines      The document split into lines (no trailing newlines).
+ * @param key        The include key token to require — `'component:'` or `'local:'`, as returned by
+ *                   {@link includeKeyAndUrl}.
+ * @param url        The remote URL or local path that must appear on the line, terminated at a token boundary.
+ * @param occurrence The 1-based ordinal among identical key+URL includes — the 1st, 2nd, … such entry in document
+ *                   order. Defaults to `1` (the first match) for callers with no duplicates to disambiguate.
+ * @returns The 0-based line index of the `occurrence`-th match, or `-1` when fewer than `occurrence` lines match.
+ */
+export function findIncludeLine(lines: string[], key: string, url: string, occurrence = 1): number {
+    let seen = 0;
+    for (let i = 0; i < lines.length; i++) {
+        if (includeLineMatches(lines[i], key, url)) {
+            seen++;
+            if (seen === occurrence) {
+                return i;
+            }
+        }
+    }
+    return -1;
+}

--- a/tests/extension-host/suite/duplicateIncludeCompletion.test.ts
+++ b/tests/extension-host/suite/duplicateIncludeCompletion.test.ts
@@ -1,0 +1,64 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+const EXTENSION_ID = 'eFAILution.gitlab-component-helper';
+
+// __dirname is <repo>/out-test/suite at runtime; fixtures live under tests/fixtures.
+const FIXTURE_DIR = path.resolve(__dirname, '..', '..', 'tests', 'fixtures', 'duplicate-include-completion');
+const FIXTURE = path.join(FIXTURE_DIR, '.gitlab-ci.yml');
+
+async function ensureActive(): Promise<void> {
+  const ext = vscode.extensions.getExtension(EXTENSION_ID);
+  assert.ok(ext);
+  if (!ext.isActive) await ext.activate();
+}
+
+/**
+ * The input-name completion slot under the second include: the blank, six-space-indented line directly after the
+ * second include's `region: eu-west-2`. Derived from the document so the position survives fixture edits.
+ */
+function secondIncludeSlot(doc: vscode.TextDocument): vscode.Position {
+  const lines = doc.getText().split('\n');
+  let seen = 0;
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].includes('region: eu-west-2')) {
+      seen++;
+      if (seen === 1) {
+        const slotLine = i + 1;
+        assert.ok(lines[slotLine] !== undefined, 'fixture missing the blank slot line after the second include');
+        return new vscode.Position(slotLine, 6); // align with the existing input keys
+      }
+    }
+  }
+  throw new Error('fixture missing the second include`s region: eu-west-2 input');
+}
+
+// The fixture includes the same local template twice. The duplicate-include fix made the completion provider
+// anchor each include to its own occurrence's line; before it, the second include's inputs slot resolved to the
+// first include and offered nothing. This drives the real CompletionProvider end-to-end.
+suite('Duplicate include input completions', () => {
+  suiteSetup(ensureActive);
+
+  test('offers input completions in the second identical include`s slot', async () => {
+    const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(FIXTURE));
+    await vscode.window.showTextDocument(doc);
+    const slot = secondIncludeSlot(doc);
+
+    const list = await vscode.commands.executeCommand<vscode.CompletionList>(
+      'vscode.executeCompletionItemProvider',
+      doc.uri,
+      slot
+    );
+    const labels = (list?.items ?? []).map((i) => (typeof i.label === 'string' ? i.label : i.label.label));
+
+    // The template's inputs are job_name, cluster, region. `region` is already set under the second include,
+    // so it must be filtered out; the other two must be offered.
+    assert.ok(labels.includes('job_name'), `expected job_name to be offered. Got: ${JSON.stringify(labels)}`);
+    assert.ok(labels.includes('cluster'), `expected cluster to be offered. Got: ${JSON.stringify(labels)}`);
+    assert.ok(
+      !labels.includes('region'),
+      `region is already present under the second include and must be filtered out. Got: ${JSON.stringify(labels)}`
+    );
+  });
+});

--- a/tests/fixtures/duplicate-include-completion/.gitlab-ci.yml
+++ b/tests/fixtures/duplicate-include-completion/.gitlab-ci.yml
@@ -1,0 +1,16 @@
+include:
+  # First include of the deploy template — fully populated.
+  - local: "duplicate-include-completion/templates/deploy.yml"
+    inputs:
+      job_name: deploy:first
+      cluster: first-cluster
+      region: eu-west-1
+
+  # Second include of the SAME template. `region` is already set; the blank,
+  # six-space-indented slot below is where input-name completions must fire.
+  # Before the duplicate-include fix this slot resolved to the first include
+  # and returned nothing.
+  - local: "duplicate-include-completion/templates/deploy.yml"
+    inputs:
+      region: eu-west-2
+      

--- a/tests/fixtures/duplicate-include-completion/templates/deploy.yml
+++ b/tests/fixtures/duplicate-include-completion/templates/deploy.yml
@@ -1,0 +1,16 @@
+spec:
+  inputs:
+    job_name:
+      description: The name of the CI job
+      type: string
+    cluster:
+      description: The target cluster (no default — required)
+      type: string
+    region:
+      description: The deployment region
+      type: string
+      default: eu-west-1
+---
+$[[ inputs.job_name ]]:
+  script:
+    - echo "deploying to $[[ inputs.cluster ]] in $[[ inputs.region ]]"

--- a/tests/unit/completionInputContext.test.ts
+++ b/tests/unit/completionInputContext.test.ts
@@ -194,6 +194,23 @@ stages:
     });
   });
 
+  test('scopes to the second of two identical include', () => {
+    const text = `include:
+  - component: ${FULL_PIPELINE_URL}
+    inputs:
+      environment: "dev"
+  - component: ${FULL_PIPELINE_URL}
+    inputs:
+      stage: build
+      `;
+    const ctx = findCompletionInputContextAtLine(text, 7); // slot under the second (duplicate) include
+    assert.deepStrictEqual(ctx, {
+      componentUrl: FULL_PIPELINE_URL,
+      includeKind: 'component',
+      existingInputNames: ['stage'],
+    });
+  });
+
   test('detects a slot under a `- local:` include and reports includeKind = local', () => {
     const text = `include:
   - local: /templates/nx-test.yml

--- a/tests/unit/hoverInputContext.test.ts
+++ b/tests/unit/hoverInputContext.test.ts
@@ -80,6 +80,22 @@ stages:
     });
   });
 
+  test('resolves an input under the second of two identical includes', () => {
+    const text = `include:
+  - component: ${FULL_PIPELINE_URL}
+    inputs:
+      environment: "dev"
+  - component: ${FULL_PIPELINE_URL}
+    inputs:
+      stage: build`;
+    const ctx = findInputContextAtLine(text, 6); // `stage:` under the second include
+    assert.deepStrictEqual(ctx, {
+      inputName: 'stage',
+      componentUrl: FULL_PIPELINE_URL,
+      includeKind: 'component',
+    });
+  });
+
   test('returns null when the line is in a sibling `variables:` block, not `inputs:`', () => {
     const text = `include:
   - component: https://gitlab.com/components/test@1.0.0

--- a/tests/unit/includeMatcher.test.ts
+++ b/tests/unit/includeMatcher.test.ts
@@ -14,6 +14,7 @@ import {
     isLocalInclude,
     includeKeyAndUrl,
     includeLineMatches,
+    findIncludeLine,
 } from '../../src/utils/includeMatcher';
 
 suite('includeMatcher — isIncludeEntry', () => {
@@ -94,5 +95,37 @@ suite('includeMatcher — includeLineMatches token boundary', () => {
         const localUrl = 'templates/deploy';
         assert.equal(includeLineMatches('  - local: templates/deploy10', 'local:', localUrl), false);
         assert.equal(includeLineMatches('  - local: templates/deploy', 'local:', localUrl), true);
+    });
+});
+
+suite('includeMatcher — findIncludeLine occurrence disambiguation', () => {
+    const url = 'host/g/c@1';
+    const lines = [
+        'include:',
+        `  - component: ${url}`,
+        '    inputs:',
+        '      a: 1',
+        `  - component: ${url}`,
+        '    inputs:',
+        '      b: 2',
+    ];
+
+    test('defaults to the first occurrence', () => {
+        assert.equal(findIncludeLine(lines, 'component:', url), 1);
+    });
+
+    test('returns the Nth occurrence for duplicate key+URL includes', () => {
+        assert.equal(findIncludeLine(lines, 'component:', url, 1), 1);
+        assert.equal(findIncludeLine(lines, 'component:', url, 2), 4);
+    });
+
+    test('returns -1 when fewer than `occurrence` lines match', () => {
+        assert.equal(findIncludeLine(lines, 'component:', url, 3), -1);
+        assert.equal(findIncludeLine(lines, 'component:', 'host/g/absent@1'), -1);
+    });
+
+    test('honours the token boundary, not a prefix match', () => {
+        const collide = ['  - component: host/g/c@10', '  - component: host/g/c@1'];
+        assert.equal(findIncludeLine(collide, 'component:', 'host/g/c@1', 1), 1);
     });
 });


### PR DESCRIPTION
## Summary
- Fixes input-name completions not appearing under the **second** (and later) of two identical component/`local:` includes. The completion provider matched a parsed include back to its document line by substring-searching for the include key + URL and taking the **first** match, so every duplicate resolved to the first occurrence's line and the second include's `inputs:` block was never recognised as a completion context.
- Extracts the occurrence-aware line lookup the validation provider already used inline into a shared, `vscode`-free `findIncludeLine(lines, key, url, occurrence)` helper in [includeMatcher.ts](../src/utils/includeMatcher.ts). It returns the **Nth** matching line, where the match uses the existing token-boundary `includeLineMatches` (so `…@deploy-1` can't match a longer `…@deploy-10` sibling).
- Both the completion and hover input-context finders now compute each include's occurrence ordinal from its position in the parsed `include` array (built in document order) and anchor to that occurrence's line via the shared helper.
- Link related issue(s): Fixes #206

## Change Type
- [ ] feat
- [x] fix
- [x] refactor (extract `findIncludeLine`; validation provider now reuses it)
- [ ] docs
- [ ] test

## Context
### User-facing impact
- The second of two identical includes now offers input-name completions, filtered against the inputs already present under that specific include. Hover anchoring of a duplicated include's input line is corrected to the right occurrence (not observable through hover output today, since both duplicates share a URL, but it removes the latent mismatch).

### GitLab scope
- [ ] gitlab.com
- [ ] self-managed GitLab
- [x] both (document line-anchoring only; no GitLab interaction)

### Affected areas
- [ ] Component Browser
- [x] Hover provider
- [x] Completion provider
- [x] Validation provider (refactor to shared helper; behavior unchanged)
- [ ] Cache and refresh behavior
- [ ] GitLab API calls/auth/token storage
- [ ] Docs only

## What changed by bucket

| Bucket | Files | Approach |
|---|---|---|
| Shared line lookup | [includeMatcher.ts](../src/utils/includeMatcher.ts) | New `findIncludeLine(lines, key, url, occurrence = 1)` returns the 0-based line of the `occurrence`-th key+URL match (via the existing token-boundary `includeLineMatches`), or `-1`. Encapsulates the occurrence-counting walk that previously lived inline in the validation provider. |
| Completion input context | [completionInputContext.ts](../src/providers/completionInputContext.ts) | `findClosestInclude` walks the parsed `include` array (document order), tracking how many earlier entries share each key+URL, and anchors each entry to that occurrence's line via `findIncludeLine` instead of a first-match `break`. Also replaces the naive `lines[i].includes(url)` (prefix-matching) with the token-boundary match. |
| Hover input context | [hoverInputContext.ts](../src/providers/hoverInputContext.ts) | Same occurrence-ordinal approach for the closest-include walk; removes the per-candidate first-match `break` that ignored later occurrences. |
| Validation provider | [validationProvider.ts](../src/providers/validationProvider.ts) | `findLineForComponent` now delegates its document walk to `findIncludeLine` (same occurrence ordinal, same logging), removing the duplicated inline loop. No behavior change. |
| Regression tests | [includeMatcher.test.ts](../tests/unit/includeMatcher.test.ts), [completionInputContext.test.ts](../tests/unit/completionInputContext.test.ts), [hoverInputContext.test.ts](../tests/unit/hoverInputContext.test.ts), [duplicateIncludeCompletion.test.ts](../tests/extension-host/suite/duplicateIncludeCompletion.test.ts), [tests/fixtures/duplicate-include-completion/](../tests/fixtures/duplicate-include-completion/) | **Unit:** `findIncludeLine` occurrence disambiguation incl. token boundary and `-1` underflow; a duplicate-include completion test (verified load-bearing — fails when the source fix is removed) and a duplicate-include hover test. **Extension-host:** drives the real `CompletionProvider` through `vscode.executeCompletionItemProvider` at the second of two identical `local:` includes — asserts the template's inputs are offered, minus the one already present under that second include (`region`). Uses a dedicated fixture (the second include's input slot must carry literal indent whitespace, else the cursor resolves to column 0 and falls through to variable completions). Verified load-bearing — fails when the completion source fix is removed. |

## Breaking Changes
- [x] No breaking changes
- [ ] Breaking changes (describe below)
