### PR TITLE
chore(deps): hold conventionalcommits at v9 via dependabot ignore

### DIFF
--- a/.ai/errors.yaml
+++ b/.ai/errors.yaml
@@ -349,6 +349,31 @@ errors:
       types: chore, docs, style don't trigger version bump
     - check: GitHub Actions secrets
       required: GITHUB_TOKEN (automatic) or GH_TOKEN
+  empty_changelog_conventionalcommits_v10:
+    symptoms:
+    - Release changelog renders empty (version header only, no sections/entries)
+    - Dependabot repeatedly proposes conventional-changelog-conventionalcommits v10
+    causes:
+    - cause: >-
+        conventional-changelog-conventionalcommits v10 replaced Handlebars
+        template strings with render functions (@conventional-changelog/template)
+        that require conventional-changelog-writer@9. The release toolchain pins
+        the older Handlebars writer transitively via
+        @release-it/conventional-changelog@11 (conventional-changelog@7 ->
+        writer@8) and expects the conventionalcommits family at ^9.3.1. writer@8
+        handed v10 render functions compiles to nothing.
+      solution:
+        note: >-
+          This repo uses the angular preset (.release-it.json), and the top-level
+          conventional-changelog-conventionalcommits dep is dev-only and unused by
+          the changelog path, so it is not directly affected today. It is held at
+          v9 to honor the org-wide lesson and guard against a future preset switch.
+        steps:
+        - Keep conventional-changelog-conventionalcommits at ^9.3.1 in package.json
+        - Dependabot ignores its version-update:semver-major (.github/dependabot.yml)
+        - Re-enable v10 once @release-it/conventional-changelog adopts the render-function stack (conventional-changelog@8 / writer@9)
+        reference: .github/dependabot.yml + package.json; see huntridge-labs/argus#318
+    symptom: empty changelog|release preview shows only version header|no sections|dependabot re-proposes conventionalcommits v10
 debugging:
   enable_debug_logs:
     steps:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,10 +43,26 @@ updates:
     # fails when @types/vscode > engines.vscode. Allow only patch bumps (which stay
     # within the floor); a minor/major bump must be a deliberate engines.vscode raise,
     # not an automatic dependency update. This stops the bump, not any security alert.
+    # Hold conventional-changelog-conventionalcommits at v9.x. v10 replaced
+    # Handlebars template strings with render functions (@conventional-changelog/
+    # template) that require conventional-changelog-writer@9. Our release
+    # toolchain pins the older Handlebars writer transitively via
+    # @release-it/conventional-changelog@11 (conventional-changelog@7 -> writer@8)
+    # and expects the conventionalcommits family at ^9.3.1. In the Argus repo,
+    # whose release preset IS conventionalcommits, the v10 bump rendered an EMPTY
+    # changelog (see huntridge-labs/argus#318). This repo currently uses the
+    # angular preset, so it is not directly affected today, but the top-level dep
+    # is dev-only and unused by our changelog path, so a major bump has no upside
+    # and would become a latent footgun if the preset ever switched. Re-enable
+    # once @release-it/conventional-changelog ships the render-function stack
+    # (conventional-changelog@8 / writer@9).
     ignore:
       - dependency-name: "@types/vscode"
         update-types:
           - "version-update:semver-minor"
+          - "version-update:semver-major"
+      - dependency-name: "conventional-changelog-conventionalcommits"
+        update-types:
           - "version-update:semver-major"
 
   # Maintain GitHub Actions


### PR DESCRIPTION
## Description
Stops Dependabot from re-proposing the `conventional-changelog-conventionalcommits` v10 major bump (#216) and documents why.

## Background
In Argus (`huntridge-labs/argus#318`), the v10 bump broke changelog generation — the release preview rendered an **empty** changelog. Root cause: v10 replaced Handlebars template *strings* with render *functions* (`@conventional-changelog/template`, requiring `conventional-changelog-writer@9`), but our release toolchain pins the older Handlebars writer transitively via `@release-it/conventional-changelog@11` (`conventional-changelog@7` → `writer@8`) and expects the conventionalcommits family at `^9.3.1`.

## Why hold it here
This repo's `.release-it.json` uses the **angular** preset, and the top-level `conventional-changelog-conventionalcommits` dep is **dev-only and unused by our changelog path** (commitlint's `@commitlint/config-conventional` carries its own nested copy at 9.3.1). So we are **not** directly affected today — but a major bump of an unused dev dep has no upside and would become a latent footgun if the preset ever switched to conventionalcommits. `package.json` already pins `^9.3.1` (the caret blocks v10); Dependabot only proposed v10 by rewriting the constraint, which this ignore rule prevents.

## Changes
- `.github/dependabot.yml` — ignore `version-update:semver-major` for `conventional-changelog-conventionalcommits` (npm), with an explanatory comment.
- `.ai/errors.yaml` — record the incompatibility, accurate root cause, and the fix.

## Testing
- YAML lint/parse of both edited files passes.
- No runtime/dependency resolution change (config + docs only).

Re-enable the major bump once `@release-it/conventional-changelog` adopts the render-function stack (`conventional-changelog@8` / `writer@9`).