### PR TITLE
fix(parser): resolve include: in multi-document component templates

### DIFF
--- a/src/providers/completionInputContext.ts
+++ b/src/providers/completionInputContext.ts
@@ -5,7 +5,7 @@
  * missing ones).
  */
 
-import { parseYaml, isYamlNode } from '../utils/yamlParser';
+import { parseYaml, parseYamlDocuments, findDocumentWith, isYamlNode, type YamlNode } from '../utils/yamlParser';
 import { findIncludeLine } from '../utils/includeMatcher';
 import type { ComponentParameter } from '../types/git-component';
 
@@ -65,7 +65,7 @@ export function findCompletionInputContextAtLine(
   // exactly while the user is typing the name. Blank the cursor line before parsing: it contributes nothing to the
   // existing-input set (it *is* the slot being typed), and the positional scans below read `lines`, not the parse.
   const parsed = parseInputDocument(text, lines, lineIndex);
-  if (!isYamlNode(parsed) || !parsed.include) return null;
+  if (parsed === null) return null;
 
   const includes = Array.isArray(parsed.include) ? parsed.include : [parsed.include];
 
@@ -120,30 +120,34 @@ export function findCompletionInputContextAtLine(
 }
 
 /**
- * Parse `text` as a YAML mapping, tolerating an in-progress input name on the cursor line.
+ * Parse `text` and return the document that owns the `include:` block, tolerating an in-progress input name on the
+ * cursor line.
  *
- * The document parses normally first. If that fails (or yields a non-mapping), and the cursor line looks like a
+ * A GitLab component template is a multi-document stream — the `spec:` header and the `include:`/jobs body are
+ * separate `---`-delimited documents — so we parse the whole stream and pick the document carrying `include`.
+ *
+ * The stream parses normally first. If no `include`-bearing document is found, and the cursor line looks like a
  * partially-typed name — leading whitespace then a bare token with no `:` — the line is blanked and the document
- * re-parsed. That token is the slot being typed; as a bare scalar beside its mapping siblings it makes the whole
- * document invalid, so blanking it lets the surrounding structure parse while the user types.
+ * re-parsed. That token is the slot being typed; as a bare scalar beside its mapping siblings it makes the
+ * surrounding document invalid, so blanking it lets the structure parse while the user types.
  *
  * @param text - The full YAML document text to parse.
  * @param lines - `text` split into lines, so the cursor line can be blanked without re-splitting.
  * @param lineIndex - 0-based index of the cursor line, the one blanked on the retry.
- * @returns the parsed value (from the original text where valid, otherwise the cursor-line-blanked retry), or the
- *   original parse result when the cursor line isn't an in-progress name.
+ * @returns the `include`-bearing document (from the original text where valid, otherwise the cursor-line-blanked
+ *   retry), or `null` when no such document is found.
  */
-function parseInputDocument(text: string, lines: string[], lineIndex: number): unknown {
-  const parsed = parseYaml(text, true);
-  if (isYamlNode(parsed) && parsed.include) return parsed;
+function parseInputDocument(text: string, lines: string[], lineIndex: number): YamlNode | null {
+  const includeDoc = findDocumentWith(parseYamlDocuments(text, true), 'include');
+  if (includeDoc) return includeDoc;
 
   const cursorLine = lines[lineIndex];
   const isInProgressName = /^\s*[^\s:#-][^:]*$/.test(cursorLine);
-  if (!isInProgressName) return parsed;
+  if (!isInProgressName) return null;
 
   const blanked = [...lines];
   blanked[lineIndex] = '';
-  return parseYaml(blanked.join('\n'), true);
+  return findDocumentWith(parseYamlDocuments(blanked.join('\n'), true), 'include');
 }
 
 /**

--- a/src/providers/hoverInputContext.ts
+++ b/src/providers/hoverInputContext.ts
@@ -4,7 +4,7 @@
  * parameter it names.
  */
 
-import { parseYaml, isYamlNode } from '../utils/yamlParser';
+import { parseYamlDocuments, findDocumentWith, isYamlNode } from '../utils/yamlParser';
 import { findIncludeLine } from '../utils/includeMatcher';
 
 /**
@@ -47,8 +47,10 @@ export function findInputContextAtLine(text: string, lineIndex: number): InputCo
 
   // Need a parsed `include:` array to know which includes are in scope; if YAML doesn't parse, bail.
   // Silent: hover runs against the live, often mid-edit document, where a parse failure is expected and handled.
-  const parsed = parseYaml(text, true);
-  if (!isYamlNode(parsed) || !parsed.include) return null;
+  // A component template is a multi-document stream (`spec:` header + `include:` body), so select the document
+  // that owns `include` rather than assuming a single document.
+  const parsed = findDocumentWith(parseYamlDocuments(text, true), 'include');
+  if (parsed === null) return null;
   const includes = Array.isArray(parsed.include) ? parsed.include : [parsed.include];
 
   // Each include is either a remote `component:` URL or a `local:` path — both behave the same here.

--- a/src/providers/validationProvider.ts
+++ b/src/providers/validationProvider.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { getComponentService } from '../services/component';
 import { getComponentCacheManager } from '../services/cache/componentCacheManager';
-import { parseYaml, isYamlNode } from '../utils/yamlParser';
+import { parseYamlDocuments, findDocumentWith } from '../utils/yamlParser';
 import { Component, ComponentParameter } from '../types/git-component';
 import { Logger } from '../utils/logger';
 import { expandComponentUrl, containsGitLabVariables } from '../utils/gitlabVariables';
@@ -164,9 +164,11 @@ export class ValidationProvider implements vscode.CodeActionProvider {
         const diagnosticKeys = new Set<string>(); // Track unique diagnostics to prevent duplicates
         // Silent: validation runs on every edit against the live, often mid-edit document; a parse failure is
         // expected and handled below (diagnostics cleared), so it should not log to the debug console.
-        const parsedYaml = parseYaml(text, true);
+        // A component template is a multi-document stream (`spec:` header + `include:` body), so select the
+        // document that owns `include` rather than assuming a single document.
+        const parsedYaml = findDocumentWith(parseYamlDocuments(text, true), 'include');
 
-        if (!isYamlNode(parsedYaml) || !parsedYaml.include) {
+        if (parsedYaml === null) {
             this.diagnosticCollection.set(document.uri, diagnostics);
             return;
         }

--- a/src/utils/yamlParser.ts
+++ b/src/utils/yamlParser.ts
@@ -51,6 +51,44 @@ export function parseYaml(text: string, silent = false): unknown {
   }
 }
 
+/**
+ * Parse a YAML document *stream* into its constituent mapping documents.
+ *
+ * A GitLab CI component template is a multi-document file: the `spec:` header is one document, the `include:`/jobs
+ * body another, separated by `---`. `js-yaml`'s `load` throws on any stream with more than one document, so
+ * {@link parseYaml} returns `null` for these files. This uses `loadAll` and returns each document that is a mapping,
+ * in document order, so a caller can select the one owning the key it needs (see {@link findDocumentWith}) rather
+ * than flattening distinct documents together.
+ *
+ * @param text - The YAML source (one or more `---`-separated documents) to parse.
+ * @param silent - Suppress the `console.error` on a parse failure. Use on hot paths where a mid-edit parse failure
+ *   is expected and handled.
+ * @returns the stream's mapping documents in order (non-mapping documents — scalars, sequences, `null` — are
+ *   dropped); an empty array when the stream is empty or fails to parse.
+ */
+export function parseYamlDocuments(text: string, silent = false): YamlNode[] {
+  try {
+    const docs = yaml.loadAll(text);
+    return docs.filter(isYamlNode);
+  } catch (e) {
+    if (!silent) {
+      console.error('Error parsing YAML:', e);
+    }
+    return [];
+  }
+}
+
+/**
+ * Find the first document in a parsed stream that carries the given top-level key.
+ *
+ * @param docs - Mapping documents from {@link parseYamlDocuments}, in document order.
+ * @param key - The top-level key to locate (e.g. `'include'` or `'spec'`).
+ * @returns the first document whose own `key` is defined, or `null` when no document carries it.
+ */
+export function findDocumentWith(docs: YamlNode[], key: string): YamlNode | null {
+  return docs.find((doc) => doc[key] !== undefined) ?? null;
+}
+
 // Clean expired cache entries
 function cleanParseCache(currentTime: number): void {
   for (const [key, value] of parseCache.entries()) {

--- a/tests/extension-host/suite/specHeaderCompletion.test.ts
+++ b/tests/extension-host/suite/specHeaderCompletion.test.ts
@@ -1,0 +1,70 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+const EXTENSION_ID = 'eFAILution.gitlab-component-helper';
+
+// __dirname is <repo>/out-test/suite at runtime; fixtures live under tests/fixtures.
+const FIXTURE_DIR = path.resolve(__dirname, '..', '..', 'tests', 'fixtures', 'spec-header-completion');
+const FIXTURE = path.join(FIXTURE_DIR, '.gitlab-ci.yml');
+
+async function ensureActive(): Promise<void> {
+  const ext = vscode.extensions.getExtension(EXTENSION_ID);
+  assert.ok(ext);
+  if (!ext.isActive) await ext.activate();
+}
+
+/** 0-indexed line whose trimmed text starts with `<name>:`. */
+function lineStartingWith(doc: vscode.TextDocument, name: string): number {
+  const lines = doc.getText().split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].trim().startsWith(`${name}:`)) return i;
+  }
+  throw new Error(`fixture missing a line starting with ${name}:`);
+}
+
+function labels(list: vscode.CompletionList | undefined): string[] {
+  return (list?.items ?? []).map((i) => (typeof i.label === 'string' ? i.label : i.label.label));
+}
+
+async function completionsAt(doc: vscode.TextDocument, position: vscode.Position): Promise<vscode.CompletionList> {
+  const list = await vscode.commands.executeCommand<vscode.CompletionList>(
+    'vscode.executeCompletionItemProvider',
+    doc.uri,
+    position
+  );
+  assert.ok(list, 'executeCompletionItemProvider returned no completion list');
+  return list;
+}
+
+// Regression for multi-document consumer files: the open `.gitlab-ci.yml` is itself a component template — a
+// `spec:` header in one YAML document, the `include:` block in a second (`---`-separated) document. `js-yaml`'s
+// single-document `load` throws on such a stream, which previously left the parse null and suppressed all input
+// completion. Drives VS Code's own completion engine end-to-end to confirm the name slot now resolves against the
+// second document's include and offers the missing input names.
+suite('Input completion in a spec-header (multi-document) template', () => {
+  suiteSetup(ensureActive);
+
+  test('name slot under the include offers the include\'s not-yet-set inputs', async () => {
+    const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(FIXTURE));
+    const editor = await vscode.window.showTextDocument(doc);
+
+    // The include's inputs already set `job_name`; the remaining inputs are `environment` and `region`. Type a
+    // fresh 6-space-indented name slot on a new line under `job_name:` (matching that key's indent), then ask for
+    // completions at the caret — the shape a user is in mid-type.
+    const jobNameLine = lineStartingWith(doc, 'job_name');
+    const keyIndent = doc.lineAt(jobNameLine).firstNonWhitespaceCharacterIndex;
+    const insertAt = new vscode.Position(jobNameLine, doc.lineAt(jobNameLine).text.length);
+    await editor.edit((b) => b.insert(insertAt, `\n${' '.repeat(keyIndent)}`));
+
+    const slotLine = jobNameLine + 1;
+    const position = new vscode.Position(slotLine, keyIndent);
+    const list = await completionsAt(doc, position);
+
+    const got = labels(list);
+    assert.ok(got.includes('environment'), `expected an 'environment' completion. Got: ${JSON.stringify(got)}`);
+    assert.ok(got.includes('region'), `expected a 'region' completion. Got: ${JSON.stringify(got)}`);
+    // The already-set input must not be re-offered.
+    assert.ok(!got.includes('job_name'), `'job_name' is already set and must not be offered. Got: ${JSON.stringify(got)}`);
+  });
+});

--- a/tests/fixtures/spec-header-completion/.gitlab-ci.yml
+++ b/tests/fixtures/spec-header-completion/.gitlab-ci.yml
@@ -1,0 +1,12 @@
+spec:
+  inputs:
+    tier:
+      description: Deployment tier
+      type: string
+      default: standard
+---
+include:
+  - local: "spec-header-completion/templates/deploy.yml"
+    inputs:
+      job_name: deploy
+

--- a/tests/fixtures/spec-header-completion/templates/deploy.yml
+++ b/tests/fixtures/spec-header-completion/templates/deploy.yml
@@ -1,0 +1,16 @@
+spec:
+  inputs:
+    environment:
+      description: Target environment
+      type: string
+      default: staging
+    region:
+      description: Target region
+      type: string
+    job_name:
+      description: The name of the CI job
+      type: string
+---
+$[[ inputs.job_name ]]:
+  script:
+    - echo "deploy $[[ inputs.job_name ]] to $[[ inputs.environment ]]/$[[ inputs.region ]]"

--- a/tests/unit/completionInputContext.test.ts
+++ b/tests/unit/completionInputContext.test.ts
@@ -339,6 +339,50 @@ variables:
     const ctx = findCompletionInputContextAtLine(text, 3);
     assert.strictEqual(ctx, null);
   });
