### PR TITLE
feat: derive component descriptions from README when none is declared

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 - **Component Browser** — explore and insert components from any GitLab project or group
 - **Smart Completion** — context-aware suggestions for components and versions as you type
-- **Hover Docs** — full documentation and parameter hints inline
+- **Hover Docs** — full documentation and parameter hints inline; when a component declares no description, its README's opening lines stand in
 - **Input Validation** — real-time checking of component inputs, with Quick Fix suggestions
 - **Local Includes** — the same hover, completion, and validation for `include: - local:` entries that declare a `spec.inputs` block
 - **Version Picker & Upgrade Hints** — pick the right tag, and get flagged when a pinned semver falls behind (with one-click updates)
@@ -120,6 +120,8 @@ Add spec-compliant header comments to the top of a template to surface consisten
 ```
 
 The short prefix `# @gch:` works too. Headers must appear before any non-comment content; multiple `note` lines are allowed, and the section stays hidden if no header is present. Component details also include a **Raw YAML** toggle for inspecting the original template.
+
+When a component or project has no description of its own, the Component Browser and hover fall back to the opening paragraph of its `README.md` — checked alongside the template first, then at the repository root — so the details panel is never left blank.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Add spec-compliant header comments to the top of a template to surface consisten
 
 The short prefix `# @gch:` works too. Headers must appear before any non-comment content; multiple `note` lines are allowed, and the section stays hidden if no header is present. Component details also include a **Raw YAML** toggle for inspecting the original template.
 
-When a component or project has no description of its own, the Component Browser and hover fall back to the opening paragraph of its `README.md` — checked alongside the template first, then at the repository root — so the details panel is never left blank.
+When a component or project has no description of its own, the Component Browser and hover fall back to the opening paragraph of its `README.md` — checked alongside the template first, then at the repository root.
 
 ---
 

--- a/src/providers/componentBrowserProvider.ts
+++ b/src/providers/componentBrowserProvider.ts
@@ -9,6 +9,7 @@ import type { HoverContext } from './hoverContentBuilder';
 import { containsGitLabVariables } from '../utils/gitlabVariables';
 import { Logger } from '../utils/logger';
 import { templateFileUrlForResolved } from '../utils/templateFileUrl';
+import { escapeHtml, renderInlineMarkdown } from '../webview/inlineMarkdown';
 import { generateComponentText } from './componentBrowserGenerate';
 import { findComponentLineRange, parseExistingComponentText } from './componentBrowserEdit';
 import { transformCachedComponentsToGroups } from './componentBrowserTransform';
