### PR TITLE
Fix(completion): valid local include with no spec is reported as not found

### DIFF
--- a/src/providers/localComponentResolver.ts
+++ b/src/providers/localComponentResolver.ts
@@ -183,15 +183,91 @@ async function readIncludeTarget(uri: vscode.Uri): Promise<string | null> {
 }
 
 /**
- * Resolve a local include path into a synthetic `Component` so the rest of the providers can treat it identically to
- * a catalog component. Reads the target file (preferring an open editor buffer), parses every YAML document in it,
- * picks the first one declaring `spec`, and maps `spec.inputs` onto `ComponentParameter[]`.
+ * The outcome of resolving a `local:` include, discriminating the reasons resolution can fail to yield a component.
  *
- * Returns `null` for several distinct reasons, all of which the caller treats the same way (no spurious diagnostics):
- *   - the path is a glob or contains `..` (see `isUnsupportedLocalPath`)
- *   - no resolution root is available (no document, no Git repo, no workspace folder)
- *   - the file doesn't exist or can't be read
- *   - the file parses but has no `spec` block (a legitimate plain include, not a parameterised template)
+ * `unreadable` and `no-spec` look identical to callers that only want the component, but they are opposites to the
+ * validator: `unreadable` is a real problem (the included file is missing or can't be read) worth a diagnostic,
+ * whereas `no-spec` is a legitimate plain include (hidden jobs, `.pre`/`.post`, cache config) with nothing to
+ * validate and must stay silent. Collapsing both to `null` is what made valid non-parameterised includes report a
+ * spurious "file not found" warning.
+ */
+export type LocalIncludeOutcome =
+  | { kind: 'component'; component: Component }
+  /** Path is a glob/`..`, or no resolution root is available — not something to diagnose. */
+  | { kind: 'skipped' }
+  /** The include target is missing or unreadable — the validator surfaces this as a diagnostic. */
+  | { kind: 'unreadable' }
+  /** The target was read and parsed but declares no `spec:` document — a valid plain include, nothing to validate. */
+  | { kind: 'no-spec' };
+
+/**
+ * Resolve a local include path into a {@link LocalIncludeOutcome}. Reads the target file (preferring an open editor
+ * buffer), parses every YAML document in it, picks the first one declaring `spec`, and maps `spec.inputs` onto
+ * `ComponentParameter[]`.
+ *
+ * @param localPath  The raw path string from a parsed `include: - local:` entry.
+ * @param document   The document making the include. Used to determine the resolution root and the open-buffer fast path.
+ * @returns          The resolution outcome — a `component` on success, or one of `skipped`/`unreadable`/`no-spec`.
+ */
+export async function resolveLocalIncludeOutcome(
+  localPath: string,
+  document?: vscode.TextDocument
+): Promise<LocalIncludeOutcome> {
+  if (isUnsupportedLocalPath(localPath)) {
+    return { kind: 'skipped' };
+  }
+
+  const uri = resolveLocalIncludeUri(localPath, document);
+  if (!uri) {
+    logger.debug(`[LocalComponentResolver] No resolution root available for: ${localPath}`, 'LocalComponentResolver');
+    return { kind: 'skipped' };
+  }
+
+  const text = await readIncludeTarget(uri);
+  if (text === null) {
+    return { kind: 'unreadable' };
+  }
+  let docs: unknown[];
+  try {
+    docs = yaml.loadAll(text);
+  } catch (err) {
+    logger.debug(`[LocalComponentResolver] Failed to parse ${uri.fsPath}: ${err}`, 'LocalComponentResolver');
+    // The file exists and was read; it just isn't valid YAML. That's a plain include we can't extract inputs from,
+    // not a missing file — treat it like a no-spec include rather than a false "not found".
+    return { kind: 'no-spec' };
+  }
+  const specDoc = docs.find(
+    (d): d is { spec?: { inputs?: unknown } } => !!d && typeof d === 'object' && 'spec' in d
+  );
+  if (!specDoc) {
+    logger.debug(`[LocalComponentResolver] ${uri.fsPath} has no spec document`, 'LocalComponentResolver');
+    return { kind: 'no-spec' };
+  }
+
+  const specInputs = specDoc.spec && specDoc.spec.inputs;
+  const parameters = parseInputs(specInputs);
+  const displayName = path.basename(localPath);
+  const url = buildLocalComponentUrl(localPath);
+
+  return {
+    kind: 'component',
+    component: {
+      name: displayName,
+      description: `Local include: \`${localPath}\``,
+      parameters,
+      source: 'local',
+      url,
+      originalUrl: url,
+      sourcePath: localPath,
+    },
+  };
+}
+
+/**
+ * Resolve a local include path into a synthetic `Component`, or `null` when no component can be produced (unsupported
+ * path, no resolution root, unreadable file, or no `spec` block). A thin wrapper over
+ * {@link resolveLocalIncludeOutcome} for callers (completion, include detection) that only need the component and
+ * treat every failure the same way.
  *
  * @param localPath  The raw path string from a parsed `include: - local:` entry.
  * @param document   The document making the include. Used to determine the resolution root and the open-buffer fast path.
@@ -201,49 +277,8 @@ export async function resolveLocalComponent(
   localPath: string,
   document?: vscode.TextDocument
 ): Promise<Component | null> {
-  if (isUnsupportedLocalPath(localPath)) {
-    return null;
-  }
-
-  const uri = resolveLocalIncludeUri(localPath, document);
-  if (!uri) {
-    logger.debug(`[LocalComponentResolver] No resolution root available for: ${localPath}`, 'LocalComponentResolver');
-    return null;
-  }
-
-  const text = await readIncludeTarget(uri);
-  if (text === null) {
-    return null;
-  }
-  let docs: unknown[];
-  try {
-    docs = yaml.loadAll(text);
-  } catch (err) {
-    logger.debug(`[LocalComponentResolver] Failed to parse ${uri.fsPath}: ${err}`, 'LocalComponentResolver');
-    return null;
-  }
-  const specDoc = docs.find(
-    (d): d is { spec?: { inputs?: unknown } } => !!d && typeof d === 'object' && 'spec' in d
-  );
-  if (!specDoc) {
-    logger.debug(`[LocalComponentResolver] ${uri.fsPath} has no spec document`, 'LocalComponentResolver');
-    return null;
-  }
-
-  const specInputs = specDoc.spec && specDoc.spec.inputs;
-  const parameters = parseInputs(specInputs);
-  const displayName = path.basename(localPath);
-  const url = buildLocalComponentUrl(localPath);
-
-  return {
-    name: displayName,
-    description: `Local include: \`${localPath}\``,
-    parameters,
-    source: 'local',
-    url,
-    originalUrl: url,
-    sourcePath: localPath,
-  };
+  const outcome = await resolveLocalIncludeOutcome(localPath, document);
+  return outcome.kind === 'component' ? outcome.component : null;
 }
 
 /**

--- a/src/providers/validationProvider.ts
+++ b/src/providers/validationProvider.ts
@@ -7,7 +7,7 @@ import { Logger } from '../utils/logger';
 import { expandComponentUrl, containsGitLabVariables } from '../utils/gitlabVariables';
 import { isGitLabCIFile } from '../utils/gitlabCiFileMatcher';
 import { spawn } from 'child_process';
-import { resolveLocalComponent, isUnsupportedLocalPath } from './localComponentResolver';
+import { resolveLocalIncludeOutcome, isUnsupportedLocalPath } from './localComponentResolver';
 import { attachDiagnosticMetadata, readDiagnosticMetadata } from './validationMetadata';
 import { isAuthError } from '../errors';
 import type { MissingRequiredInputMetadata } from './validationMetadata';
@@ -919,8 +919,8 @@ export class ValidationProvider implements vscode.CodeActionProvider {
             return;
         }
 
-        const component = await resolveLocalComponent(localPath, document);
-        if (!component) {
+        const outcome = await resolveLocalIncludeOutcome(localPath, document);
+        if (outcome.kind === 'unreadable') {
             const line = this.findLineForComponent(document, includes, includeIndex);
             const range = new vscode.Range(line, 0, line, document.lineAt(line).text.length);
             const diagnostic = new vscode.Diagnostic(
@@ -933,6 +933,14 @@ export class ValidationProvider implements vscode.CodeActionProvider {
             diagnostics.push(diagnostic);
             return;
         }
+
+        // `skipped` (glob/`..`/no root) and `no-spec` (a valid plain include with no `spec:` block) both have no
+        // inputs to validate — leave them alone rather than reporting a spurious not-found.
+        if (outcome.kind !== 'component') {
+            this.logger.debug(`[ValidationProvider] Local include not a parameterised template (${outcome.kind}), skipping: ${localPath}`, 'ValidationProvider');
+            return;
+        }
+        const component = outcome.component;
 
         if (!component.parameters || component.parameters.length === 0) {
             this.logger.debug(`[ValidationProvider] Local include has no spec.inputs, skipping input validation: ${localPath}`, 'ValidationProvider');

--- a/tests/extension-host/suite/localInclude.test.ts
+++ b/tests/extension-host/suite/localInclude.test.ts
@@ -92,9 +92,15 @@ suite('Local include support', () => {
     );
   });
 
-  test('missing local include file produces a not-found diagnostic', async () => {
+  test('missing local include file produces a not-found diagnostic on the missing-file line', async () => {
     const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(FIXTURE));
     await vscode.window.showTextDocument(doc);
+
+    const missingLine = doc
+      .getText()
+      .split('\n')
+      .findIndex((l) => l.includes('missing-template.yml'));
+    assert.ok(missingLine !== -1, 'fixture missing the missing-template.yml include');
 
     const diags = await waitForDiagnostics(doc.uri);
     const notFound = diags.find(
@@ -103,6 +109,34 @@ suite('Local include support', () => {
     assert.ok(
       notFound,
       `expected a local-include-not-found diagnostic. Got: ${JSON.stringify(diags.map((d) => ({ code: d.code, msg: d.message })))}`
+    );
+    assert.strictEqual(
+      notFound.range.start.line,
+      missingLine,
+      'the not-found diagnostic should anchor to the missing-template.yml line'
+    );
+  });
+
+  test('a valid local include with no spec: block produces no not-found diagnostic (regression)', async () => {
+    // `no-spec.yml` exists and is readable but declares hidden jobs, not a `spec:` component. It is a legitimate
+    // plain include with nothing to validate — it must not be reported as "file not found or unreadable".
+    const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(FIXTURE));
+    await vscode.window.showTextDocument(doc);
+
+    const noSpecLine = doc
+      .getText()
+      .split('\n')
+      .findIndex((l) => l.includes('no-spec.yml'));
+    assert.ok(noSpecLine !== -1, 'fixture missing the no-spec.yml include');
+
+    await waitForDiagnostics(doc.uri);
+    const onNoSpecLine = vscode.languages
+      .getDiagnostics(doc.uri)
+      .filter((d) => d.source === 'gitlab-component-helper' && d.range.start.line === noSpecLine);
+    assert.deepStrictEqual(
+      onNoSpecLine.map((d) => d.code),
+      [],
+      `expected no diagnostics on the no-spec include line. Got: ${JSON.stringify(onNoSpecLine.map((d) => ({ code: d.code, msg: d.message })))}`
     );
   });
 


### PR DESCRIPTION
## Summary
- Fixes a valid `local:` include with no `spec:` block being reported as `File not found or unreadable`. `resolveLocalComponent` collapsed four distinct outcomes into a single `null` (unsupported path, no resolution root, unreadable file, and readable-but-no-`spec:`), and the validation provider treated any `null` as not-found — so a legitimate plain include (hidden jobs, cache config) got a spurious warning.
- Adds `resolveLocalIncludeOutcome`, returning a discriminated `LocalIncludeOutcome` (`component` / `skipped` / `unreadable` / `no-spec`). The validator now only emits `local-include-not-found` for `unreadable`; `no-spec` and `skipped` are silent. Unparseable-but-readable YAML is treated as `no-spec` rather than a false not-found.
- `resolveLocalComponent` is kept as a thin wrapper over the new function (returns the component or `null`), so the completion and include-detection callers are unchanged.
- Link related issue(s): Fixes #227

## Change Type
- [ ] feat
- [x] fix
- [ ] refactor
- [ ] docs
- [ ] test
- [ ] chore

## Context
### User-facing impact
- A `local:` include of a file with no `spec:` block (a plain include of hidden jobs / cache config) no longer shows a spurious "file not found or unreadable" warning. Genuinely missing/unreadable includes still warn.

### GitLab scope
- [ ] gitlab.com
- [ ] self-managed GitLab
- [x] both (local include resolution only; no GitLab interaction)

### Affected areas
- [ ] Component Browser
- [ ] Hover provider
- [ ] Completion provider
- [x] Validation provider
- [ ] Cache and refresh behavior
- [ ] GitLab API calls/auth/token storage
- [ ] Docs only

## What changed by bucket

| Bucket | Files | Approach |
|---|---|---|
| Resolution outcome | [localComponentResolver.ts](../src/providers/localComponentResolver.ts) | New `LocalIncludeOutcome` union and `resolveLocalIncludeOutcome(localPath, document)`: `skipped` for a glob/`..` path or no resolution root, `unreadable` when the file is missing/unreadable, `no-spec` when it's readable but declares no `spec:` document (or is unparseable YAML), and `component` on success. `resolveLocalComponent` becomes a thin wrapper returning `outcome.component` or `null`, so completion and `detectLocalIncludeComponent` are untouched. |
| Validator branch | [validationProvider.ts](../src/providers/validationProvider.ts) | `validateLocalInclude` switches to `resolveLocalIncludeOutcome`. Only `unreadable` produces the `local-include-not-found` diagnostic; `no-spec`/`skipped` return silently (no inputs to validate). |
| Regression tests | [localInclude.test.ts](../tests/extension-host/suite/localInclude.test.ts) | New extension-host test: a readable `local:` include with no `spec:` block produces **no** diagnostics on its line. Strengthened the existing missing-file test to assert the not-found diagnostic anchors to the `missing-template.yml` line specifically. Both verified load-bearing (fail when the validator warns on `no-spec`). Reuses the existing `local-include/no-spec.yml` fixture. |

## Breaking Changes
- [x] No breaking changes
- [ ] Breaking changes (describe below)
