### PR TITLE
ci(release): fix GitHub release-notes shell quoting (unblocks 0.16.0)

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -16,7 +16,6 @@
   "github": {
     "release": true,
     "releaseName": "${version}",
-    "releaseNotes": "echo '${changelog}'",
     "draft": false,
     "preRelease": false,
     "assets": [


### PR DESCRIPTION
## Problem
The `main` `release` job failed cutting **0.16.0** (run 28943563537):
```
ERROR /bin/sh: 6: Syntax error: "(" unexpected
```
Version logic was correct (0.15.6 → 0.16.0, even-minor check passed) and the VSIX packaged — it died generating the GitHub release notes. `main` is clean at the #208 merge (no partial 0.16.0 tag/release).

## Root cause
`.release-it.json` set `github.releaseNotes: "echo '${changelog}'"`, run via `sh -c`. This release's changelog includes #205's title **"enum input values aren't offered…"** — the apostrophe in `aren't` closes the single quote, exposing the changelog's markdown parens to dash. Data-dependent, so earlier `0.14.x` releases passed.

## Fix
Remove the redundant `echo` wrapper. `@release-it/conventional-changelog` already supplies the changelog as the GitHub release body, so release notes are unchanged — just no longer routed through a fragile shell command.

## Effect
Merging re-triggers the `release` job on `main` and cuts **0.16.0** with the fixed config.

> Note: targeted at `main` because `beta` was deleted when #208 merged; it should be recreated from `main` afterward to restore the pre-release channel.