### PR TITLE
feat(httpClient): follow GitLab redirects safely (same-origin only, strip credentials cross-origin)

### DIFF
--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -42,6 +42,8 @@ export const HTTP_STATUS_SERVER_ERROR_MIN = 500 as const;
 // HTTP Headers
 export const HEADER_USER_AGENT = 'User-Agent' as const;
 export const HEADER_PRIVATE_TOKEN = 'PRIVATE-TOKEN' as const;
+export const HEADER_AUTHORIZATION = 'Authorization' as const;
+export const HEADER_COOKIE = 'Cookie' as const;
 export const USER_AGENT_VALUE = 'VSCode-GitLabComponentHelper' as const;
 
 // Documentation URLs

--- a/src/constants/timing.ts
+++ b/src/constants/timing.ts
@@ -26,6 +26,10 @@ export const API_PER_PAGE_LIMIT = 100 as const;
 /** Runaway-loop backstop for paginated fetches: 50 pages × 100/page = up to 5,000 items. */
 export const MAX_PAGINATION_PAGES = 50 as const;
 
+// HTTP Redirects
+/** Backstop for redirect following: refuse to chase more than this many `Location` hops. */
+export const MAX_REDIRECTS = 5 as const;
+
 // Batch Processing
 export const DEFAULT_BATCH_SIZE = 5 as const;
 

--- a/src/utils/httpClient.ts
+++ b/src/utils/httpClient.ts
@@ -5,7 +5,8 @@ import { Logger } from './logger';
 import { getRequestDeduplicator, RequestDeduplicator } from './requestDeduplicator';
 import { getPerformanceMonitor } from './performanceMonitor';
 import { NetworkError, getErrorHandler, extractStatusCode } from '../errors';
