### PR TITLE
fix(links): show component links on first view

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -116,12 +116,14 @@ export function activate(context: vscode.ExtensionContext) {
     // Register document link provider so `component:` URLs (including those using GitLab variables like
     // $CI_SERVER_FQDN) become clickable and point at the GitLab project tree at the requested ref.
     logger.debug('[Extension] Registering document link provider...', 'Extension');
+    const documentLinkProvider = new ComponentDocumentLinkProvider();
     context.subscriptions.push(
+      documentLinkProvider,
       vscode.languages.registerDocumentLinkProvider(
         [
           { language: 'yaml' }
         ],
-        new ComponentDocumentLinkProvider()
+        documentLinkProvider
       )
     );
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -70,6 +70,7 @@ export function activate(context: vscode.ExtensionContext) {
     let cacheManager: ComponentCacheManager;
     try {
       cacheManager = getComponentCacheManager(context);
+      context.subscriptions.push(cacheManager);
       logger.info(`[Extension] Component cache manager initialized successfully`, 'Extension');
     } catch (cacheError) {
       logger.error(`[Extension] ERROR initializing cache manager: ${cacheError}`, 'Extension');
@@ -126,6 +127,8 @@ export function activate(context: vscode.ExtensionContext) {
         documentLinkProvider
       )
     );
+    // Fire the initial refresh after registration.
+    queueMicrotask(() => documentLinkProvider.refresh());
 
     // Register command to add project/group token
     logger.debug('[Extension] Registering addProjectToken command...', 'Extension');

--- a/src/providers/documentLinkProvider.ts
+++ b/src/providers/documentLinkProvider.ts
@@ -21,11 +21,14 @@ export class ComponentDocumentLinkProvider implements vscode.DocumentLinkProvide
   private readonly cacheSubscription: vscode.Disposable;
 
   constructor() {
-    // Re-request links whenever the cache changes. Fire once up front too, so an editor already open at registration
-    // re-requests against the current cache rather than keeping the (possibly empty) result from its first render.
     this.cacheSubscription = getComponentCacheManager().onDidChangeComponents(() => {
       this._onDidChangeLinks.fire();
     });
+  }
+
+  // Re-request links against the current cache. Call after registration so an editor already open at activation
+  // re-requests instead of keeping the (possibly empty) result from its first render.
+  public refresh(): void {
     this._onDidChangeLinks.fire();
   }
 

--- a/src/providers/documentLinkProvider.ts
+++ b/src/providers/documentLinkProvider.ts
@@ -9,9 +9,30 @@ import { isGitLabCIFile } from '../utils/gitlabCiFileMatcher';
 
 const COMPONENT_LINE = /^(\s*-?\s*component:\s*)(\S+)/;
 
-export class ComponentDocumentLinkProvider implements vscode.DocumentLinkProvider {
+export class ComponentDocumentLinkProvider implements vscode.DocumentLinkProvider, vscode.Disposable {
   private logger = Logger.getInstance();
   private urlParser = new UrlParser();
+
+  // VS Code requests links once per document render and caches the result, re-asking only when the document changes or
+  // this event fires. Without it, links resolved from the async cache never appear on first view — they only show up
+  // after the first edit. We fire it when the component cache is populated/updated so VS Code re-requests then.
+  private readonly _onDidChangeLinks = new vscode.EventEmitter<void>();
+  public readonly onDidChangeLinks = this._onDidChangeLinks.event;
+  private readonly cacheSubscription: vscode.Disposable;
+
+  constructor() {
+    // Re-request links whenever the cache changes. Fire once up front too, so an editor already open at registration
+    // re-requests against the current cache rather than keeping the (possibly empty) result from its first render.
+    this.cacheSubscription = getComponentCacheManager().onDidChangeComponents(() => {
+      this._onDidChangeLinks.fire();
+    });
+    this._onDidChangeLinks.fire();
+  }
+
+  public dispose(): void {
+    this.cacheSubscription.dispose();
+    this._onDidChangeLinks.dispose();
+  }
 
   public async provideDocumentLinks(
     document: vscode.TextDocument,

--- a/src/services/cache/componentCacheManager.ts
+++ b/src/services/cache/componentCacheManager.ts
@@ -36,6 +36,12 @@ export class ComponentCacheManager {
   private sourceErrors: Map<string, string> = new Map();
   private context: vscode.ExtensionContext | null = null;
 
+  // Fires whenever the in-memory component list is populated or changes. Consumers that render from the cache (e.g. the
+  // document link provider) subscribe so they can re-request once the cache is ready — VS Code caches a provider's
+  // result and won't re-ask on its own until the document changes.
+  private readonly _onDidChangeComponents = new vscode.EventEmitter<void>();
+  public readonly onDidChangeComponents = this._onDidChangeComponents.event;
+
   // Specialized cache modules
   private projectCache: ProjectCache;
   private versionCache: VersionCache;
@@ -143,6 +149,8 @@ export class ComponentCacheManager {
       // Persist so dynamically fetched entries (and their freshness fields) survive across sessions instead of being
       // re-resolved on next launch. Fire-and-forget — a failed save only costs a re-fetch, never correctness.
       this.persistComponentState();
+
+      this.notifyComponentsChanged();
     } catch (error) {
       this.logger.debug(
         `[ComponentCache] Error adding dynamic component: ${error}`,
@@ -160,6 +168,10 @@ export class ComponentCacheManager {
     this.saveCacheToDisk().catch(error => {
       this.logger.debug(`[ComponentCache] Failed to persist component state: ${error}`, 'ComponentCache');
     });
+  }
+
+  private notifyComponentsChanged(): void {
+    this._onDidChangeComponents.fire();
   }
 
   public getSourceErrors(): Map<string, string> {
@@ -331,6 +343,8 @@ export class ComponentCacheManager {
 
       // Save updated cache to disk
       await this.saveCacheToDisk();
+
+      this.notifyComponentsChanged();
     } catch (error) {
       this.logger.error(`[ComponentCache] Error during refresh: ${error}`, 'ComponentCache');
     } finally {
@@ -464,6 +478,7 @@ export class ComponentCacheManager {
         'ComponentCache'
       );
       this.logger.debug(`[ComponentCache] Cache location: ${cacheInfo.location}`, 'ComponentCache');
+      this.notifyComponentsChanged();
       return;
     }
 

--- a/src/services/cache/componentCacheManager.ts
+++ b/src/services/cache/componentCacheManager.ts
@@ -6,6 +6,7 @@ import { CachedComponent, PersistentCacheData } from '../../types/cache';
 import { ProjectCache } from './projectCache';
 import { VersionCache } from './versionCache';
 import { GroupCache } from './groupCache';
+import { sameCachedComponent } from '../../utils/cachedComponentEquality';
 import {
   CACHE_LOCATION_GLOBAL_STATE,
   CACHE_LOCATION_MEMORY_ONLY,
@@ -27,7 +28,7 @@ const CURRENT_CACHE_VERSION = '1.3.0';
  * - Track source errors
  * - Provide singleton access pattern
  */
-export class ComponentCacheManager {
+export class ComponentCacheManager implements vscode.Disposable {
   private logger = Logger.getInstance();
   private performanceMonitor = getPerformanceMonitor();
   private components: CachedComponent[] = [];
@@ -35,12 +36,14 @@ export class ComponentCacheManager {
   private refreshInProgress = false;
   private sourceErrors: Map<string, string> = new Map();
   private context: vscode.ExtensionContext | null = null;
+  private readonly disposables: vscode.Disposable[] = [];
 
   // Fires whenever the in-memory component list is populated or changes. Consumers that render from the cache (e.g. the
   // document link provider) subscribe so they can re-request once the cache is ready — VS Code caches a provider's
   // result and won't re-ask on its own until the document changes.
   private readonly _onDidChangeComponents = new vscode.EventEmitter<void>();
   public readonly onDidChangeComponents = this._onDidChangeComponents.event;
+  private changeNotificationScheduled = false;
 
   // Specialized cache modules
   private projectCache: ProjectCache;
@@ -71,20 +74,27 @@ export class ComponentCacheManager {
     });
 
     // Listen for configuration changes to refresh cache
-    vscode.workspace.onDidChangeConfiguration(e => {
-      if (e.affectsConfiguration('gitlabComponentHelper.componentSources')) {
-        this.logger.debug(
-          '[ComponentCache] Configuration changed, forcing refresh...',
-          'ComponentCache'
-        );
-        this.forceRefresh().catch(error => {
+    this.disposables.push(
+      vscode.workspace.onDidChangeConfiguration(e => {
+        if (e.affectsConfiguration('gitlabComponentHelper.componentSources')) {
           this.logger.debug(
-            `[ComponentCache] Error during config refresh: ${error}`,
+            '[ComponentCache] Configuration changed, forcing refresh...',
             'ComponentCache'
           );
-        });
-      }
-    });
+          this.forceRefresh().catch(error => {
+            this.logger.debug(
+              `[ComponentCache] Error during config refresh: ${error}`,
+              'ComponentCache'
+            );
+          });
+        }
+      })
+    );
+  }
+
+  public dispose(): void {
+    this._onDidChangeComponents.dispose();
+    this.disposables.forEach(d => d.dispose());
   }
 
   /**
@@ -130,8 +140,11 @@ export class ComponentCacheManager {
           comp.version === component.version
       );
 
+      let changed: boolean;
       if (existingIndex >= 0) {
-        // Update existing component
+        // Update existing component. Skip notifying when nothing link-relevant changed — validation re-adds the same
+        // entries on every open/change/save, and an unconditional fire would thrash the link provider.
+        changed = !sameCachedComponent(this.components[existingIndex], component);
         this.components[existingIndex] = component;
         this.logger.debug(
           `[ComponentCache] Updated existing dynamic component: ${component.name}@${component.version}`,
@@ -139,6 +152,7 @@ export class ComponentCacheManager {
         );
       } else {
         // Add new component
+        changed = true;
         this.components.push(component);
         this.logger.debug(
           `[ComponentCache] Added new dynamic component: ${component.name}@${component.version} from ${component.gitlabInstance}/${component.sourcePath}`,
@@ -150,7 +164,9 @@ export class ComponentCacheManager {
       // re-resolved on next launch. Fire-and-forget — a failed save only costs a re-fetch, never correctness.
       this.persistComponentState();
 
-      this.notifyComponentsChanged();
+      if (changed) {
+        this.notifyComponentsChanged();
+      }
     } catch (error) {
       this.logger.debug(
         `[ComponentCache] Error adding dynamic component: ${error}`,
@@ -170,8 +186,17 @@ export class ComponentCacheManager {
     });
   }
 
+  // Coalesce a burst of mutations (e.g. a refresh adding many components, or a validation pass re-adding several) into a
+  // single emission on the next microtask, so consumers re-request once rather than once per component.
   private notifyComponentsChanged(): void {
-    this._onDidChangeComponents.fire();
+    if (this.changeNotificationScheduled) {
+      return;
+    }
+    this.changeNotificationScheduled = true;
+    queueMicrotask(() => {
+      this.changeNotificationScheduled = false;
+      this._onDidChangeComponents.fire();
+    });
   }
 
   public getSourceErrors(): Map<string, string> {

--- a/src/utils/cachedComponentEquality.ts
+++ b/src/utils/cachedComponentEquality.ts
@@ -1,0 +1,22 @@
+import { CachedComponent } from '../types/cache';
+
+/**
+ * Whether two cache entries are equivalent for the purposes of the cache's change notification. Callers pass entries
+ * already matched on identity (name/sourcePath/gitlabInstance/version), so this compares the remaining fields that
+ * consumers render from — chiefly `templatePath`, which the document link provider gates on. Used to suppress the
+ * no-op re-adds that validation performs on every open/change/save, which would otherwise thrash the link provider.
+ *
+ * @param a One cache entry.
+ * @param b The other cache entry, already identity-matched against `a`.
+ * @returns `true` when the render-relevant fields match (so the re-add is a no-op), `false` when any differ.
+ */
+export function sameCachedComponent(a: CachedComponent, b: CachedComponent): boolean {
+  return (
+    a.templatePath === b.templatePath &&
+    a.url === b.url &&
+    a.source === b.source &&
+    a.tagPattern === b.tagPattern &&
+    a.resolvedSha === b.resolvedSha &&
+    JSON.stringify(a.availableVersions) === JSON.stringify(b.availableVersions)
+  );
+}

--- a/tests/unit/cachedComponentEquality.test.ts
+++ b/tests/unit/cachedComponentEquality.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Tests src/utils/cachedComponentEquality.ts — the no-op guard the cache manager uses to decide whether re-adding an
+ * (already identity-matched) dynamic component should fire its change notification.
+ *
+ * Regression coverage for the event-storm bug: validation re-adds identical entries on every open/change/save, and an
+ * unconditional fire would re-request document links O(N) times per pass. `sameCachedComponent` returning true for an
+ * identical re-add is what suppresses that.
+ */
+
+import * as assert from 'node:assert/strict';
+import { sameCachedComponent } from '../../src/utils/cachedComponentEquality';
+import type { CachedComponent } from '../../src/types/cache';
+
+const base: CachedComponent = {
+  name: 'deploy',
+  description: 'deploy component',
+  parameters: [],
+  source: 'my-source',
+  sourcePath: 'group/project',
+  gitlabInstance: 'gitlab.com',
+  version: '1.0.0',
+  url: 'https://gitlab.com/group/project',
+  templatePath: 'templates/deploy.yml',
+  availableVersions: ['1.0.0', '1.1.0'],
+  tagPattern: '{name}-{version}',
+  resolvedSha: 'abc123',
+};
+
+const clone = (overrides: Partial<CachedComponent> = {}): CachedComponent => ({ ...base, ...overrides });
+
+suite('sameCachedComponent', () => {
+  test('an identical re-add is equal (suppresses the fire)', () => {
+    assert.equal(sameCachedComponent(base, clone()), true);
+  });
+
+  test('ignores fields it does not compare (description, parameters)', () => {
+    // These are not link-relevant; a change to them alone must not force a re-request.
+    assert.equal(
+      sameCachedComponent(base, clone({ description: 'changed', parameters: [{ name: 'x', description: '', required: false, type: 'string' }] })),
+      true
+    );
+  });
+
+  test('a changed templatePath is a real change (must fire)', () => {
+    assert.equal(sameCachedComponent(base, clone({ templatePath: 'templates/other.yml' })), false);
+  });
+
+  test('templatePath appearing where there was none is a real change', () => {
+    assert.equal(sameCachedComponent(clone({ templatePath: undefined }), base), false);
+  });
+
+  test('a changed url is a real change', () => {
+    assert.equal(sameCachedComponent(base, clone({ url: 'https://gitlab.com/other' })), false);
+  });
+
+  test('a changed source (reconciled group name) is a real change', () => {
+    assert.equal(sameCachedComponent(base, clone({ source: 'other-source' })), false);
+  });
+
+  test('a changed tagPattern is a real change', () => {
+    assert.equal(sameCachedComponent(base, clone({ tagPattern: 'v{version}' })), false);
+  });
+
+  test('a moved branch HEAD (resolvedSha) is a real change', () => {
+    assert.equal(sameCachedComponent(base, clone({ resolvedSha: 'def456' })), false);
+  });
+
+  test('a changed availableVersions list is a real change', () => {
+    assert.equal(sameCachedComponent(base, clone({ availableVersions: ['1.0.0'] })), false);
+  });
+
+  test('availableVersions order matters (list identity, not set)', () => {
+    assert.equal(sameCachedComponent(base, clone({ availableVersions: ['1.1.0', '1.0.0'] })), false);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes `component:` links being absent when a GitLab CI file is first viewed — they previously only appeared after the first edit, even with a populated cache.
- The document link provider resolves links asynchronously from the component cache but never implemented VS Code's optional `onDidChangeLinks` event. VS Code requests links once per document render, caches the result, and re-requests only on a document change or when `onDidChangeLinks` fires. With no change event, the first-render result stuck until the first edit forced a re-request.
- Adds an `onDidChangeComponents` event to the cache manager, fired whenever the in-memory component list is populated/changed; the provider subscribes and re-fires its own `onDidChangeLinks` so VS Code re-requests once the cache is ready.
- The provider also fires an initial refresh *after* registration (a fire before VS Code has subscribed is discarded), so an editor already open at activation re-requests against the current cache.
- The cache event is coalesced onto a microtask and suppressed on no-op re-adds, so a validation pass (which re-adds every include's component on each open/change/save) triggers at most one re-request instead of one per component.
- Link related issue(s): Fixes #231

## Change Type
- [ ] feat
- [x] fix
- [ ] refactor
- [ ] docs
- [ ] test

## Context
### User-facing impact
- Clickable component links now appear as soon as a GitLab CI file is rendered, without needing to edit the file first.

### GitLab scope
- [ ] gitlab.com
- [ ] self-managed GitLab
- [x] both (local link-refresh scheduling only; no GitLab interaction)

### Affected areas
- [ ] Component Browser
- [ ] Hover provider
- [ ] Completion provider
- [ ] Validation provider
- [x] Cache and refresh behavior
- [ ] GitLab API calls/auth/token storage
- [ ] Docs only

## What changed by bucket

| Bucket | Files | Approach |
|---|---|---|
| Cache change event | [componentCacheManager.ts](../src/services/cache/componentCacheManager.ts) | Added an `onDidChangeComponents` `EventEmitter` and a private `notifyComponentsChanged()` helper, fired at every point the in-memory list is populated/changed: the valid-disk-cache early return in `initializeCache` (the first-view "already populated" path), the end of `refreshComponentsInternal`, and `addDynamicComponent`. `notifyComponentsChanged()` coalesces a burst of mutations into one emission via `queueMicrotask`; `addDynamicComponent` skips the fire when nothing link-relevant changed. Manager is now `Disposable` — disposes the emitter and the (previously un-disposed) config-change subscription. |
| No-op guard | [cachedComponentEquality.ts](../src/utils/cachedComponentEquality.ts) | `sameCachedComponent` — pure comparison of the render-relevant fields of two already-identity-matched entries. Extracted to a vscode-free util so it is unit-testable. |
| Link refresh | [documentLinkProvider.ts](../src/providers/documentLinkProvider.ts) | Provider now exposes `onDidChangeLinks`, subscribes to `onDidChangeComponents` to re-fire it, and exposes `refresh()` (called after registration) so an already-open editor re-requests against the current cache. Provider is now `Disposable` and cleans up its subscription and emitter. |
| Registration + initial fire | [extension.ts](../src/extension.ts) | Register the provider and cache manager in `context.subscriptions` so their `dispose()` runs on deactivation. Call `documentLinkProvider.refresh()` via `queueMicrotask` *after* `registerDocumentLinkProvider`, so the initial fire lands once VS Code has subscribed rather than being discarded. |
| Unit test | [cachedComponentEquality.test.ts](../tests/unit/cachedComponentEquality.test.ts) | Covers the no-op guard: an identical re-add is equal (suppresses the fire); a change to `templatePath`/`url`/`source`/`tagPattern`/`resolvedSha`/`availableVersions` is a real change; non-link fields are ignored. |

## Validation
### Local checks
- [x] `npm run compile` (`tsc --noEmit` clean)
- [x] `npm test` (339 passing, incl. the new no-op-guard suite)
- [x] `npm run test:extension-host` (20 passing)
- [x] `npm run lint` clean

### Manual test notes
- Reproduced with a populated cache: opening a `.gitlab-ci.yml` showed no link on the `component:` line until the first edit. After the fix, the link appears on first render.

## Breaking Changes
- [x] No breaking changes
- [ ] Breaking changes (describe below)
