### PR TITLE
fix(browser): hover-fetched components create a phantom top-level instance group in the browser

### DIFF
--- a/src/services/cache/componentCacheManager.ts
+++ b/src/services/cache/componentCacheManager.ts
@@ -3,6 +3,8 @@ import { getComponentService } from '../component';
 import { Logger } from '../../utils/logger';
 import { getPerformanceMonitor } from '../../utils/performanceMonitor';
 import { CachedComponent, PersistentCacheData } from '../../types/cache';
+import { ComponentSource } from '../../types/api';
+import { reconcileComponentSource } from './sourceReconciliation';
 import { ProjectCache } from './projectCache';
 import { VersionCache } from './versionCache';
 import { GroupCache } from './groupCache';
@@ -115,6 +117,13 @@ export class ComponentCacheManager {
    */
   public addDynamicComponent(component: CachedComponent): void {
     try {
+      // Dynamic fetches synthesize `source` as `instance/path`; adopt the configured source's display name (and tag
+      // template) so the entry merges into its source group instead of spawning a phantom top-level instance node.
+      const sources = vscode.workspace
+        .getConfiguration('gitlabComponentHelper')
+        .get<ComponentSource[]>('componentSources', []);
+      component = reconcileComponentSource(component, sources);
+
       // Check if component already exists (avoid duplicates)
       const existingIndex = this.components.findIndex(
         comp =>

--- a/src/services/cache/sourceReconciliation.ts
+++ b/src/services/cache/sourceReconciliation.ts
@@ -1,0 +1,39 @@
+import { CachedComponent } from '../../types/cache';
+import { ComponentSource } from '../../types/api';
+
+const DEFAULT_GITLAB_INSTANCE = 'gitlab.com';
+
+const normalizeInstance = (instance: string): string => instance.replace(/^https?:\/\//, '');
+
+/**
+ * When a dynamically fetched component belongs to a configured source, return it with that source's display `name`
+ * adopted (and `tagPattern` filled in if absent). Dynamic fetches synthesize `source` as `instance/path`, which would
+ * otherwise group the component under a phantom top-level instance node in the browser — separate from the configured
+ * source's own components — and leave version discovery without the tag template.
+ *
+ * Matching is by `gitlabInstance` + `sourcePath`. No match returns the component unchanged (an ad-hoc hover on a
+ * project outside any configured source).
+ *
+ * @param component The dynamically fetched cache entry, with `source` synthesized as `instance/path`.
+ * @param sources   The configured component sources from settings to match against.
+ * @returns         The component with `source`/`tagPattern` adopted from the matching source, or unchanged if none match.
+ */
+export function reconcileComponentSource(
+  component: CachedComponent,
+  sources: ComponentSource[],
+): CachedComponent {
+  const match = sources.find(source => {
+    const sourceInstance = normalizeInstance(source.gitlabInstance || DEFAULT_GITLAB_INSTANCE);
+    return sourceInstance === component.gitlabInstance && source.path === component.sourcePath;
+  });
+
+  if (!match) {
+    return component;
+  }
+
+  return {
+    ...component,
+    source: match.name,
+    tagPattern: component.tagPattern ?? match.tagPattern,
+  };
+}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -128,6 +128,7 @@ export interface ComponentSource {
   path: string;
   gitlabInstance?: string;
   type?: 'project' | 'group';
+  tagPattern?: string;
 }
 
 /**

--- a/tests/unit/sourceReconciliation.test.ts
+++ b/tests/unit/sourceReconciliation.test.ts
@@ -1,0 +1,78 @@
+// @mocha
+/**
+ * Tests src/services/cache/sourceReconciliation.ts — the pure helper that maps a dynamically fetched component (whose
+ * `source` is synthesized as `instance/path`) back onto the configured source it belongs to, so hover-fetched entries
+ * merge into their source group instead of spawning a phantom top-level instance node in the component browser.
+ */
+
+import * as assert from 'node:assert/strict';
+import { reconcileComponentSource } from '../../src/services/cache/sourceReconciliation';
+import { CachedComponent } from '../../src/types/cache';
+import { ComponentSource } from '../../src/types/api';
+
+const dynamicComponent = (overrides: Partial<CachedComponent> = {}): CachedComponent => ({
+  name: 'markdown-lint',
+  description: 'Component/Project does not have a description',
+  parameters: [],
+  source: 'gitlab.com/yu-life/infrastructure/yulife-devops-shared-config',
+  sourcePath: 'yu-life/infrastructure/yulife-devops-shared-config',
+  gitlabInstance: 'gitlab.com',
+  version: 'markdown-lint-1',
+  url: '',
+  ...overrides,
+});
+
+const configuredSource: ComponentSource = {
+  name: 'yulife-devops-shared-config',
+  path: 'yu-life/infrastructure/yulife-devops-shared-config',
+  gitlabInstance: 'gitlab.com',
+  type: 'project',
+  tagPattern: '{name}-{version}',
+};
+
+suite('reconcileComponentSource', () => {
+  test('adopts the configured source name when instance + path match', () => {
+    const result = reconcileComponentSource(dynamicComponent(), [configuredSource]);
+    assert.equal(result.source, 'yulife-devops-shared-config');
+  });
+
+  test('fills in the configured tagPattern when the component has none', () => {
+    const result = reconcileComponentSource(dynamicComponent(), [configuredSource]);
+    assert.equal(result.tagPattern, '{name}-{version}');
+  });
+
+  test('keeps a tagPattern already on the component over the configured one', () => {
+    const result = reconcileComponentSource(
+      dynamicComponent({ tagPattern: '{name}/{version}' }),
+      [configuredSource],
+    );
+    assert.equal(result.tagPattern, '{name}/{version}');
+  });
+
+  test('leaves the component untouched when no source matches', () => {
+    const component = dynamicComponent({ sourcePath: 'some/other/project' });
+    const result = reconcileComponentSource(component, [configuredSource]);
+    assert.equal(result.source, component.source);
+    assert.equal(result.tagPattern, undefined);
+  });
+
+  test('does not match across different gitlab instances', () => {
+    const component = dynamicComponent({ gitlabInstance: 'gitlab.example.com' });
+    const result = reconcileComponentSource(component, [configuredSource]);
+    assert.equal(result.source, component.source);
+  });
+
+  test('normalizes an https:// prefix on the configured instance before matching', () => {
+    const result = reconcileComponentSource(dynamicComponent(), [
+      { ...configuredSource, gitlabInstance: 'https://gitlab.com' },
+    ]);
+    assert.equal(result.source, 'yulife-devops-shared-config');
+  });
+
+  test('defaults a source with no gitlabInstance to gitlab.com', () => {
+    const result = reconcileComponentSource(dynamicComponent(), [
+      { name: configuredSource.name, path: configuredSource.path },
+    ]);
+    assert.equal(result.source, 'yulife-devops-shared-config');
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes a **phantom top-level source group** in the Component Browser. Hovering a tag-pinned component that isn't already cached triggers a dynamic fetch; the fetched cache entry was labelled with a synthesized `source` of `` `${gitlabInstance}/${projectPath}` `` (e.g. `gitlab.com/yu-life/infrastructure/yulife-devops-shared-config`) instead of the configured source's display name. Since the browser groups by `source.split('/')[0]`, this created a duplicate `gitlab.com` group alongside the real source, with the component showing no description, a raw unstripped tag (`markdown-lint-1`), and no version dropdown.
- **New pure helper** (`src/services/cache/sourceReconciliation.ts`): `reconcileComponentSource(component, sources)` matches a fetched component against the configured sources by `gitlabInstance` + `sourcePath` and, on a match, adopts the source's display `name` and fills in its `tagPattern` (a `tagPattern` already on the component wins). No match returns the component unchanged. Instance comparison normalizes a leading `https?://` and defaults an unset `gitlabInstance` to `gitlab.com`.
- **Wired into the single cache-write chokepoint**: `ComponentCacheManager.addDynamicComponent` reads `componentSources` and runs the reconciliation before dedup, so **both** dynamic-fetch call sites in `componentDetector.ts` (specific-version fetch and catalog-fallback fetch) are covered, plus any future callers.
- Adds `tagPattern?` to the `ComponentSource` type (`src/types/api.ts`) so the config shape is typed at the read site.
- Link related issue(s): Fixes #229 

## Change Type
- [ ] feat
- [x] fix
- [ ] refactor
- [ ] docs
- [x] test
- [ ] chore

## Context
### User-facing impact
- After hovering a tag-pinned component belonging to a configured source, the entry now merges into that source's group instead of spawning a duplicate `gitlab.com` top-level group.
- Because the merged entry inherits the source's `tagPattern`, its version discovery scopes/strips correctly (e.g. `1` rather than the raw `markdown-lint-1`).
- No change for hovers on projects outside any configured source, or for ordinary single-component sources.
- **Existing caches**: the fix prevents new phantom entries but does not retroactively relabel an entry already persisted from a previous session. `CURRENT_CACHE_VERSION` is not bumped, so users with the phantom group must **Reset Cache** (or Refresh) once. (Open question for review — see Risk/Rollback.)

### GitLab scope
- [ ] gitlab.com
- [ ] self-managed GitLab
- [x] both (matching logic is instance-independent)

### Affected areas
- [x] Component Browser
- [x] Hover provider
- [ ] Completion provider
- [ ] Validation provider
- [x] Cache and refresh behavior
- [ ] GitLab API calls/auth/token storage
- [ ] Docs only

## Validation
### Local checks
- [x] `npm run compile`
- [x] `npm test` or targeted tests
- [ ] Manual verification in VS Code Extension Host

New unit tests in `tests/unit/sourceReconciliation.test.ts` cover: name adoption on an instance+path match; `tagPattern` fill vs. preserve precedence; no-match passthrough; cross-instance non-match; `https://`-prefix normalization; and default-to-`gitlab.com` when a source omits `gitlabInstance`. Full suite: 336 passing.

## Breaking Changes
- [x] No breaking changes

The added `tagPattern?` field on `ComponentSource` is additive and optional. No settings or persisted-cache shape changes.

## Risk and Rollback
- Main risks:
  - Low. The reconciliation only rewrites `source`/`tagPattern` on entries that positively match a configured source; unmatched entries are untouched.
- Stale caches: existing persisted phantom entries are not migrated. Options for review: (a) accept a one-time manual **Reset Cache**, or (b) bump `CURRENT_CACHE_VERSION` so old caches self-invalidate on upgrade. This PR takes (a); happy to switch to (b) if preferred.
- Rollback strategy: revert the PR. No data migration; the settings/cache shapes are unchanged.

## Release Notes Draft
- Fixed hover-fetched components appearing as a duplicate top-level `gitlab.com` group in the Component Browser; they now merge into their configured source and inherit its tag pattern.

## Checklist
- [x] Branch is up to date with target branch
- [x] Commit messages follow conventional commits
- [ ] Added/updated docs for behavior or settings changes
- [x] Added/updated tests for new behavior
- [x] No secrets or tokens in code, logs, screenshots, or test fixtures
