### PR TITLE
fix(spec-parser): recognise hyphenated input names (#211)

### DIFF
--- a/src/parsers/specParser.ts
+++ b/src/parsers/specParser.ts
@@ -157,9 +157,12 @@ export class GitLabSpecParser {
         break;
       }
 
-      // New input parameter (indented under inputs) - handle both 2-space and 4-space indentation
-      // Match lines like "    name:" where the input name ends with ":" and has only whitespace after
-      if (line.match(/^\s{2,4}[a-zA-Z_][a-zA-Z0-9_]*:\s*$/)) {
+      // New input parameter (indented under inputs) - handle both 2-space and 4-space indentation.
+      // Match lines like "    name:" where the input name ends with ":" and has only whitespace after.
+      // The name class includes `-`: GitLab input names are commonly hyphenated (e.g. `job-name`). Without
+      // it, a hyphenated key isn't recognised as a new input, so its `description:`/`default:` lines bleed
+      // onto the previous (non-hyphenated) input and mis-map every field after it (issue #211).
+      if (line.match(/^\s{2,4}[a-zA-Z_][a-zA-Z0-9_-]*:\s*$/)) {
         // If we have a current input, finalize it before starting a new one
         if (currentInput) {
           // Mark as required if no default was specified (GitLab CI/CD component behavior)

--- a/tests/unit/GitLabSpecParser.test.ts
+++ b/tests/unit/GitLabSpecParser.test.ts
@@ -59,6 +59,60 @@ deploy-job:
     }
   });
 
+  test('maps hyphenated input names correctly across comments and blank lines (issue #211)', () => {
+    // Hyphenated keys (e.g. `job-name`) weren't recognised as new inputs, so their description/default
+    // bled onto the previous non-hyphenated input — `architecture` would show a later input's description.
+    // Comment and blank lines within the inputs block must not shift the mapping either.
+    const template = `spec:
+  inputs:
+    job-name:
+      description: The job name
+      default: build
+    # ── package metadata ──────────────
+    package-name:
+      description: The package name
+
+    package-version:
+      description: The version to stamp
+      default: 0.0.1
+
+    # ── build options ─────────────────
+    architecture:
+      description: Target CPU architecture
+      default: amd64
+    skip-find-images:
+      description: Skip image discovery
+      default: false
+---
+$[[ inputs.job-name ]]:
+  script: echo build`;
+
+    const parsed = GitLabSpecParser.parse(template);
+    const byName = Object.fromEntries(parsed.variables.map((v) => [v.name, v]));
+
+    // All five inputs are recognised — the hyphenated ones were previously skipped entirely.
+    assert.deepStrictEqual(parsed.variables.map((v) => v.name), [
+      'job-name',
+      'package-name',
+      'package-version',
+      'architecture',
+      'skip-find-images',
+    ]);
+
+    // Each input keeps its OWN description/default — no bleed across the comment/blank boundaries.
+    assert.strictEqual(byName['job-name'].description, 'The job name');
+    assert.strictEqual(byName['job-name'].default, 'build');
+    assert.strictEqual(byName['package-version'].description, 'The version to stamp');
+    assert.strictEqual(byName['package-version'].default, '0.0.1');
+    assert.strictEqual(byName['architecture'].description, 'Target CPU architecture');
+    assert.strictEqual(byName['architecture'].default, 'amd64');
+    assert.strictEqual(byName['skip-find-images'].description, 'Skip image discovery');
+
+    // A hyphenated input with no default is marked required, same as a non-hyphenated one.
+    assert.strictEqual(byName['package-name'].default, undefined);
+    assert.strictEqual(byName['package-name'].required, true);
+  });
+
   test('component without --- separator (legacy format) still scopes inputs to the spec section', () => {
     const template = `spec:
   inputs:


### PR DESCRIPTION
## Summary
Fixes #211 — component input parameters were mis-mapped when the `spec.inputs` block uses **hyphenated** names (common in practice: `job-name`, `skip-find-images`, `oci-registry-password`, …).

## Cause
`GitLabSpecParser.parseInputsSection` detects a new input key with `^\s{2,4}[a-zA-Z_][a-zA-Z0-9_]*:\s*$` — which excludes `-`. A hyphenated key wasn't recognised as a new input, so its `description:`/`default:` lines bled onto the previous *non-hyphenated* input, shifting every field after it (hence `architecture` showed `skip-find-images`' description, and `publish` showed `oci-registry-password`'). The hyphenated inputs themselves were dropped. (The top-level-key regex one line above already allowed `-`; the input-key regex just missed it.)

Note: comments and blank lines were **not** the cause despite the issue title — they're already filtered before iteration. The real trigger was the hyphenated names in that spec.

## Fix
Add `-` to the input-name character class. Plus a regression test with hyphenated names interspersed with comment and blank lines, asserting each input keeps its own `description`/`default` and that a hyphenated input with no default is still marked required.

## Validation
- [x] `npm run lint`, `npm run compile`, `npm test` — **306 passing** (+1 new)

## Follow-up (out of scope)
`parseInputsSection` is hand-rolled line iteration; a js-yaml-based rewrite would be more robust for multiline values, quoting, and nesting. Noted for later, not attempted here.

Fixes #211