### PR TITLE
docs(ci): correct Argus hardening pin comment to v1.9.2

### DIFF
--- a/.github/workflows/security-hardening.yml
+++ b/.github/workflows/security-hardening.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   argus-hardening:
     name: Argus Reusable Hardening
-    # Pinned to the commit for Argus v1.3.0 for supply-chain safety.
+    # Pinned to the commit for Argus v1.9.2 for supply-chain safety.
     uses: huntridge-labs/argus/.github/workflows/reusable-security-hardening.yml@18073b6ab8d5d561f77d358f37f1aacb23fcb83f
     with:
       scanners: codeql,gitleaks,osv,dependency-review


### PR DESCRIPTION
## Description
Corrects the stale pin comment in `.github/workflows/security-hardening.yml`.

The comment read *"Pinned to the commit for Argus v1.3.0"*, but the pinned SHA `18073b6` is tag **1.9.2**. The comment was already inaccurate before #241 — the prior SHA `19eaf05` was tag **1.8.0**, not 1.3.0.

Verified by resolving both SHAs against `huntridge-labs/argus` tags:
- `18073b6ab8d5d561f77d358f37f1aacb23fcb83f` → `1.9.2`
- `19eaf0531b49991748e5aecfd775ee35f595d3e5` → `1.8.0`

## Type of Change
- [x] Documentation update (comment only — no workflow behavior change)

## Notes
Comment-only; the `uses:` SHA pin is unchanged.