+
+  test('detects a slot when a spec: header precedes the include in a separate YAML document (regression)', () => {
+    // A component template is a multi-document stream: the `spec:` header is its own `---`-delimited document,
+    // the `include:`/jobs body another. `include:` therefore lives in the second document, not the first. This
+    // is the shape of every real GitLab component template; the slot must still resolve against it.
+    const text = `spec:
+  inputs:
+    job_name:
+      type: string
+---
+include:
+  - component: ${FULL_PIPELINE_URL}
+    inputs:
+      environment: "development"
+      `;
+    const ctx = findCompletionInputContextAtLine(text, 9); // blank, 6-space slot under the second-document include
+    assert.deepStrictEqual(ctx, {
+      componentUrl: FULL_PIPELINE_URL,
+      includeKind: 'component',
+      slot: 'name',
+      existingInputNames: ['environment'],
+    });
+  });
+
+  test('resolves an in-progress name slot in a multi-document template (regression)', () => {
+    // The half-typed name blanks the cursor line before re-parsing; that retry must still locate the
+    // `include`-bearing document past the `spec:` header rather than treating the whole stream as unparseable.
+    const text = `spec:
+  inputs:
+    debug:
+      type: boolean
+---
+include:
+  - component: ${FULL_PIPELINE_URL}
+    inputs:
+      env`;
+    const ctx = findCompletionInputContextAtLine(text, 8, 9); // cursor after the partial `env`
+    assert.deepStrictEqual(ctx, {
+      componentUrl: FULL_PIPELINE_URL,
+      includeKind: 'component',
+      slot: 'name',
+      existingInputNames: [],
+    });
+  });
 });
 
 suite('buildInputInsertValue', () => {

--- a/tests/unit/yamlParser.test.ts
+++ b/tests/unit/yamlParser.test.ts
@@ -1,0 +1,59 @@
+// @mocha
+/**
+ * yamlParser tests — the multi-document stream helpers `parseYamlDocuments` and `findDocumentWith`.
+ *
+ * The critical case: a GitLab component template is a multi-document file — the `spec:` header is one
+ * `---`-delimited document, the `include:`/jobs body another. `js-yaml`'s `load` throws on such a stream, so
+ * completion/hover/validation (which read `include:`) got nothing until they switched to these helpers, which
+ * parse all documents and let a caller select the one owning the key it needs.
+ */
+
+import * as assert from 'node:assert/strict';
+import { parseYamlDocuments, findDocumentWith } from '../../src/utils/yamlParser';
+
+suite('parseYamlDocuments', () => {
+  test('returns every mapping document of a multi-document stream', () => {
+    const text = `spec:
+  inputs:
+    job_name:
+      type: string
+---
+include:
+  - component: https://gitlab.com/c/x@1.0.0
+`;
+    const docs = parseYamlDocuments(text, true);
+    assert.strictEqual(docs.length, 2);
+    assert.ok('spec' in docs[0]);
+    assert.ok('include' in docs[1]);
+  });
+
+  test('returns the single document of a one-document stream', () => {
+    const docs = parseYamlDocuments('include:\n  - local: a.yml\n', true);
+    assert.strictEqual(docs.length, 1);
+    assert.ok('include' in docs[0]);
+  });
+
+  test('drops non-mapping documents (scalars, sequences, null)', () => {
+    const docs = parseYamlDocuments('- a\n- b\n---\njustAScalar\n', true);
+    assert.deepStrictEqual(docs, []);
+  });
+
+  test('returns [] on unparseable input', () => {
+    assert.deepStrictEqual(parseYamlDocuments('key: "unterminated', true), []);
+  });
+});
+
+suite('findDocumentWith', () => {
+  test('finds the document that owns the requested key, past an earlier document', () => {
+    const docs = parseYamlDocuments('spec:\n  inputs: {}\n---\ninclude:\n  - local: a.yml\n', true);
+    const includeDoc = findDocumentWith(docs, 'include');
+    assert.ok(includeDoc && 'include' in includeDoc);
+    const specDoc = findDocumentWith(docs, 'spec');
+    assert.ok(specDoc && 'spec' in specDoc);
+  });
+
+  test('returns null when no document carries the key', () => {
+    const docs = parseYamlDocuments('stages:\n  - build\n', true);
+    assert.strictEqual(findDocumentWith(docs, 'include'), null);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes input completion, hover, and validation doing nothing on a component template that keeps its `spec:` header. Such a template is a **multi-document** YAML stream (`spec:` header + `---` + `include:`/jobs body); `parseYaml` used `js-yaml`'s single-document `load()`, which throws on a multi-document stream, so the parse returned `null` and every provider that reads `include:` bailed. Deleting the `spec:` block was the only workaround.
- Adds `parseYamlDocuments` (parses the whole stream via `loadAll`, returning each mapping document in order) and `findDocumentWith(docs, key)` (selects the document that owns a given top-level key). The three broken providers now select the `include`-bearing document instead of assuming a single document — matching what `localComponentResolver` already does with `loadAll`. Distinct documents are **not** flattened together; each caller picks the document it needs.
- `parseYaml` is unchanged, so the single-document callers (the `quoteYamlIfUnsafe` round-trip probe, the wrapped-include parse in the component browser) keep their exact behaviour.
- Link related issue(s): Fixes #225

## Change Type
- [ ] feat
- [x] fix
- [ ] refactor
- [ ] docs
- [ ] test
- [ ] chore

## Context
### User-facing impact
- Completion, hover, and validation now work on `spec:`-header component templates, not only on plain single-document `.gitlab-ci.yml` files.

### GitLab scope
- [ ] gitlab.com
- [ ] self-managed GitLab
- [x] both (local YAML parsing only; no GitLab interaction)

### Affected areas
- [ ] Component Browser
- [x] Hover provider
- [x] Completion provider
- [x] Validation provider
- [ ] Cache and refresh behavior
- [ ] GitLab API calls/auth/token storage
- [ ] Docs only

## What changed by bucket

| Bucket | Files | Approach |
|---|---|---|
| Multi-document parse helpers | [yamlParser.ts](../src/utils/yamlParser.ts) | New `parseYamlDocuments(text, silent)` uses `yaml.loadAll` and returns the stream's mapping documents in document order (non-mapping documents — scalars, sequences, `null` — are dropped); `[]` on empty or unparseable input. New `findDocumentWith(docs, key)` returns the first document whose own `key` is defined, or `null`. `parseYaml` is untouched. |
| Provider parse-selection | [completionInputContext.ts](../src/providers/completionInputContext.ts), [hoverInputContext.ts](../src/providers/hoverInputContext.ts), [validationProvider.ts](../src/providers/validationProvider.ts) | Each path replaces `parseYaml(text)` + `parsed.include` guard with `findDocumentWith(parseYamlDocuments(text, true), 'include')`. In completion, `parseInputDocument` (including its in-progress-name blank-line retry) now returns the `include`-bearing `YamlNode` or `null`. |
| Regression tests | [yamlParser.test.ts](../tests/unit/yamlParser.test.ts), [completionInputContext.test.ts](../tests/unit/completionInputContext.test.ts), [specHeaderCompletion.test.ts](../tests/extension-host/suite/specHeaderCompletion.test.ts), [tests/fixtures/spec-header-completion/](../tests/fixtures/spec-header-completion/) | **Unit:** `parseYamlDocuments`/`findDocumentWith` (multi-doc, single-doc, non-mapping-dropping, unparseable), plus two completion regressions resolving a slot in a `spec:`-header template (blank slot and in-progress name). **Extension-host:** `spec-header-completion` drives VS Code's own completion engine against a consumer file that is itself a `spec:`-header multi-document template; verified load-bearing (fails against the old single-document `parseYaml`, offering only generic word completions). |

## Breaking Changes
- [x] No breaking changes
- [ ] Breaking changes (describe below)
