### PR TITLE
ci(pre-commit): stop linting and auto-fixing test fixtures

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,9 +9,11 @@ repos:
     rev: v6.0.0
     hooks:
       - id: trailing-whitespace
-        exclude: ^(docs)
+        # tests/fixtures/** are intentionally-crafted parser inputs (trailing
+        # whitespace / blank lines are part of the test scenario) — never rewrite them.
+        exclude: ^(docs|tests/fixtures)
       - id: end-of-file-fixer
-        exclude: ^(docs)
+        exclude: ^(docs|tests/fixtures)
       - id: check-ast
         exclude: ^(docs)
       # - id: check-yaml
@@ -24,7 +26,7 @@ repos:
       - id: detect-private-key
       - id: mixed-line-ending
         args: ["--fix=lf"]
-        exclude: \.md$
+        exclude: (\.md$|^tests/fixtures/)
       # - id: no-commit-to-branch
       #   args: [--branch, main]
       - id: pretty-format-json

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -9,6 +9,12 @@ yaml-files:
   - ".yamllint"
 
 ignore:
+  # Test fixtures are intentionally-crafted GitLab CI parser inputs: flow-style
+  # braces ({ job_name: deploy }), empty values (region:), trailing whitespace
+  # and blank lines are the exact conditions the parser/completion tests exist to
+  # exercise. They represent arbitrary user files, so they must not be
+  # style-linted — the mocha suite validates their behaviour instead.
+  - "tests/fixtures/**"
   - "node_modules/**"
   - ".git/**"
   - ".github/**"

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -3,8 +3,20 @@
   "compilerOptions": {
     "noEmit": true,
     "rootDir": ".",
-    "types": ["node", "mocha"]
+    "types": [
+      "node",
+      "mocha"
+    ]
   },
-  "include": ["src/**/*", "tests/unit/**/*.ts"],
-  "exclude": ["node_modules", ".vscode-test", "out", "out-test", "tests/extension-host"]
+  "include": [
+    "src/**/*",
+    "tests/unit/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    ".vscode-test",
+    "out",
+    "out-test",
+    "tests/extension-host"
+  ]
 }


### PR DESCRIPTION
## Description
Makes the local pre-commit suite pass again. It was failing on files under `tests/fixtures/` — which are **intentionally-crafted GitLab CI parser inputs**, not project source.

## Root cause
`tests/fixtures/**` deliberately contains messy YAML the parser/completion tests must handle:
- flow-style inputs — `inputs: { job_name: deploy }` (`flow-inputs`), `a_input: { type: string }` (`revalidate-on-edit`) → yamllint `braces`
- empty values + trailing whitespace — `region: ` with a trailing blank line (`enum-options`) → yamllint `empty-values`, and the `trailing-whitespace`/`end-of-file-fixer` hooks **rewrote** those fixtures on every commit, corrupting the test inputs.

A brace-only relaxation wasn't enough: the file-mutating hooks corrupt fixtures regardless of yamllint, and `empty-values` also fired. The coherent fix is to stop linting/auto-fixing fixtures entirely — the mocha suite validates their behaviour.

## Changes
- `.yamllint.yml` — ignore `tests/fixtures/**` (`braces` stays at default `enable`).
- `.pre-commit-config.yaml` — exclude `tests/fixtures/` from `trailing-whitespace`, `end-of-file-fixer`, `mixed-line-ending`.
- `tsconfig.tests.json` — conform to the repo's `pretty-format-json` hook (a real file that had drifted; unrelated to fixtures but was also blocking every commit).

## Testing
- `pre-commit run --all-files` → all hooks pass.
- Commit succeeds through the husky `prepare-commit-msg` hook with no bypass.
- `npm test` → **306 passing**; fixtures are byte-for-byte unchanged.

## Note
yamllint / pre-commit run **only** in the local git hook — they are not GitHub Actions CI checks — so this doesn't change any CI gate. The mocha tests that consume these fixtures were already green in CI. Targeting `beta` per the repo's beta→main integration flow.