-import { API_PER_PAGE_LIMIT, MAX_PAGINATION_PAGES } from '../constants/timing';
+import { API_PER_PAGE_LIMIT, MAX_PAGINATION_PAGES, MAX_REDIRECTS } from '../constants/timing';
+import { planRedirect, stripCredentialHeaders } from './redirectPolicy';
 
 interface RequestOptions {
   timeout?: number;
@@ -224,13 +225,20 @@ export class HttpClient {
    * `makeRequest` discards headers; this sibling preserves them so callers that need pagination metadata (GitLab's
    * `x-next-page` / `x-total-pages`) can read it. Header names are lower-cased by Node's HTTP layer.
    *
+   * Redirects are followed under the credential-safe policy in {@link planRedirect}: same-origin hops keep the
+   * request headers, cross-origin hops drop the `Authorization`/`PRIVATE-TOKEN`/`Cookie` headers first (so a moved
+   * project whose old path was reclaimed can't harvest the user's token), HTTPS→HTTP downgrades are refused, and the
+   * chain is capped at `redirectsRemaining` hops.
+   *
    * @param url The fully-qualified request URL.
    * @param options Request timeout (ms) and headers to send.
+   * @param redirectsRemaining Remaining redirect hops before the chain is rejected (defaults to {@link MAX_REDIRECTS}).
    * @returns The response body string and a lower-cased header map.
    */
   private makeRequestWithHeaders(
     url: string,
-    options: { timeout: number; headers: Record<string, string> }
+    options: { timeout: number; headers: Record<string, string> },
+    redirectsRemaining: number = MAX_REDIRECTS
   ): Promise<{ body: string; headers: Record<string, string> }> {
     return new Promise((resolve, reject) => {
       try {
@@ -248,6 +256,36 @@ export class HttpClient {
         };
 
         const req = client.request(requestOptions, (res) => {
+          const statusCode = res.statusCode ?? 0;
+
+          // Resolve redirects before reading the body. `planRedirect` enforces the credential-safe,
+          // same-origin-preferring policy; a malformed redirect or a refused HTTPS→HTTP downgrade throws.
+          let redirect;
+          try {
+            redirect = planRedirect(url, statusCode, res.headers.location);
+          } catch (policyError) {
+            res.resume(); // drain so the socket can be released
+            reject(policyError);
+            return;
+          }
+
+          if (redirect) {
+            res.resume(); // discard the redirect response body
+            if (redirectsRemaining <= 0) {
+              reject(new NetworkError(`Too many redirects while fetching ${url}`, { statusCode }));
+              return;
+            }
+            const nextHeaders = redirect.stripCredentials
+              ? stripCredentialHeaders(options.headers)
+              : options.headers;
+            this.makeRequestWithHeaders(
+              redirect.nextUrl,
+              { timeout: options.timeout, headers: nextHeaders },
+              redirectsRemaining - 1
+            ).then(resolve, reject);
+            return;
+          }
+
           let data = '';
 
           res.on('data', (chunk) => {
@@ -255,7 +293,7 @@ export class HttpClient {
           });
 
           res.on('end', () => {
-            if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
+            if (statusCode >= 200 && statusCode < 300) {
               const headers: Record<string, string> = {};
               for (const [key, value] of Object.entries(res.headers)) {
                 if (typeof value === 'string') {
@@ -266,8 +304,8 @@ export class HttpClient {
               }
               resolve({ body: data, headers });
             } else {
-              const message = `HTTP ${res.statusCode}: ${data.substring(0, 200)}`;
-              reject(new NetworkError(message, { statusCode: res.statusCode }));
+              const message = `HTTP ${statusCode}: ${data.substring(0, 200)}`;
+              reject(new NetworkError(message, { statusCode }));
             }
           });
         });

--- a/src/utils/redirectPolicy.ts
+++ b/src/utils/redirectPolicy.ts
@@ -1,0 +1,93 @@
+// Import from the pure `errors/types` module, not the `../errors` barrel: the barrel re-exports
+// `handler.ts`, which imports `vscode` and is therefore unloadable in the pure-Node unit-test context.
+import { NetworkError } from '../errors/types';
+import { HEADER_AUTHORIZATION, HEADER_PRIVATE_TOKEN, HEADER_COOKIE } from '../constants/api';
+
+/**
+ * HTTP status codes that represent a followable redirect. 304 (Not Modified) is deliberately excluded:
+ * it is a 3xx response but not a redirect, and this client never sends conditional requests.
+ */
+export const REDIRECT_STATUS_CODES: ReadonlySet<number> = new Set([301, 302, 303, 307, 308]);
+
+/**
+ * Outgoing request headers that carry credentials and must never be replayed to a different origin.
+ * Stored lower-cased and compared case-insensitively against header names.
+ */
+export const SENSITIVE_HEADERS: readonly string[] = [
+  HEADER_AUTHORIZATION.toLowerCase(),
+  HEADER_PRIVATE_TOKEN.toLowerCase(),
+  HEADER_COOKIE.toLowerCase(),
+];
+
+/** The decision produced by {@link planRedirect}: where to go next and whether credentials survive the hop. */
+export interface RedirectPlan {
+  /** Absolute URL to request next. */
+  nextUrl: string;
+  /** True when the redirect crosses origin, so credential headers must be dropped before following. */
+  stripCredentials: boolean;
+}
+
+/**
+ * Return a copy of `headers` with every credential-bearing header removed. Names are matched
+ * case-insensitively, so a caller's `PRIVATE-TOKEN` and a server-echoed `private-token` are both dropped.
+ *
+ * @param headers The outgoing header map to sanitise.
+ * @returns A new map containing only the non-credential headers.
+ */
+export function stripCredentialHeaders(headers: Record<string, string>): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(headers).filter(([name]) => !SENSITIVE_HEADERS.includes(name.toLowerCase()))
+  );
+}
+
+/**
+ * Decide whether and how to follow an HTTP redirect under a credential-safe, same-origin-preferring policy.
+ *
+ * Policy:
+ *  - Only 301/302/303/307/308 carrying a `Location` are followed; any other status (including the
+ *    non-redirect 304) returns `null` so the caller handles the response normally.
+ *  - A redirect status with a missing/empty `Location` is a malformed response and throws.
+ *  - Downgrading the transport from HTTPS to HTTP is refused (throws): an attacker able to force a
+ *    downgrade could strip TLS, so we fail closed rather than replay the request in the clear.
+ *  - A cross-origin target is permitted but flagged `stripCredentials: true`, so the caller drops the
+ *    `Authorization`/`PRIVATE-TOKEN`/`Cookie` headers before following. This prevents a malicious or
+ *    compromised host from harvesting the user's GitLab token via an attacker-controlled `Location`.
+ *
+ * @param currentUrl  The URL that produced this redirect response.
+ * @param statusCode  The redirect response's status code.
+ * @param location    The raw `Location` header, absolute or relative to `currentUrl` (Node lower-cases the name).
+ * @returns A {@link RedirectPlan}, or `null` when the response is not a followable redirect.
+ * @throws NetworkError on a malformed redirect (no `Location`) or a refused HTTPS→HTTP downgrade.
+ */
+export function planRedirect(
+  currentUrl: string,
+  statusCode: number,
+  location: string | undefined
+): RedirectPlan | null {
+  if (!REDIRECT_STATUS_CODES.has(statusCode)) {
+    return null;
+  }
+
+  if (!location || location.trim() === '') {
+    throw new NetworkError(
+      `Redirect (HTTP ${statusCode}) from ${currentUrl} is missing a Location header`,
+      { statusCode }
+    );
+  }
+
+  const current = new URL(currentUrl);
+  // Resolves an absolute Location as-is and a relative Location against the current URL.
+  const next = new URL(location, current);
+
+  if (current.protocol === 'https:' && next.protocol === 'http:') {
+    throw new NetworkError(
+      `Refusing to follow HTTPS→HTTP redirect from ${currentUrl} to ${next.toString()}`,
+      { statusCode }
+    );
+  }
+
+  return {
+    nextUrl: next.toString(),
+    stripCredentials: next.origin !== current.origin,
+  };
+}

--- a/tests/unit/redirectPolicy.test.ts
+++ b/tests/unit/redirectPolicy.test.ts
@@ -1,0 +1,124 @@
+// @mocha
+/**
+ * Tests for the credential-safe redirect policy the HTTP client applies before following a `Location`.
+ * The security-critical guarantees are: the user's GitLab token (`PRIVATE-TOKEN`/`Authorization`) is never
+ * replayed to a different origin, HTTPS is never silently downgraded to HTTP, and only genuine redirect
+ * statuses are followed. These protect against token exfiltration when a moved component project's old
+ * path is reclaimed by a third party.
+ */
+
+import * as assert from 'node:assert/strict';
+import { NetworkError } from '../../src/errors/types';
+import {
+  planRedirect,
+  stripCredentialHeaders,
+  REDIRECT_STATUS_CODES,
+} from '../../src/utils/redirectPolicy';
+
+const BASE = 'https://gitlab.com/api/v4/projects/foo%2Fbar';
+
+suite('planRedirect: non-redirect responses', () => {
+  test('returns null for a 2xx status', () => {
+    assert.equal(planRedirect(BASE, 200, undefined), null);
+  });
+
+  test('returns null for a 4xx status', () => {
+    assert.equal(planRedirect(BASE, 404, 'https://gitlab.com/elsewhere'), null);
+  });
+
+  test('returns null for 304 Not Modified (a 3xx that is not a redirect)', () => {
+    assert.equal(planRedirect(BASE, 304, undefined), null);
+  });
+});
+
+suite('planRedirect: same-origin redirects keep credentials', () => {
+  for (const status of REDIRECT_STATUS_CODES) {
+    test(`HTTP ${status} to an absolute same-origin URL is followed without stripping`, () => {
+      const plan = planRedirect(BASE, status, 'https://gitlab.com/api/v4/projects/newns%2Fbar');
+      assert.ok(plan);
+      assert.equal(plan.nextUrl, 'https://gitlab.com/api/v4/projects/newns%2Fbar');
+      assert.equal(plan.stripCredentials, false);
+    });
+  }
+
+  test('a relative Location resolves against the current URL and stays same-origin', () => {
+    const plan = planRedirect(BASE, 302, '/api/v4/projects/999');
+    assert.ok(plan);
+    assert.equal(plan.nextUrl, 'https://gitlab.com/api/v4/projects/999');
+    assert.equal(plan.stripCredentials, false);
+  });
+
+  test('same host on a non-default port is still same-origin when the port matches', () => {
+    const plan = planRedirect('https://gitlab.example.com:8443/a', 302, 'https://gitlab.example.com:8443/b');
+    assert.ok(plan);
+    assert.equal(plan.stripCredentials, false);
+  });
+});
+
+suite('planRedirect: cross-origin redirects strip credentials', () => {
+  test('a different host is cross-origin', () => {
+    const plan = planRedirect(BASE, 302, 'https://attacker.example/api/v4/projects/foo%2Fbar');
+    assert.ok(plan);
+    assert.equal(plan.nextUrl, 'https://attacker.example/api/v4/projects/foo%2Fbar');
+    assert.equal(plan.stripCredentials, true);
+  });
+
+  test('a different port on the same host is cross-origin', () => {
+    const plan = planRedirect('https://gitlab.example.com/a', 302, 'https://gitlab.example.com:9999/a');
+    assert.ok(plan);
+    assert.equal(plan.stripCredentials, true);
+  });
+
+  test('an HTTP→HTTPS upgrade to the same host is cross-origin (scheme differs) so credentials are stripped', () => {
+    const plan = planRedirect('http://gitlab.example.com/a', 302, 'https://gitlab.example.com/a');
+    assert.ok(plan);
+    assert.equal(plan.stripCredentials, true);
+  });
+});
+
+suite('planRedirect: malformed and unsafe redirects throw', () => {
+  test('a redirect status with no Location throws', () => {
+    assert.throws(() => planRedirect(BASE, 302, undefined), NetworkError);
+  });
+
+  test('a redirect status with an empty Location throws', () => {
+    assert.throws(() => planRedirect(BASE, 301, '   '), NetworkError);
+  });
+
+  test('an HTTPS→HTTP downgrade is refused', () => {
+    assert.throws(
+      () => planRedirect(BASE, 302, 'http://gitlab.com/api/v4/projects/foo%2Fbar'),
+      NetworkError
+    );
+  });
+});
+
+suite('stripCredentialHeaders', () => {
+  test('removes Authorization, PRIVATE-TOKEN, and Cookie', () => {
+    const stripped = stripCredentialHeaders({
+      'User-Agent': 'VSCode-GitLabComponentHelper',
+      'PRIVATE-TOKEN': 'glpat-secret',
+      Authorization: 'Bearer secret',
+      Cookie: '_gitlab_session=abc',
+      Accept: 'application/json',
+    });
+    assert.deepEqual(stripped, {
+      'User-Agent': 'VSCode-GitLabComponentHelper',
+      Accept: 'application/json',
+    });
+  });
+
+  test('matches credential header names case-insensitively', () => {
+    const stripped = stripCredentialHeaders({
+      'private-token': 'glpat-secret',
+      authorization: 'Bearer secret',
+      'X-Keep': 'yes',
+    });
+    assert.deepEqual(stripped, { 'X-Keep': 'yes' });
+  });
+
+  test('returns an equivalent map when there is nothing to strip', () => {
+    const headers = { 'User-Agent': 'VSCode-GitLabComponentHelper' };
+    assert.deepEqual(stripCredentialHeaders(headers), headers);
+  });
+});


### PR DESCRIPTION
## Description

Adds a credential-safe redirect policy to `HttpClient`. Previously any `3xx` was treated as an error, so a moved GitLab component project (whose old path `302`s to the new location) failed to fetch. Now redirects are followed under a policy that never replays the user's GitLab token to another origin.

## Type of Change

- [x] Bug fix (moved projects now resolve)
- [x] Security hardening

## Changes Made

- **`src/utils/redirectPolicy.ts`** (new): pure, unit-tested `planRedirect()` + `stripCredentialHeaders()`.
  - Follows only `301/302/303/307/308` with a `Location`.
  - **Same-origin** → keep headers; **cross-origin** → strip `Authorization`/`PRIVATE-TOKEN`/`Cookie`.
  - Refuses `HTTPS→HTTP` downgrade; a redirect status with no `Location` throws.
- **`src/utils/httpClient.ts`**: `makeRequestWithHeaders` now follows redirects via the policy, capped at `MAX_REDIRECTS` hops. Policy extracted to its own module (httpClient was already over the file-size limit).
- **`src/constants/api.ts`**: `HEADER_AUTHORIZATION`, `HEADER_COOKIE`.
- **`src/constants/timing.ts`**: `MAX_REDIRECTS = 5`.
- **`tests/unit/redirectPolicy.test.ts`** (new): 19 tests — same/cross-origin, relative `Location` resolution, port/scheme differences, downgrade refusal, malformed redirects, case-insensitive header stripping.

## Security rationale

Every request carries the user's GitLab token (`PRIVATE-TOKEN`, attached in `versionManager`/`componentFetcher`/`groupCache`). Following a redirect and replaying that header cross-origin would leak the token to an attacker-controlled `Location` — e.g. after a moved component project's old path is reclaimed by a third party. Same-origin-only following plus credential stripping (the browser/`fetch` model) closes that vector; the downgrade refusal prevents TLS-stripping.

Note: the extension does not execute components, so this is not the pipeline-time supply-chain risk (that lives at GitLab `include:` resolution and is outside the extension's control). This change specifically prevents token exfiltration during metadata fetches.

## Testing

- `npm test` — **325 passing** (+19)
- `npm run lint` — clean (`--max-warnings 0`)
- `npm run compile` — clean

## Follow-up (out of scope)

Project-ID pinning in cache to make moved projects transparent — decision from discussion: keep the pin in the transient cache, no durable storage; the validation surface is a non-security backstop only. Tracked in #221.

Closes #221
