### PR TITLE
fix(matcher): recognize *.gitlab-ci.{yml,yaml} suffix-named files

### DIFF
--- a/src/utils/gitlabCiFileMatcherCore.ts
+++ b/src/utils/gitlabCiFileMatcherCore.ts
@@ -6,12 +6,16 @@
 import { minimatch } from 'minimatch';
 
 /**
- * Built-in glob patterns that always identify a file as a GitLab CI file. Covers the canonical entrypoint and the
- * conventional `.gitlab/` directory used for nested/included pipeline config.
+ * Built-in glob patterns that always identify a file as a GitLab CI file. Covers the canonical entrypoint, the
+ * `*.gitlab-ci.{yml,yaml}` suffix convention used for modular/included pipeline files, and the conventional
+ * `.gitlab/` directory. The suffix patterns restore recognition of files like `deploy.gitlab-ci.yml` that the
+ * removed custom `gitlab-ci` language used to match via its `extensions` (a filename-suffix match).
  */
 export const DEFAULT_GITLAB_CI_FILE_GLOBS = [
   '**/.gitlab-ci.yml',
   '**/.gitlab-ci.yaml',
+  '**/*.gitlab-ci.yml',
+  '**/*.gitlab-ci.yaml',
   '**/.gitlab/**/*.yml',
   '**/.gitlab/**/*.yaml',
 ];

--- a/tests/unit/gitlabCiFileMatcherCore.test.ts
+++ b/tests/unit/gitlabCiFileMatcherCore.test.ts
@@ -70,6 +70,11 @@ suite('matchesGitLabCIFile — default globs (yaml language)', () => {
     { path: 'repo/.gitlab-ci.yml', label: 'canonical .yml in subdir' },
     { path: 'repo/.gitlab-ci.yaml', label: 'canonical .yaml in subdir' },
     { path: '.gitlab-ci.yml', label: 'root canonical' },
+    // Suffix convention (`*.gitlab-ci.{yml,yaml}`) — restores what the removed custom language matched via
+    // its `extensions`. Regression guard for files like `deploy.gitlab-ci.yml` losing hover/completion.
+    { path: 'deploy.gitlab-ci.yml', label: 'suffix-named at root' },
+    { path: 'repo/templates/component.gitlab-ci.yml', label: 'suffix-named in subdir' },
+    { path: 'repo/test-example.gitlab-ci.yaml', label: 'suffix-named .yaml' },
     { path: 'repo/.gitlab/ci/build.yml', label: '.gitlab/ nested .yml' },
     { path: 'repo/.gitlab/pipelines/deploy.yaml', label: '.gitlab/ deep .yaml' },
   ];
@@ -86,6 +91,9 @@ suite('matchesGitLabCIFile — default globs (yaml language)', () => {
     // Regression guard: validation must not fire on arbitrary YAML — only files matching the defaults.
     { path: 'repo/docker-compose.yml', label: 'plain YAML with no matching glob' },
     { path: 'repo/kustomize/base.yaml', label: 'arbitrary YAML in unrelated subdir' },
+    // Guard: the suffix glob must anchor on `.gitlab-ci.{yml,yaml}` — a file that merely contains
+    // "gitlab-ci" mid-name but ends differently must not match.
+    { path: 'repo/my-gitlab-ci-notes.yml', label: 'contains gitlab-ci but wrong suffix' },
   ];
   for (const c of negativeCases) {
     test(`rejects: ${c.label} (${c.path})`, () => {


### PR DESCRIPTION
## Description
Restores provider recognition of suffix-named CI files (e.g. `deploy.gitlab-ci.yml`, `test-example.gitlab-ci.yml`) that regressed when #210 removed the custom `gitlab-ci` language.

## Root cause
The removed language declared `extensions: [".gitlab-ci.yml", ".gitlab-ci.yaml"]`, which VS Code matches by **filename suffix** — so any `*.gitlab-ci.yml` file opened as `gitlab-ci` and was in scope. The replacement `DEFAULT_GITLAB_CI_FILE_GLOBS` only matched a file named **exactly** `.gitlab-ci.yml`. Suffix-named files opened as `yaml` and fell out of scope → no hover/completion, and the `isCiFile`-gated **Browse Components** menu was hidden.

## Fix
Add `**/*.gitlab-ci.yml` + `**/*.gitlab-ci.yaml` to the defaults (keeping the explicit canonical entries for clarity). Non-standard paths remain configurable via `gitlabComponentHelper.additionalFileGlobs`.

## Testing
- `npm test` — 329 passing (+4: suffix .yml at root, suffix in subdir, suffix .yaml, plus an over-match guard that `my-gitlab-ci-notes.yml` still rejects)
- `npm run compile` / `npm run lint` — clean