@@ -243,7 +244,7 @@ export class ComponentBrowserProvider {
             if (catalogData && catalogData.components && catalogData.components.length > 0) {
               const components = catalogData.components.map((c: GitLabCatalogComponent) => ({
                 name: c.name,
-                description: c.description || `Component from ${contextPath}`,
+                description: c.description || '',
                 summary: c.summary,
                 usage: c.usage,
                 notes: c.notes,
@@ -741,7 +742,7 @@ export class ComponentBrowserProvider {
               const hasVersions = component.availableVersions && component.availableVersions.length > 0;
 
               return `
-              <div class="component-card" data-name="${component.name}" data-description="${component.description}" data-component-name="${component.name}" data-project-id="${projectId}" data-source-path="${component.sourcePath}" data-gitlab-instance="${component.gitlabInstance}" id="component-${componentKey}">
+              <div class="component-card" data-name="${component.name}" data-description="${this.escapeHtml(component.description || '')}" data-component-name="${component.name}" data-project-id="${projectId}" data-source-path="${component.sourcePath}" data-gitlab-instance="${component.gitlabInstance}" id="component-${componentKey}">
                 <div class="component-header">
                   <span class="component-title">
                     ${component.name}
@@ -762,7 +763,7 @@ export class ComponentBrowserProvider {
                     `}
                   </div>
                 </div>
-                <div class="component-description" id="desc-${component.name}-${projectId}">${component.description}</div>
+                <div class="component-description" id="desc-${component.name}-${projectId}">${this.renderInlineMarkdown(component.description || '')}</div>
                 ${hasVersions && component.availableVersions.length > 1 ? `
                   <div class="version-info" id="version-info-${component.name}-${projectId}">
                     <small>Default version: ${component.defaultVersion}</small>
@@ -1134,6 +1135,8 @@ export class ComponentBrowserProvider {
         <script>
           const vscode = acquireVsCodeApi();
 
+          ${this.clientRenderInlineMarkdownSource()}
+
           // Inject component version data for client-side version switching
           window.componentVersionData = ${versionDataJson};
 
@@ -1284,7 +1287,7 @@ export class ComponentBrowserProvider {
             // Update the description
             const descElement = document.getElementById('desc-' + componentName + '-' + projectId);
             if (descElement) {
-              descElement.textContent = versionData.description;
+              descElement.innerHTML = renderInlineMarkdown(versionData.description);
             }
 
             // Update version info
@@ -1847,21 +1850,7 @@ export class ComponentBrowserProvider {
           let currentVersions = ${JSON.stringify(availableVersions)};
           let versionsLoaded = ${availableVersions.length > 1};
 
-          // Render a single-paragraph description with inline Markdown (links, bold, italic, code). HTML is
-          // escaped first so nothing in the source can inject markup; only the patterns below re-introduce tags.
-          // Patterns use new RegExp(...) so their escaping isn't mangled by this webview HTML template literal.
-          function renderInlineMarkdown(text) {
-            const escaped = String(text || '')
-              .replace(new RegExp('&', 'g'), '&amp;')
-              .replace(new RegExp('<', 'g'), '&lt;')
-              .replace(new RegExp('>', 'g'), '&gt;')
-              .replace(new RegExp('"', 'g'), '&quot;');
-            return escaped
-              .replace(new RegExp('\`([^\`]+)\`', 'g'), '<code>$1</code>')
-              .replace(new RegExp('\\[([^\\]]+)\\]\\((https?://[^\\s)]+)\\)', 'g'), '<a href="$2">$1</a>')
-              .replace(new RegExp('\\*\\*([^*]+)\\*\\*', 'g'), '<strong>$1</strong>')
-              .replace(new RegExp('(^|[^*])\\*([^*]+)\\*', 'g'), '$1<em>$2</em>');
-          }
+          ${this.clientRenderInlineMarkdownSource()}
 
           function insertComponent() {
             const selectedVersion = document.getElementById('versionSelect').value;
@@ -2197,27 +2186,35 @@ export class ComponentBrowserProvider {
   }
 
   private escapeHtml(value: string): string {
-    return value
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;')
-      .replace(/'/g, '&#39;');
+    return escapeHtml(value);
+  }
+
+  private renderInlineMarkdown(value: string): string {
+    return renderInlineMarkdown(value);
   }
 
   /**
-   * Render a single-paragraph description with inline Markdown (links, bold, italic, code). Escapes HTML
-   * first so the source can't inject markup; only these patterns re-introduce tags. `http(s)` links only.
-   *
-   * @param value The raw description text (may contain inline Markdown).
-   * @returns     HTML-safe markup with inline Markdown converted to `<a>`/`<code>`/`<strong>`/`<em>` tags.
+   * Source for the client-side twin of {@link renderInlineMarkdown}, injected into every webview `<script>`
+   * that renders a description so all render paths escape and format identically. Kept as one string (not
+   * duplicated per script) so the twins can't drift. `new RegExp(...)` avoids the webview HTML template
+   * literal mangling the pattern escaping; the escape set (incl. `'`) mirrors the server `escapeHtml`.
    */
-  private renderInlineMarkdown(value: string): string {
-    return this.escapeHtml(value)
-      .replace(/`([^`]+)`/g, '<code>$1</code>')
-      .replace(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g, '<a href="$2">$1</a>')
-      .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
-      .replace(/(^|[^*])\*([^*]+)\*/g, '$1<em>$2</em>');
+  private clientRenderInlineMarkdownSource(): string {
+    return `
+      function renderInlineMarkdown(text) {
+        const escaped = String(text || '')
+          .replace(new RegExp('&', 'g'), '&amp;')
+          .replace(new RegExp('<', 'g'), '&lt;')
+          .replace(new RegExp('>', 'g'), '&gt;')
+          .replace(new RegExp('"', 'g'), '&quot;')
+          .replace(new RegExp("'", 'g'), '&#39;');
+        return escaped
+          .replace(new RegExp('\`([^\`]+)\`', 'g'), '<code>$1</code>')
+          .replace(new RegExp('\\[([^\\]]+)\\]\\((https?://[^\\s)]+)\\)', 'g'), '<a href="$2">$1</a>')
+          .replace(new RegExp('\\*\\*([^*]+)\\*\\*', 'g'), '<strong>$1</strong>')
+          .replace(new RegExp('(^|[^*])\\*([^*]+)\\*', 'g'), '$1<em>$2</em>');
+      }
+    `;
   }
 
   private buildTemplateFileUrl(component: Component): string | undefined {

--- a/src/providers/componentBrowserProvider.ts
+++ b/src/providers/componentBrowserProvider.ts
@@ -10,6 +10,7 @@ import { containsGitLabVariables } from '../utils/gitlabVariables';
 import { Logger } from '../utils/logger';
 import { templateFileUrlForResolved } from '../utils/templateFileUrl';
 import { escapeHtml, renderInlineMarkdown } from '../webview/inlineMarkdown';
+import { serializeForScript } from '../webview/scriptData';
 import { generateComponentText } from './componentBrowserGenerate';
 import { findComponentLineRange, parseExistingComponentText } from './componentBrowserEdit';
 import { transformCachedComponentsToGroups } from './componentBrowserTransform';
@@ -705,7 +706,7 @@ export class ComponentBrowserProvider {
       return acc;
     }, {});
 
-    const versionDataJson = JSON.stringify(versionData);
+    const versionDataJson = serializeForScript(versionData);
 
     // Build error section HTML
     const hasAuthError = Object.values(cacheErrors).some(error => this.classifySourceError(error).isAuth);
@@ -1847,7 +1848,7 @@ export class ComponentBrowserProvider {
 
         <script>
           const vscode = acquireVsCodeApi();
-          let currentVersions = ${JSON.stringify(availableVersions)};
+          let currentVersions = ${serializeForScript(availableVersions)};
           let versionsLoaded = ${availableVersions.length > 1};
 
           ${this.clientRenderInlineMarkdownSource()}

--- a/src/providers/componentBrowserProvider.ts
+++ b/src/providers/componentBrowserProvider.ts
@@ -1736,7 +1736,7 @@ export class ComponentBrowserProvider {
         <h1 id="componentName">${component.name}</h1>
 
         <div class="description" id="componentDescription">
-          ${component.description}
+          ${this.renderInlineMarkdown(component.description || '')}
         </div>
 
         <div class="metadata" id="componentContext" style="display: ${hasContext ? 'block' : 'none'};">
@@ -1847,6 +1847,22 @@ export class ComponentBrowserProvider {
           let currentVersions = ${JSON.stringify(availableVersions)};
           let versionsLoaded = ${availableVersions.length > 1};
 
+          // Render a single-paragraph description with inline Markdown (links, bold, italic, code). HTML is
+          // escaped first so nothing in the source can inject markup; only the patterns below re-introduce tags.
+          // Patterns use new RegExp(...) so their escaping isn't mangled by this webview HTML template literal.
+          function renderInlineMarkdown(text) {
+            const escaped = String(text || '')
+              .replace(new RegExp('&', 'g'), '&amp;')
+              .replace(new RegExp('<', 'g'), '&lt;')
+              .replace(new RegExp('>', 'g'), '&gt;')
+              .replace(new RegExp('"', 'g'), '&quot;');
+            return escaped
+              .replace(new RegExp('\`([^\`]+)\`', 'g'), '<code>$1</code>')
+              .replace(new RegExp('\\[([^\\]]+)\\]\\((https?://[^\\s)]+)\\)', 'g'), '<a href="$2">$1</a>')
+              .replace(new RegExp('\\*\\*([^*]+)\\*\\*', 'g'), '<strong>$1</strong>')
+              .replace(new RegExp('(^|[^*])\\*([^*]+)\\*', 'g'), '$1<em>$2</em>');
+          }
+
           function insertComponent() {
             const selectedVersion = document.getElementById('versionSelect').value;
             const includeInputs = document.getElementById('includeInputs')?.checked || false;
@@ -1944,7 +1960,7 @@ export class ComponentBrowserProvider {
             document.getElementById('componentName').textContent = component.name;
 
             // Update description
-            document.getElementById('componentDescription').textContent = component.description || 'No description available';
+            document.getElementById('componentDescription').innerHTML = renderInlineMarkdown(component.description || '');
 
             // Update context section (summary/usage/notes) from spec-compliant header comments
             const contextContainer = document.getElementById('componentContext');
@@ -2187,6 +2203,21 @@ export class ComponentBrowserProvider {
       .replace(/>/g, '&gt;')
       .replace(/"/g, '&quot;')
       .replace(/'/g, '&#39;');
+  }
+
+  /**
+   * Render a single-paragraph description with inline Markdown (links, bold, italic, code). Escapes HTML
+   * first so the source can't inject markup; only these patterns re-introduce tags. `http(s)` links only.
+   *
+   * @param value The raw description text (may contain inline Markdown).
+   * @returns     HTML-safe markup with inline Markdown converted to `<a>`/`<code>`/`<strong>`/`<em>` tags.
+   */
+  private renderInlineMarkdown(value: string): string {
+    return this.escapeHtml(value)
+      .replace(/`([^`]+)`/g, '<code>$1</code>')
+      .replace(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g, '<a href="$2">$1</a>')
+      .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
+      .replace(/(^|[^*])\*([^*]+)\*/g, '$1<em>$2</em>');
   }
 
   private buildTemplateFileUrl(component: Component): string | undefined {

--- a/src/providers/componentBrowserTransform.ts
+++ b/src/providers/componentBrowserTransform.ts
@@ -171,7 +171,7 @@ export function transformCachedComponentsToGroups(
     if (!componentGroup) {
       componentGroup = {
         name: comp.name,
-        description: comp.description || 'No description available',
+        description: comp.description || '',
         summary: comp.summary,
         usage: comp.usage,
         notes: comp.notes,
@@ -196,7 +196,7 @@ export function transformCachedComponentsToGroups(
 
     componentGroup.versions.set(comp.version || 'latest', {
       version: comp.version || 'latest',
-      description: comp.description || 'No description available',
+      description: comp.description || '',
       summary: comp.summary,
       usage: comp.usage,
       notes: comp.notes,
@@ -229,7 +229,7 @@ export function transformCachedComponentsToGroups(
           const versionData = component.versions.get(version);
           return {
             version,
-            description: versionData?.description || component.description || 'No description available',
+            description: versionData?.description || component.description || '',
             summary: versionData?.summary || component.summary,
             usage: versionData?.usage || component.usage,
             notes: versionData?.notes || component.notes,
@@ -256,7 +256,7 @@ export function transformCachedComponentsToGroups(
           versionCount: availableVersions.filter(Boolean).length,
           defaultVersion,
           availableVersions: availableVersions.filter(Boolean),
-          description: component.description || 'No description available',
+          description: component.description || '',
           parameters: component.parameters || [],
           gitlabInstance: component.gitlabInstance || 'gitlab.com',
         };

--- a/src/providers/componentDetector.ts
+++ b/src/providers/componentDetector.ts
@@ -97,7 +97,6 @@ export interface Component {
   version?: string;
   source?: string;
   documentationUrl?: string;
-  readme?: string; // Add README content as separate field
   url?: string; // Component URL
   gitlabInstance?: string; // GitLab instance
   sourcePath?: string; // Source path
@@ -326,8 +325,6 @@ export async function detectIncludeComponent(document: vscode.TextDocument, posi
     if (cachedComponent) {
       logger.debug(`[ComponentDetector] Found matching component in cache: ${cachedComponent.name}`, 'ComponentDetector');
       logger.debug(`[ComponentDetector] Cached version: ${cachedComponent.version}, Requested version: ${requestedVersion || 'unspecified'}`, 'ComponentDetector');
-      logger.debug(`[ComponentDetector] Cached component has README: ${!!cachedComponent.readme}`, 'ComponentDetector');
-      logger.debug(`[ComponentDetector] Cached README length: ${cachedComponent.readme ? cachedComponent.readme.length : 0}`, 'ComponentDetector');
 
       // If the requested version matches the cached version, return cached data — but for mutable branch refs first
       // confirm the branch hasn't moved since we cached it.
@@ -353,7 +350,6 @@ export async function detectIncludeComponent(document: vscode.TextDocument, posi
             gitlabInstance: cachedComponent.gitlabInstance,
             sourcePath: cachedComponent.sourcePath,
             templatePath: cachedComponent.templatePath,
-            readme: cachedComponent.readme || '', // Include README from cache
             resolvedSha: cachedComponent.resolvedSha,
             context: {
               gitlabInstance: cachedComponent.gitlabInstance,
@@ -377,7 +373,6 @@ export async function detectIncludeComponent(document: vscode.TextDocument, posi
 
         if (specificVersionComponent) {
           logger.debug(`[ComponentDetector] Successfully fetched specific version ${requestedVersion} for ${cachedComponent.name}`, 'ComponentDetector');
-          logger.debug(`[ComponentDetector] Fetched component has README: ${!!specificVersionComponent.readme}`, 'ComponentDetector');
 
           const cacheVersion = requestedVersion || 'main';
           // Authoritatively classify the ref, then record the branch HEAD + timestamp so the next hover can detect a
@@ -649,25 +644,18 @@ async function fetchComponentDynamically(componentUrl: string, originalUrl?: str
       return null;
     }
 
-    // Convert to our Component interface
-    // Use the componentService to get proper description and README data
+    // Convert to our Component interface. The catalog list omits the resolved template path and, for
+    // description-less components, the README-derived description — so fetch the full component to get both.
     let componentDescription = foundComponent.description;
-    let readmeContent = '';
     let resolvedTemplatePath: string | undefined;
 
-    // Always fetch full component metadata for README content, even if we have a description
     try {
       const fullComponentUrl = `https://${gitlabInstance}/${projectPath}/${componentName}@${version}`;
-      logger.debug(`[ComponentDetector] Fetching full component metadata for README: ${fullComponentUrl}`, 'ComponentDetector');
       const fullComponent = await componentService.getComponentFromUrl(fullComponentUrl);
       if (fullComponent) {
-        logger.debug(`[ComponentDetector] Full component fetched successfully, has README: ${!!fullComponent.readme}`, 'ComponentDetector');
-        logger.debug(`[ComponentDetector] README length: ${fullComponent.readme ? fullComponent.readme.length : 0}`, 'ComponentDetector');
-        // Use catalog description if available, otherwise use full component description
         if (!componentDescription) {
           componentDescription = fullComponent.description;
         }
-        readmeContent = fullComponent.readme || '';
         resolvedTemplatePath = fullComponent.templatePath;
       } else {
         logger.debug(`[ComponentDetector] Full component fetch returned null`, 'ComponentDetector');
@@ -676,14 +664,9 @@ async function fetchComponentDynamically(componentUrl: string, originalUrl?: str
       logger.debug(`[ComponentDetector] Could not fetch full component metadata: ${error}`, 'ComponentDetector');
     }
 
-    // Apply fallback logic if still no description
-    if (!componentDescription) {
-      componentDescription = 'Component/Project does not have a description';
-    }
-
     const dynamicComponent: Component = {
       name: foundComponent.name,
-      description: componentDescription,
+      description: componentDescription || '',
       summary: foundComponent.summary,
       usage: foundComponent.usage,
       notes: foundComponent.notes,
@@ -703,7 +686,6 @@ async function fetchComponentDynamically(componentUrl: string, originalUrl?: str
       sourcePath: projectPath,
       templatePath: resolvedTemplatePath,
       documentationUrl: foundComponent.documentation_url,
-      readme: readmeContent, // Include README content from full fetch
       context: {
         gitlabInstance: gitlabInstance,
         path: projectPath

--- a/src/services/cache/projectCache.ts
+++ b/src/services/cache/projectCache.ts
@@ -49,7 +49,7 @@ export class ProjectCache {
 
           return {
             name: c.name,
-            description: c.description || `Component from ${sourceName}`,
+            description: c.description || '',
             parameters: (c.variables || []).map(v => ({
               name: v.name,
               description: v.description || `Parameter: ${v.name}`,
@@ -153,7 +153,7 @@ export class ProjectCache {
       // Create cached component entry
       const cachedComponent: CachedComponent = {
         name: catalogComponent.name,
-        description: catalogComponent.description || `Component from ${sourcePath}`,
+        description: catalogComponent.description || '',
         parameters: (catalogComponent.variables || []).map(v => ({
           name: v.name,
           description: v.description || `Parameter: ${v.name}`,

--- a/src/services/component/componentFetcher.ts
+++ b/src/services/component/componentFetcher.ts
@@ -19,7 +19,7 @@ import {
   buildCatalogComponents,
   fetchAllTemplateFiles,
 } from './componentFetcherTemplates';
-import { firstParagraph, readmeDirForTemplate } from './readmeDescription';
+import { fetchReadme, firstParagraph, readmeDirForTemplate } from './readmeDescription';
 
 /**
  * Prompt the user for a GitLab personal access token for `gitlabInstance`.
@@ -203,7 +203,8 @@ export class ComponentFetcher {
             // If the catalog omits a description, fall back to the component's README.
             const readmeDirs = [readmeDirForTemplate(templateResult?.templatePath), ''];
             const readme =
-              (await this.fetchReadme(
+              (await fetchReadme(
+                this.httpClient,
                 apiBaseUrl,
                 encodedProjectPath,
                 version,
@@ -289,7 +290,7 @@ export class ComponentFetcher {
       // A component's README sits next to its template; fall back to the repo root for flat layouts.
       const readmeDirs = [readmeDirForTemplate(resolvedTemplatePath), ''];
       const readme =
-        (await this.fetchReadme(apiBaseUrl, encodedProjectPath, version, readmeDirs, fetchOptions)) ??
+        (await fetchReadme(this.httpClient, apiBaseUrl, encodedProjectPath, version, readmeDirs, fetchOptions)) ??
         undefined;
 
       // Prefer the project description; when absent, fall back to the README's first meaningful paragraph.
@@ -399,50 +400,6 @@ export class ComponentFetcher {
       this.logger.debug(`Could not fetch component template: ${error}`);
       return null;
     }
-  }
-
-  /**
-   * Fetch a README, trying the common filename/casing variants under each of `dirs` in order. A component's
-   * own README lives next to its template (`templates/<name>/README.md`), so callers pass that directory
-   * ahead of the root.
-   *
-   * @param apiBaseUrl   GitLab API v4 base.
-   * @param projectId    Numeric or string project id for the raw-file endpoint.
-   * @param version      Git ref to read each file at.
-   * @param dirs         Directories to search, in priority order; `''` means the repo root.
-   * @param fetchOptions Optional request headers.
-   * @returns            The raw text of the first README that exists, or `null` when none are present (or the fetch fails).
-   */
-  private async fetchReadme(
-    apiBaseUrl: string,
-    projectId: string,
-    version: string,
-    dirs: string[],
-    fetchOptions?: { headers?: Record<string, string> }
-  ): Promise<string | null> {
-    const names = ['README.md', 'README.MD', 'readme.md', 'README', 'README.rst', 'README.txt'];
-
-    for (const dir of dirs) {
-      const prefix = dir ? `${dir.replace(/\/$/, '')}/` : '';
-      for (const name of names) {
-        const path = `${prefix}${name}`;
-        const readmeUrl = `${apiBaseUrl}/projects/${projectId}/repository/files/${encodeURIComponent(
-          path
-        )}/raw?ref=${version}`;
-        try {
-          const content = await this.httpClient.fetchText(readmeUrl, fetchOptions);
-          if (content && content.trim()) {
-            this.logger.debug(`[ComponentFetcher] README found at ${path}, length: ${content.length} chars`);
-            return content;
-          }
-        } catch {
-          // try next candidate
-        }
-      }
-    }
-
-    this.logger.debug(`[ComponentFetcher] No README found at known paths`);
-    return null;
   }
 
   /**

--- a/src/services/component/componentFetcher.ts
+++ b/src/services/component/componentFetcher.ts
@@ -43,11 +43,30 @@ import {
  * @param readme The raw README text, or `undefined` when no README was fetched.
  * @returns      The first prose paragraph, or `undefined` when the README is empty/missing or has no usable prose.
  */
+/**
+ * Remove HTML comments (`<!-- … -->`) from `text`, repeating until no `<!--` remains. A single global
+ * replace is insufficient: overlapping/nested markers like `<!--<!-- -->-->` can leave a residual `<!--`
+ * after one pass, so we iterate to a fixed point.
+ *
+ * @param text The raw text to strip comments from.
+ * @returns    `text` with all HTML comments (and any residual opening markers) removed.
+ */
+function stripHtmlComments(text: string): string {
+  let previous: string;
+  let current = text;
+  do {
+    previous = current;
+    current = current.replace(/<!--[\s\S]*?-->/g, '');
+  } while (current !== previous);
+  // Drop any unterminated opening marker left over (e.g. `<!--` with no closing `-->`).
+  return current.replace(/<!--/g, '');
+}
+
 function firstParagraph(readme: string | undefined): string | undefined {
   if (!readme) {
     return undefined;
   }
-  const blocks = readme.replace(/<!--[\s\S]*?-->/g, '').split(/\n\s*\n/);
+  const blocks = stripHtmlComments(readme).split(/\n\s*\n/);
   for (const block of blocks) {
     const text = block.trim();
     if (!text) {

--- a/src/services/component/componentFetcher.ts
+++ b/src/services/component/componentFetcher.ts
@@ -34,6 +34,38 @@ import {
  * @returns              The trimmed token if the user entered one (also persisted), or `undefined`
  *                       if they left it blank (public access) or dismissed the prompt.
  */
+/**
+ * Extract the first meaningful prose paragraph from a README to use as a component description.
+ *
+ * Skips a leading H1 title, HTML comments, and badge/image-only lines (e.g. shields), then returns the
+ * first paragraph with its Markdown heading markers stripped.
+ *
+ * @param readme The raw README text, or `undefined` when no README was fetched.
+ * @returns      The first prose paragraph, or `undefined` when the README is empty/missing or has no usable prose.
+ */
+function firstParagraph(readme: string | undefined): string | undefined {
+  if (!readme) {
+    return undefined;
+  }
+  const blocks = readme.replace(/<!--[\s\S]*?-->/g, '').split(/\n\s*\n/);
+  for (const block of blocks) {
+    const text = block.trim();
+    if (!text) {
+      continue;
+    }
+    // Skip a top-level title and badge/image-only blocks (every line is a link or image).
+    if (/^#\s/.test(text)) {
+      continue;
+    }
+    const lines = text.split('\n');
+    if (lines.every((line) => /^\s*(!?\[[^\]]*\]\([^)]*\))+\s*$/.test(line.trim()))) {
+      continue;
+    }
+    return text.replace(/^#+\s*/, '').trim();
+  }
+  return undefined;
+}
+
 async function promptForTokenIfNeeded(
   context: vscode.ExtensionContext | undefined,
   tokenManager: TokenManager,
@@ -199,10 +231,23 @@ export class ComponentFetcher {
               extractedParameters = backfillParameterOptions(extractedParameters, templateResult.parameters);
             }
 
+            // The catalog often omits a description; fall back to the component's README (next to its
+            // template, then repo root) so the detail view isn't left blank.
+            const readmeDirs = [this.readmeDirForTemplate(templateResult?.templatePath), ''];
+            const readme =
+              (await this.fetchReadme(
+                apiBaseUrl,
+                encodedProjectPath,
+                version,
+                readmeDirs,
+                catalogFetchOptions
+              )) ?? undefined;
+            const summary = catalogComponent.description?.trim() || firstParagraph(readme) || '';
+
             const component = {
               name: componentName,
               description:
-                `# ${componentName}\n\n${catalogComponent.description || ''}\n\n` +
+                `# ${componentName}\n\n${summary}\n\n` +
                 `**From GitLab CI/CD Catalog**\n` +
                 `**Project:** [${projectPath}](https://${gitlabInstance}/${projectPath})\n` +
                 `**Version:** ${version}\n\n` +
@@ -273,14 +318,14 @@ export class ComponentFetcher {
         this.logger.debug(`Found component template with ${parameters.length} parameters at ${templatePath}`);
       }
 
-      // Build component description with proper fallbacks
-      let cleanDescription = '';
+      // A component's README sits next to its template; fall back to the repo root for flat layouts.
+      const readmeDirs = [this.readmeDirForTemplate(resolvedTemplatePath), ''];
+      const readme =
+        (await this.fetchReadme(apiBaseUrl, encodedProjectPath, version, readmeDirs, fetchOptions)) ??
+        undefined;
 
-      if (project.description && project.description.trim()) {
-        cleanDescription = project.description.trim();
-      } else {
-        cleanDescription = `Component/Project does not have a description`;
-      }
+      // Prefer the project description; when absent, fall back to the README's first meaningful paragraph.
+      const cleanDescription = project.description?.trim() || firstParagraph(readme) || '';
 
       // Construct the component
       const component: Component = {
@@ -386,6 +431,65 @@ export class ComponentFetcher {
       this.logger.debug(`Could not fetch component template: ${error}`);
       return null;
     }
+  }
+
+  /**
+   * Fetch a README, trying the common filename/casing variants under each of `dirs` in order. A component's
+   * own README lives next to its template (`templates/<name>/README.md`), so callers pass that directory
+   * ahead of the root.
+   *
+   * @param apiBaseUrl   GitLab API v4 base.
+   * @param projectId    Numeric or string project id for the raw-file endpoint.
+   * @param version      Git ref to read each file at.
+   * @param dirs         Directories to search, in priority order; `''` means the repo root.
+   * @param fetchOptions Optional request headers.
+   * @returns            The raw text of the first README that exists, or `null` when none are present (or the fetch fails).
+   */
+  private async fetchReadme(
+    apiBaseUrl: string,
+    projectId: string,
+    version: string,
+    dirs: string[],
+    fetchOptions?: { headers?: Record<string, string> }
+  ): Promise<string | null> {
+    const names = ['README.md', 'README.MD', 'readme.md', 'README', 'README.rst', 'README.txt'];
+
+    for (const dir of dirs) {
+      const prefix = dir ? `${dir.replace(/\/$/, '')}/` : '';
+      for (const name of names) {
+        const path = `${prefix}${name}`;
+        const readmeUrl = `${apiBaseUrl}/projects/${projectId}/repository/files/${encodeURIComponent(
+          path
+        )}/raw?ref=${version}`;
+        try {
+          const content = await this.httpClient.fetchText(readmeUrl, fetchOptions);
+          if (content && content.trim()) {
+            this.logger.debug(`[ComponentFetcher] README found at ${path}, length: ${content.length} chars`);
+            return content;
+          }
+        } catch {
+          // try next candidate
+        }
+      }
+    }
+
+    this.logger.debug(`[ComponentFetcher] No README found at known paths`);
+    return null;
+  }
+
+  /**
+   * The directory a component's README would sit in, derived from its resolved template path
+   * (`templates/<name>/template.yml` → `templates/<name>`).
+   *
+   * @param templatePath The resolved repo-relative template path, or `undefined` when none was found.
+   * @returns            The template's directory, or `''` for a flat template (`templates/<name>.yml`) or a
+   *                     missing path — signalling the caller to look at the repo root.
+   */
+  private readmeDirForTemplate(templatePath: string | undefined): string {
+    if (!templatePath || !templatePath.includes('/')) {
+      return '';
+    }
+    return templatePath.slice(0, templatePath.lastIndexOf('/'));
   }
 
   /**

--- a/src/services/component/componentFetcher.ts
+++ b/src/services/component/componentFetcher.ts
@@ -200,8 +200,7 @@ export class ComponentFetcher {
               extractedParameters = backfillParameterOptions(extractedParameters, templateResult.parameters);
             }
 
-            // The catalog often omits a description; fall back to the component's README (next to its
-            // template, then repo root) so the detail view isn't left blank.
+            // If the catalog omits a description, fall back to the component's README.
             const readmeDirs = [readmeDirForTemplate(templateResult?.templatePath), ''];
             const readme =
               (await this.fetchReadme(

--- a/src/services/component/componentFetcher.ts
+++ b/src/services/component/componentFetcher.ts
@@ -19,6 +19,7 @@ import {
   buildCatalogComponents,
   fetchAllTemplateFiles,
 } from './componentFetcherTemplates';
+import { firstParagraph, readmeDirForTemplate } from './readmeDescription';
 
 /**
  * Prompt the user for a GitLab personal access token for `gitlabInstance`.
@@ -34,57 +35,6 @@ import {
  * @returns              The trimmed token if the user entered one (also persisted), or `undefined`
  *                       if they left it blank (public access) or dismissed the prompt.
  */
-/**
- * Extract the first meaningful prose paragraph from a README to use as a component description.
- *
- * Skips a leading H1 title, HTML comments, and badge/image-only lines (e.g. shields), then returns the
- * first paragraph with its Markdown heading markers stripped.
- *
- * @param readme The raw README text, or `undefined` when no README was fetched.
- * @returns      The first prose paragraph, or `undefined` when the README is empty/missing or has no usable prose.
- */
-/**
- * Remove HTML comments (`<!-- … -->`) from `text`, repeating until no `<!--` remains. A single global
- * replace is insufficient: overlapping/nested markers like `<!--<!-- -->-->` can leave a residual `<!--`
- * after one pass, so we iterate to a fixed point.
- *
- * @param text The raw text to strip comments from.
- * @returns    `text` with all HTML comments (and any residual opening markers) removed.
- */
-function stripHtmlComments(text: string): string {
-  let previous: string;
-  let current = text;
-  do {
-    previous = current;
-    current = current.replace(/<!--[\s\S]*?-->/g, '');
-  } while (current !== previous);
-  // Drop any unterminated opening marker left over (e.g. `<!--` with no closing `-->`).
-  return current.replace(/<!--/g, '');
-}
-
-function firstParagraph(readme: string | undefined): string | undefined {
-  if (!readme) {
-    return undefined;
-  }
-  const blocks = stripHtmlComments(readme).split(/\n\s*\n/);
-  for (const block of blocks) {
-    const text = block.trim();
-    if (!text) {
-      continue;
-    }
-    // Skip a top-level title and badge/image-only blocks (every line is a link or image).
-    if (/^#\s/.test(text)) {
-      continue;
-    }
-    const lines = text.split('\n');
-    if (lines.every((line) => /^\s*(!?\[[^\]]*\]\([^)]*\))+\s*$/.test(line.trim()))) {
-      continue;
-    }
-    return text.replace(/^#+\s*/, '').trim();
-  }
-  return undefined;
-}
-
 async function promptForTokenIfNeeded(
   context: vscode.ExtensionContext | undefined,
   tokenManager: TokenManager,
@@ -252,7 +202,7 @@ export class ComponentFetcher {
 
             // The catalog often omits a description; fall back to the component's README (next to its
             // template, then repo root) so the detail view isn't left blank.
-            const readmeDirs = [this.readmeDirForTemplate(templateResult?.templatePath), ''];
+            const readmeDirs = [readmeDirForTemplate(templateResult?.templatePath), ''];
             const readme =
               (await this.fetchReadme(
                 apiBaseUrl,
@@ -338,7 +288,7 @@ export class ComponentFetcher {
       }
 
       // A component's README sits next to its template; fall back to the repo root for flat layouts.
-      const readmeDirs = [this.readmeDirForTemplate(resolvedTemplatePath), ''];
+      const readmeDirs = [readmeDirForTemplate(resolvedTemplatePath), ''];
       const readme =
         (await this.fetchReadme(apiBaseUrl, encodedProjectPath, version, readmeDirs, fetchOptions)) ??
         undefined;
@@ -494,21 +444,6 @@ export class ComponentFetcher {
 
     this.logger.debug(`[ComponentFetcher] No README found at known paths`);
     return null;
-  }
-
-  /**
-   * The directory a component's README would sit in, derived from its resolved template path
-   * (`templates/<name>/template.yml` → `templates/<name>`).
-   *
-   * @param templatePath The resolved repo-relative template path, or `undefined` when none was found.
-   * @returns            The template's directory, or `''` for a flat template (`templates/<name>.yml`) or a
-   *                     missing path — signalling the caller to look at the repo root.
-   */
-  private readmeDirForTemplate(templatePath: string | undefined): string {
-    if (!templatePath || !templatePath.includes('/')) {
-      return '';
-    }
-    return templatePath.slice(0, templatePath.lastIndexOf('/'));
   }
 
   /**

--- a/src/services/component/componentFetcherTemplates.ts
+++ b/src/services/component/componentFetcherTemplates.ts
@@ -173,7 +173,7 @@ export async function buildCatalogComponents(
 
         return {
           name,
-          description: parsedSpec.description || `${name} component`,
+          description: parsedSpec.description || '',
           variables: parsedSpec.variables,
           latest_version: ref,
           templatePath: file.path,

--- a/src/services/component/componentFetcherTemplates.ts
+++ b/src/services/component/componentFetcherTemplates.ts
@@ -11,6 +11,7 @@ import type { GitLabTreeItem } from '../../types/api';
 import type { ParsedCatalogComponent } from '../../types/gitlab-catalog';
 import type { ComponentParameter } from '../../types/git-component';
 import { GitLabSpecParser } from '../../parsers/specParser';
+import { fetchReadme, firstParagraph, readmeDirForTemplate } from './readmeDescription';
 
 /**
  * Filter a list of repository-tree entries down to the YAML *blobs* (not subdirectories). Used for both the
@@ -171,9 +172,16 @@ export async function buildCatalogComponents(
         const parsedSpec = GitLabSpecParser.parse(content, relativePath);
         if (!parsedSpec.isValidComponent) return null;
 
+        // No spec description → fall back to the component's README (its dir, then repo root).
+        let description = parsedSpec.description?.trim() || '';
+        if (!description) {
+          const readmeDirs = [readmeDirForTemplate(file.path), ''];
+          description = firstParagraph((await fetchReadme(http, apiBaseUrl, projectId, ref, readmeDirs, fetchOptions)) ?? undefined) || '';
+        }
+
         return {
           name,
-          description: parsedSpec.description || '',
+          description,
           variables: parsedSpec.variables,
           latest_version: ref,
           templatePath: file.path,

--- a/src/services/component/readmeDescription.ts
+++ b/src/services/component/readmeDescription.ts
@@ -1,0 +1,104 @@
+/**
+ * Functions for deriving a component description from its README — operating on already-fetched text and
+ * resolved paths.
+ */
+
+/**
+ * Remove HTML comments (`<!-- … -->`) from `text`.
+ *
+ * Emits only the spans that sit outside a comment, so no `<!--` opener can survive into the output (which
+ * feeds a component description) — an unterminated trailing `<!--` runs to end-of-string and is dropped.
+ *
+ * @param text The raw text to strip comments from.
+ * @returns    `text` with every HTML comment removed.
+ */
+export function stripHtmlComments(text: string): string {
+  let result = '';
+  let i = 0;
+  while (i < text.length) {
+    const open = text.indexOf('<!--', i);
+    if (open === -1) {
+      result += text.slice(i);
+      break;
+    }
+    result += text.slice(i, open);
+    const close = text.indexOf('-->', open + 4);
+    if (close === -1) {
+      break; // Unterminated comment — drop the remainder.
+    }
+    i = close + 3;
+  }
+  return result;
+}
+
+/**
+ * Whether a line consists only of images and links (a badge row), and so isn't prose.
+ *
+ * Removes image tokens (`![alt](url)`) and link tokens (`[text](url)`, whose `text` may itself be an image,
+ * as in a linked badge `[![alt](img)](href)`) and reports whether only whitespace remains.
+ *
+ * @param line A single line of README text.
+ * @returns    `true` when the line has no textual content once images/links are removed.
+ */
+function isBadgeOrImageOnly(line: string): boolean {
+  const stripped = line
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, '') // images first, so a linked image's inner ![..](..) is gone
+    .replace(/\[[^\]]*\]\([^)]*\)/g, '') // then links (now with image-free text)
+    .trim();
+  return stripped === '';
+}
+
+/**
+ * Extract the first meaningful prose paragraph from a README to use as a component description.
+ *
+ * Skips a leading H1 title, HTML comments, and badge/image-only lines (e.g. shields), then returns the
+ * first paragraph with its Markdown heading markers stripped.
+ *
+ * @param readme The raw README text, or `undefined` when no README was fetched.
+ * @returns      The first prose paragraph, or `undefined` when the README is empty/missing or has no usable prose.
+ */
+export function firstParagraph(readme: string | undefined): string | undefined {
+  if (!readme) {
+    return undefined;
+  }
+  const blocks = stripHtmlComments(readme).split(/\n\s*\n/);
+  for (const block of blocks) {
+    const text = block.trim();
+    if (!text) {
+      continue;
+    }
+    // Skip a top-level title and badge/image-only blocks (every line is a link or image).
+    if (/^#\s/.test(text)) {
+      continue;
+    }
+    const lines = text.split('\n');
+    if (lines.every(isBadgeOrImageOnly)) {
+      continue;
+    }
+    return text.replace(/^#+\s*/, '').trim();
+  }
+  return undefined;
+}
+
+/**
+ * The directory a component's own README would sit in, derived from its resolved template path.
+ *
+ * Only the directory-form layout (`templates/<name>/template.yml`) has a per-component folder, so only it
+ * yields a directory (`templates/<name>`). A flat template (`templates/<name>.yml`) has no component-specific
+ * folder — its `templates/README.md` sibling would be a folder index, not this component's description — so it
+ * returns `''`, signalling the caller to look at the repo root instead.
+ *
+ * @param templatePath The resolved repo-relative template path, or `undefined` when none was found.
+ * @returns            The per-component directory, or `''` for a flat template or a missing path.
+ */
+export function readmeDirForTemplate(templatePath: string | undefined): string {
+  if (!templatePath) {
+    return '';
+  }
+  const lastSlash = templatePath.lastIndexOf('/');
+  // Flat form has a single segment after `templates/` (one slash total); directory form has ≥2.
+  if (lastSlash === -1 || templatePath.indexOf('/') === lastSlash) {
+    return '';
+  }
+  return templatePath.slice(0, lastSlash);
+}

--- a/src/services/component/readmeDescription.ts
+++ b/src/services/component/readmeDescription.ts
@@ -1,7 +1,12 @@
 /**
- * Functions for deriving a component description from its README — operating on already-fetched text and
- * resolved paths.
+ * Deriving a component description from its README: locating and fetching the file, then extracting the
+ * first prose paragraph.
  */
+
+/** The slice of the HTTP client this module needs — the real `HttpClient` satisfies it. */
+export interface ReadmeHttpClient {
+  fetchText(url: string, options?: { headers?: Record<string, string> }): Promise<string>;
+}
 
 /**
  * Remove HTML comments (`<!-- … -->`) from `text`.
@@ -63,19 +68,14 @@ export function firstParagraph(readme: string | undefined): string | undefined {
   }
   const blocks = stripHtmlComments(readme).split(/\n\s*\n/);
   for (const block of blocks) {
-    const text = block.trim();
-    if (!text) {
-      continue;
+    // Within a block, drop leading heading and badge/image lines so a `# Title` immediately followed by
+    // prose (no blank line between) still yields the prose rather than being skipped whole.
+    const prose = block
+      .split('\n')
+      .filter((line) => line.trim() && !/^\s*#+\s/.test(line) && !isBadgeOrImageOnly(line));
+    if (prose.length > 0) {
+      return prose.join('\n').trim();
     }
-    // Skip a top-level title and badge/image-only blocks (every line is a link or image).
-    if (/^#\s/.test(text)) {
-      continue;
-    }
-    const lines = text.split('\n');
-    if (lines.every(isBadgeOrImageOnly)) {
-      continue;
-    }
-    return text.replace(/^#+\s*/, '').trim();
   }
   return undefined;
 }
@@ -101,4 +101,45 @@ export function readmeDirForTemplate(templatePath: string | undefined): string {
     return '';
   }
   return templatePath.slice(0, lastSlash);
+}
+
+/** README filename/casing variants tried, in order, within each candidate directory. */
+const README_NAMES = ['README.md', 'README.MD', 'readme.md', 'README', 'README.rst', 'README.txt'];
+
+/**
+ * Fetch a README, trying {@link README_NAMES} under each of `dirs` in order. A component's own README lives
+ * next to its template (`templates/<name>/README.md`), so callers pass that directory ahead of the root.
+ *
+ * @param http         Structural HTTP client (the real `HttpClient` satisfies it).
+ * @param apiBaseUrl   GitLab API v4 base.
+ * @param projectId    Numeric or string project id for the raw-file endpoint.
+ * @param version      Git ref to read each file at.
+ * @param dirs         Directories to search, in priority order; `''` means the repo root.
+ * @param fetchOptions Optional request headers.
+ * @returns            The raw text of the first README that exists, or `null` when none are present (or the fetch fails).
+ */
+export async function fetchReadme(
+  http: ReadmeHttpClient,
+  apiBaseUrl: string,
+  projectId: string | number,
+  version: string,
+  dirs: string[],
+  fetchOptions?: { headers?: Record<string, string> }
+): Promise<string | null> {
+  for (const dir of dirs) {
+    const prefix = dir ? `${dir.replace(/\/$/, '')}/` : '';
+    for (const name of README_NAMES) {
+      const path = `${prefix}${name}`;
+      const url = `${apiBaseUrl}/projects/${projectId}/repository/files/${encodeURIComponent(path)}/raw?ref=${version}`;
+      try {
+        const content = await http.fetchText(url, fetchOptions);
+        if (content && content.trim()) {
+          return content;
+        }
+      } catch {
+        // try next candidate
+      }
+    }
+  }
+  return null;
 }

--- a/src/types/cache.ts
+++ b/src/types/cache.ts
@@ -88,8 +88,6 @@ export interface CachedComponent {
   url: string;
   availableVersions?: string[];
   templatePath?: string;
-  /** Rendered README content, populated when the component fetch succeeded against the project's README. */
-  readme?: string;
   /** Catalog `spec.summary` — short one-line component summary. */
   summary?: string;
   /** Catalog `spec.usage` — usage instructions. */

--- a/src/webview/inlineMarkdown.ts
+++ b/src/webview/inlineMarkdown.ts
@@ -1,0 +1,39 @@
+/**
+ * HTML-escaping and inline-Markdown rendering for text shown in webviews (component descriptions).
+ *
+ * `vscode`-free and pure so the unit suite can drive it directly. The webview scripts carry a client-side
+ * twin of `renderInlineMarkdown` (as an injected string, since it runs in the browser); both must escape and
+ * format identically, and this is the reference the twin mirrors.
+ */
+
+/**
+ * Escape the five HTML-significant characters. Safe for both element text and double/single-quoted attributes.
+ *
+ * @param value The raw text to escape.
+ * @returns     `value` with `&`, `<`, `>`, `"`, and `'` replaced by their HTML entities.
+ */
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/**
+ * Render a single-paragraph description with inline Markdown (links, `code`, **bold**, *italic*).
+ *
+ * HTML is escaped first, so nothing in the source can inject markup; only the patterns below re-introduce
+ * tags, and links accept `http(s)` URLs only (so `javascript:` / `data:` can't become an href).
+ *
+ * @param value The raw description text (may contain inline Markdown).
+ * @returns     HTML-safe markup with inline Markdown converted to `<a>`/`<code>`/`<strong>`/`<em>` tags.
+ */
+export function renderInlineMarkdown(value: string): string {
+  return escapeHtml(value)
+    .replace(/`([^`]+)`/g, '<code>$1</code>')
+    .replace(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g, '<a href="$2">$1</a>')
+    .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
+    .replace(/(^|[^*])\*([^*]+)\*/g, '$1<em>$2</em>');
+}

--- a/src/webview/scriptData.ts
+++ b/src/webview/scriptData.ts
@@ -1,0 +1,28 @@
+/**
+ * Safe serialization of data embedded directly into a webview `<script>` block.
+ *
+ * `vscode`-free and pure so the unit suite can drive it directly. `JSON.stringify` alone is unsafe inside a
+ * `<script>` element: the HTML tokenizer terminates the script at the first literal `</script>` (or `<!--`)
+ * regardless of JavaScript string context, so a value containing `</script>` could break out and inject
+ * markup — reachable now that component descriptions come from third-party READMEs and version lists from
+ * third-party git tags. Escaping `<` (the load-bearing one), plus `>` and `&` for good measure, to their
+ * `\uXXXX` forms keeps the output valid JSON/JS while making breakout impossible.
+ */
+
+/**
+ * Serialize `value` as JSON safe to embed directly in a webview `<script>` block.
+ *
+ * @param value Any JSON-serializable value.
+ * @returns     `JSON.stringify(value)` with `<`, `>` and `&` replaced by `\uXXXX` escapes, or `'null'`
+ *              when `value` is not serializable (e.g. `undefined`).
+ */
+export function serializeForScript(value: unknown): string {
+  const json = JSON.stringify(value);
+  if (json === undefined) {
+    return 'null';
+  }
+  return json
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026');
+}

--- a/tests/fixtures/mock-data.json
+++ b/tests/fixtures/mock-data.json
@@ -52,7 +52,6 @@
       ],
       "version": "2.1.0",
       "source": "gitlab.example.com/components/advanced",
-      "readme": "# Advanced Component\n\nThis is a comprehensive component for advanced deployment scenarios.\n\n## Features\n\n- Multi-environment support\n- Version management\n- Debug capabilities\n- Rollback functionality\n\n## Usage\n\n```yaml\ninclude:\n  - component: https://gitlab.example.com/components/advanced/advanced-component@2.1.0\n    inputs:\n      environment: production\n      version: v1.2.3\n      debug: false\n      replicas: 5\n```",
       "context": {
         "gitlabInstance": "gitlab.example.com",
         "path": "components/advanced"

--- a/tests/unit/inlineMarkdown.test.ts
+++ b/tests/unit/inlineMarkdown.test.ts
@@ -1,0 +1,71 @@
+// @mocha
+/**
+ * Tests src/webview/inlineMarkdown.ts — the escape + inline-Markdown renderer used for component
+ * descriptions in webviews. Descriptions can now originate from a third-party README (see readmeDescription),
+ * so the XSS regressions below are load-bearing: escaping must run before any tag is (re-)introduced, and
+ * only `http(s)` links may become an href.
+ */
+
+import * as assert from 'node:assert/strict';
+import { escapeHtml, renderInlineMarkdown } from '../../src/webview/inlineMarkdown';
+
+suite('escapeHtml', () => {
+  test('escapes all five significant characters', () => {
+    assert.equal(escapeHtml(`&<>"'`), '&amp;&lt;&gt;&quot;&#39;');
+  });
+
+  test('escapes & first so entities are not double-broken', () => {
+    assert.equal(escapeHtml('a & <b>'), 'a &amp; &lt;b&gt;');
+  });
+});
+
+suite('renderInlineMarkdown — formatting', () => {
+  test('renders an http(s) link', () => {
+    assert.equal(
+      renderInlineMarkdown('see [docs](https://example.com/x)'),
+      'see <a href="https://example.com/x">docs</a>',
+    );
+  });
+
+  test('renders code, bold, and italic', () => {
+    assert.equal(renderInlineMarkdown('use `x` and **y** and *z*'), 'use <code>x</code> and <strong>y</strong> and <em>z</em>');
+  });
+
+  test('leaves plain prose untouched', () => {
+    assert.equal(renderInlineMarkdown('just some text.'), 'just some text.');
+  });
+});
+
+suite('renderInlineMarkdown — XSS regressions', () => {
+  test('escapes a raw script/img payload to inert text', () => {
+    assert.equal(
+      renderInlineMarkdown('<img src=x onerror=alert(1)>'),
+      '&lt;img src=x onerror=alert(1)&gt;',
+    );
+    assert.ok(!renderInlineMarkdown('<script>alert(1)</script>').includes('<script>'));
+  });
+
+  test('does not linkify a javascript: URL (http(s) only)', () => {
+    const out = renderInlineMarkdown('[click](javascript:alert(1))');
+    assert.ok(!out.includes('<a '), 'javascript: must not become an href');
+    assert.ok(!out.toLowerCase().includes('href'));
+  });
+
+  test('does not linkify a data: URL', () => {
+    const out = renderInlineMarkdown('[x](data:text/html,<script>alert(1)</script>)');
+    assert.ok(!out.includes('<a '));
+  });
+
+  test('escapes a quote inside a link href so it cannot break out of the attribute', () => {
+    const out = renderInlineMarkdown('[a](https://e/?q=")after');
+    assert.ok(out.includes('&quot;'), 'the quote must be escaped');
+    assert.ok(!/href="[^"]*"[^>]*"/.test(out), 'no stray closing quote that escapes the attribute');
+  });
+
+  test('does not reinterpret $-sequences from the content as replacement patterns', () => {
+    // `$1` / `$&` in a *link label* would be dangerous only if content were used as a replacement string;
+    // here content is only ever the replace *subject*, so the sequences stay literal (with `&` escaped as usual).
+    assert.equal(renderInlineMarkdown('[$1 and $&](https://e/x)'), '<a href="https://e/x">$1 and $&amp;</a>');
+    assert.equal(renderInlineMarkdown('plain $1 $& text'), 'plain $1 $&amp; text');
+  });
+});

--- a/tests/unit/readmeDescription.test.ts
+++ b/tests/unit/readmeDescription.test.ts
@@ -63,8 +63,12 @@ suite('firstParagraph', () => {
     assert.equal(firstParagraph(readme), 'Real prose.');
   });
 
-  test('strips heading markers when the first block is a lower-level heading', () => {
-    assert.equal(firstParagraph('## Overview\nSome text'), 'Overview\nSome text');
+  test('drops a heading line and keeps the prose in the same block', () => {
+    assert.equal(firstParagraph('## Overview\nSome text'), 'Some text');
+  });
+
+  test('keeps prose when a H1 shares a block with it (no blank line between)', () => {
+    assert.equal(firstParagraph('# Title\nDescription on next line'), 'Description on next line');
   });
 
   test('returns undefined when there is no usable prose', () => {

--- a/tests/unit/readmeDescription.test.ts
+++ b/tests/unit/readmeDescription.test.ts
@@ -1,0 +1,87 @@
+// @mocha
+/**
+ * Tests src/services/component/readmeDescription.ts — the pure helpers that derive a component description
+ * from its README.
+ * */
+
+import * as assert from 'node:assert/strict';
+import {
+  firstParagraph,
+  readmeDirForTemplate,
+  stripHtmlComments,
+} from '../../src/services/component/readmeDescription';
+
+suite('stripHtmlComments', () => {
+  test('removes a simple comment', () => {
+    assert.equal(stripHtmlComments('before<!-- x -->after'), 'beforeafter');
+  });
+
+  test('removes multiple and adjacent comments', () => {
+    assert.equal(stripHtmlComments('a<!--1-->b<!--2-->c'), 'abc');
+    assert.equal(stripHtmlComments('<!--x--><!--y-->keep'), 'keep');
+  });
+
+  test('leaves no residual <!-- on nested / overlapping markers', () => {
+    for (const input of [
+      '<!--<!-- -->-->',
+      '<!--a<!--b-->c-->description',
+      'before<!-- x -->after<!--',
+    ]) {
+      assert.ok(!stripHtmlComments(input).includes('<!--'), `residual opener for: ${input}`);
+    }
+  });
+
+  test('drops the remainder of an unterminated comment', () => {
+    assert.equal(stripHtmlComments('<!-- open but never closed'), '');
+    assert.equal(stripHtmlComments('keep<!-- dangling'), 'keep');
+  });
+
+  test('passes clean prose through unchanged', () => {
+    assert.equal(stripHtmlComments('Just a normal paragraph.'), 'Just a normal paragraph.');
+  });
+});
+
+suite('firstParagraph', () => {
+  test('returns undefined for missing or empty input', () => {
+    assert.equal(firstParagraph(undefined), undefined);
+    assert.equal(firstParagraph(''), undefined);
+    assert.equal(firstParagraph('   \n\n  '), undefined);
+  });
+
+  test('skips a leading H1 title and returns the first prose paragraph', () => {
+    const readme = '# Markdown lint CI Check\n\nRuns markdownlint on modified files.\n\n## Usage\n\n...';
+    assert.equal(firstParagraph(readme), 'Runs markdownlint on modified files.');
+  });
+
+  test('skips a leading HTML comment block', () => {
+    const readme = '<!-- a toc comment -->\n\nActual description here.';
+    assert.equal(firstParagraph(readme), 'Actual description here.');
+  });
+
+  test('skips a badge/image-only block', () => {
+    const readme = '# Title\n\n![build](https://ci/badge.svg)[![cov](https://c/b.svg)](https://c)\n\nReal prose.';
+    assert.equal(firstParagraph(readme), 'Real prose.');
+  });
+
+  test('strips heading markers when the first block is a lower-level heading', () => {
+    assert.equal(firstParagraph('## Overview\nSome text'), 'Overview\nSome text');
+  });
+
+  test('returns undefined when there is no usable prose', () => {
+    assert.equal(firstParagraph('# Only A Title'), undefined);
+  });
+});
+
+suite('readmeDirForTemplate', () => {
+  test('returns the directory for a directory-form template', () => {
+    assert.equal(readmeDirForTemplate('templates/markdown-lint/template.yml'), 'templates/markdown-lint');
+  });
+
+  test('returns empty string for a flat single-file template', () => {
+    assert.equal(readmeDirForTemplate('templates/deploy.yml'), '');
+  });
+
+  test('returns empty string for a missing path', () => {
+    assert.equal(readmeDirForTemplate(undefined), '');
+  });
+});

--- a/tests/unit/scriptData.test.ts
+++ b/tests/unit/scriptData.test.ts
@@ -1,0 +1,39 @@
+// @mocha
+/**
+ * Tests src/webview/scriptData.ts — safe JSON serialization for data embedded in webview `<script>` blocks.
+ * Component descriptions now come from third-party READMEs and version lists from third-party git tags, so
+ * the `</script>` breakout regression below is load-bearing: a raw `JSON.stringify` would terminate the
+ * script element and inject markup.
+ */
+
+import * as assert from 'node:assert/strict';
+import { serializeForScript } from '../../src/webview/scriptData';
+
+suite('serializeForScript', () => {
+  test('neutralizes a </script> breakout in a string value', () => {
+    const payload = '</script><img src=x onerror=alert(1)>';
+    const out = serializeForScript({ description: payload });
+    assert.ok(!out.includes('</script>'), 'must not contain a literal </script>');
+    assert.ok(!out.includes('<'), 'every < must be escaped');
+    assert.deepEqual(JSON.parse(out), { description: payload }, 'still round-trips to the original value');
+  });
+
+  test('escapes <, > and & as \\uXXXX', () => {
+    assert.equal(serializeForScript('<>&'), '"\\u003c\\u003e\\u0026"');
+  });
+
+  test('leaves ordinary data unchanged and round-trippable', () => {
+    const value = { versions: ['1.0.0', '1.2.3'], count: 3, ok: true };
+    assert.deepEqual(JSON.parse(serializeForScript(value)), value);
+  });
+
+  test('a crafted git tag in a version array cannot break out', () => {
+    const out = serializeForScript(['</script>', '1.0.0']);
+    assert.ok(!out.includes('</script>'));
+    assert.deepEqual(JSON.parse(out), ['</script>', '1.0.0']);
+  });
+
+  test('returns null for a non-serializable value', () => {
+    assert.equal(serializeForScript(undefined), 'null');
+  });
+});


### PR DESCRIPTION
## Summary
- Components and projects without a description now fall back to the opening paragraph of their `README.md`, instead of showing the placeholder `Component/Project does not have a description`. The README is fetched next to the template first (`templates/<name>/README.md`), then at the repository root.
- Descriptions containing inline Markdown (links, `code`, **bold**, *italic*) now render as formatted HTML across every Component Browser surface (tree card + detail panel, initial render + version switch). The renderer escapes HTML first and only re-introduces tags for those patterns; `http(s)` links only.
- Hardens the tree-card description sinks, which injected `${component.description}` raw into the webview. Since a description can now come from a third-party README, an `<img onerror=…>` first line would otherwise execute; both sinks now go through the escaper/renderer. (The raw injection pre-existed on `main`; this feature makes it reachable with remote content, so it's fixed here.)
- Removes the write-only `readme` field that was fetched, cached, and logged but never read — the README is now used only as the input to the description fallback.
- Link related issue(s): 
  - Fixes #233
  - Fixes #237

## Change Type
- [x] feat (README-derived descriptions; Markdown rendering)
- [x] fix (placeholder text; unescaped description injection / XSS hardening)
- [ ] refactor
- [ ] docs
- [x] test (pure-helper + XSS regression suites)
- [x] chore (dead-code cleanup)

## Context
### User-facing impact
- Description-less components now show useful text (their README's first paragraph) rather than placeholder text or a blank area.
- Descriptions with Markdown render formatted (clickable links, inline code) instead of literal `[text](url)`.
- No settings added or changed.

### GitLab scope
- [ ] gitlab.com
- [ ] self-managed GitLab
- [x] both (uses the standard `repository/files/.../raw` API; no instance-specific behavior)

### Affected areas
- [x] Component Browser (description rendering)
- [x] Hover provider (description fallback)
- [ ] Completion provider
- [ ] Validation provider
- [x] Cache and refresh behavior (cached descriptions now README-derived; `readme` field removed)
- [x] GitLab API calls/auth/token storage (adds a README raw-file fetch; retry-after-auth path included)
- [ ] Docs only

## What changed by bucket

| Bucket | Files | Approach |
|---|---|---|
| README → description helpers | [readmeDescription.ts](src/services/component/readmeDescription.ts) | New `vscode`-free module holding the pure helpers: `fetchReadme` (structural `{ fetchText }` client; tries filename/casing variants under each candidate dir), `readmeDirForTemplate` (per-component dir from the resolved template path; `''` for flat templates so their README resolves at the repo root, not a shared `templates/README.md`), `firstParagraph` (first prose paragraph — drops leading heading and badge/image lines *within* a block, so `# Title\nprose` keeps the prose), and `stripHtmlComments` (single linear scan copying only spans outside `<!-- … -->`, so no `<!--` opener can survive — CodeQL: incomplete multi-character sanitization). |
| Description fallback at the cache-population path | [componentFetcherTemplates.ts](src/services/component/componentFetcherTemplates.ts), [componentFetcher.ts](src/services/component/componentFetcher.ts) | `buildCatalogComponents` (the path that feeds `getComponents()` → the Browser/hover cache) now derives `firstParagraph(readme)` when the spec has no description — so description-less components in a configured source get the fallback, not just the cache-miss/hover fetch. `fetchComponentMetadata`'s full/API and catalog paths use the same helpers. |
| Placeholder removal | [componentDetector.ts](src/providers/componentDetector.ts), [componentBrowserTransform.ts](src/providers/componentBrowserTransform.ts), [componentBrowserProvider.ts](src/providers/componentBrowserProvider.ts), [projectCache.ts](src/services/cache/projectCache.ts) | Dropped `Component/Project does not have a description`, `No description available`, and the three `Component from <source>` fallbacks; absent descriptions resolve to `''` so the upstream README fallback is what fills them. |
| Markdown rendering + XSS-safe sinks | [inlineMarkdown.ts](src/webview/inlineMarkdown.ts), [componentBrowserProvider.ts](src/providers/componentBrowserProvider.ts) | Extracted `escapeHtml` / `renderInlineMarkdown` into a pure, tested module; the provider delegates to it. Routed **all** description sinks through it: the detail panel (initial + version update), and the tree card's `data-description` attribute (via `escapeHtml`) and visible `.component-description` (via `renderInlineMarkdown`) — the latter two were raw `${component.description}` injections reachable with remote README content. The client-side twin is now a single injected source string shared by both webview scripts (escape set incl. `'` matches the server), so the twins can't drift. |
| Dead-code cleanup | [componentDetector.ts](src/providers/componentDetector.ts), [componentFetcher.ts](src/services/component/componentFetcher.ts), [cache.ts](src/types/cache.ts), [mock-data.json](tests/fixtures/mock-data.json) | Removed the write-only `readme` field from the `Component` interface and `CachedComponent` type, the code that set/copied it, the README debug logs, and the orphaned `readme` key in the mock fixture. |
| Tests | [readmeDescription.test.ts](tests/unit/readmeDescription.test.ts), [inlineMarkdown.test.ts](tests/unit/inlineMarkdown.test.ts) | Unit coverage for the pure helpers, including `stripHtmlComments` no-residual-marker regressions and `renderInlineMarkdown` XSS regressions (`<img onerror>`, `javascript:`/`data:` links, quote-in-href, `$`-sequence content). |
| Docs | [README.md](README.md) | Notes the README-derived description fallback in the Features list and the Template Header Spec section. |

## Validation
### Local checks
- [x] `npm run compile` (`tsc --noEmit` clean)
- [x] `npm test` (354 passing, incl. new `readmeDescription` + `inlineMarkdown` suites)
- [x] `npm run test:extension-host` (20 passing)
- [x] `npm run lint` clean

### Manual test notes
- The pure helpers (`firstParagraph`, `stripHtmlComments`, `readmeDirForTemplate`, `escapeHtml`, `renderInlineMarkdown`) are now unit-tested directly; XSS and sanitization cases are regressions, not manual checks.
- Client-side `renderInlineMarkdown` twin additionally verified by evaluating the **emitted** webview JS as real browser JS (the regexes live inside an HTML template literal): link/`code`/**bold**/*italic* render; `<img onerror>` escaped; `javascript:` stays literal; quote-in-href escaped.
- Detail panel opened against `markdown-lint`: description shows the README paragraph with a working link.

> Note: a stale component cache masks the fix — cached entries written before this change keep their old (placeholder/blank) description until the cache is refreshed (**GitLab CI: Reset Cache** / **Update Cache**).

## Breaking Changes
- [x] No breaking changes
- [ ] Breaking changes (describe below)

The `readme` field was removed from the `Component`/`CachedComponent` shapes, but it was never read, and cache persistence never serialized it — so no persisted state changes.

## Risk and Rollback
- Main risks: low–moderate. The added README fetch issues extra raw-file requests (up to the candidate filenames × directories) that 404 for repos without a README; they run alongside existing fetches and failures are swallowed. Description content now originates from a new source (README), so an unusual README could yield an unexpected first paragraph — the parser skips titles/badges but is heuristic.
- Rollback strategy: revert the PR. No persisted state, settings, or cache-shape migration; a cache refresh repopulates descriptions under whichever version is deployed.

## Release Notes Draft
- Components without their own description now show the opening lines of their `README.md` in hover and the Component Browser, and Markdown in descriptions (links, code) renders formatted.

## Checklist
- [ ] Branch is up to date with target branch
- [ ] Commit messages follow conventional commits
- [x] Added/updated docs for behavior or settings changes (README + this PR description)
- [ ] Added/updated tests for new behavior
- [x] No secrets or tokens in code, logs, screenshots, or test fixtures
