### PR TITLE
fix(completion): a !reference tag anywhere in the file breaks all input completion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@octokit/plugin-paginate-rest": "^15.0.0",
         "@release-it/conventional-changelog": "^12.0.0",
         "@types/glob": "^9.0.0",
-        "@types/js-yaml": "^4.0.9",
         "@types/mocha": "^10.0.10",
         "@types/node": "^26.2.0",
         "@types/vscode": "^1.120.0",
@@ -1953,13 +1952,6 @@
       "dependencies": {
         "glob": "*"
       }
-    },
-    "node_modules/@types/js-yaml": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
-      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",

--- a/package.json
+++ b/package.json
@@ -312,7 +312,6 @@
     "@octokit/plugin-paginate-rest": "^15.0.0",
     "@release-it/conventional-changelog": "^12.0.0",
     "@types/glob": "^9.0.0",
-    "@types/js-yaml": "^4.0.9",
     "@types/mocha": "^10.0.10",
     "@types/node": "^26.2.0",
     "@types/vscode": "^1.120.0",

--- a/src/providers/localComponentResolver.ts
+++ b/src/providers/localComponentResolver.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import * as yaml from 'js-yaml';
 import { Component, ComponentParameter } from './componentDetector';
 import { Logger } from '../utils/logger';
-import { isYamlNode } from '../utils/yamlParser';
+import { isYamlNode, GITLAB_CI_SCHEMA } from '../utils/yamlParser';
 import type { ParameterDefault } from '../types/git-component';
 
 // Pure parser helpers live in their own module so the unit suite can exercise them under plain Node. Re-exported
@@ -229,7 +229,7 @@ export async function resolveLocalIncludeOutcome(
   }
   let docs: unknown[];
   try {
-    docs = yaml.loadAll(text);
+    docs = yaml.loadAll(text, { schema: GITLAB_CI_SCHEMA });
   } catch (err) {
     logger.debug(`[LocalComponentResolver] Failed to parse ${uri.fsPath}: ${err}`, 'LocalComponentResolver');
     // The file exists and was read; it just isn't valid YAML. That's a plain include we can't extract inputs from,

--- a/src/utils/yamlParser.ts
+++ b/src/utils/yamlParser.ts
@@ -15,6 +15,9 @@ const referenceTag = yaml.defineSequenceTag<unknown[]>('!reference', {
   addItem: (carrier, item) => {
     carrier.push(item);
   },
+  // Load-only. `identify` selects the tag when *dumping*; returning false stops it claiming the plain arrays this
+  // constructs, which would re-emit unrelated sequences as `!reference`.
+  identify: () => false,
 });
 
 /** The core schema plus GitLab's CI-only tags, so a `.gitlab-ci.yml` using them still parses structurally. */

--- a/src/utils/yamlParser.ts
+++ b/src/utils/yamlParser.ts
@@ -3,6 +3,23 @@ import * as yaml from 'js-yaml';
 /** Loose object shape returned by `js-yaml`. Callers narrow via property checks before reading fields. */
 export type YamlNode = Record<string, unknown>;
 
+/**
+ * `!reference [.job, script]` — GitLab's own tag for splicing another job's key into this one. It belongs to no YAML
+ * schema, so a stock parser throws on it and the *whole file* — `include:` block included — yields nothing, killing
+ * completion/hover/validation for any pipeline that uses one. Resolving a reference needs the merged pipeline, which
+ * this extension never builds, so the tag constructs to its path sequence: enough for the surrounding document to
+ * parse, and a caller that reads one sees the target it points at rather than `undefined`.
+ */
+const referenceTag = yaml.defineSequenceTag<unknown[]>('!reference', {
+  create: () => [],
+  addItem: (carrier, item) => {
+    carrier.push(item);
+  },
+});
+
+/** The core schema plus GitLab's CI-only tags, so a `.gitlab-ci.yml` using them still parses structurally. */
+export const GITLAB_CI_SCHEMA = yaml.CORE_SCHEMA.withTags(referenceTag);
+
 /** Type-guard: a parsed YAML value is a non-null object (i.e. a mapping). Use to narrow `unknown` results. */
 export function isYamlNode(value: unknown): value is YamlNode {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -34,7 +51,7 @@ export function parseYaml(text: string, silent = false): unknown {
     }
 
     // Parse and cache
-    const parsed = yaml.load(text);
+    const parsed = yaml.load(text, { schema: GITLAB_CI_SCHEMA });
     parseCache.set(contentHash, { content: text, parsed, timestamp: now });
 
     // Clean old cache entries periodically
@@ -68,7 +85,7 @@ export function parseYaml(text: string, silent = false): unknown {
  */
 export function parseYamlDocuments(text: string, silent = false): YamlNode[] {
   try {
-    const docs = yaml.loadAll(text);
+    const docs = yaml.loadAll(text, { schema: GITLAB_CI_SCHEMA });
     return docs.filter(isYamlNode);
   } catch (e) {
     if (!silent) {

--- a/tests/extension-host/suite/referenceTagCompletion.test.ts
+++ b/tests/extension-host/suite/referenceTagCompletion.test.ts
@@ -1,0 +1,68 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+const EXTENSION_ID = 'eFAILution.gitlab-component-helper';
+
+// __dirname is <repo>/out-test/suite at runtime; fixtures live under tests/fixtures.
+const FIXTURE_DIR = path.resolve(__dirname, '..', '..', 'tests', 'fixtures', 'reference-tag-completion');
+const FIXTURE = path.join(FIXTURE_DIR, '.gitlab-ci.yml');
+
+async function ensureActive(): Promise<void> {
+  const ext = vscode.extensions.getExtension(EXTENSION_ID);
+  assert.ok(ext);
+  if (!ext.isActive) await ext.activate();
+}
+
+/** 0-indexed line whose trimmed text starts with `<name>:`. */
+function lineStartingWith(doc: vscode.TextDocument, name: string): number {
+  const lines = doc.getText().split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].trim().startsWith(`${name}:`)) return i;
+  }
+  throw new Error(`fixture missing a line starting with ${name}:`);
+}
+
+function labels(list: vscode.CompletionList | undefined): string[] {
+  return (list?.items ?? []).map((i) => (typeof i.label === 'string' ? i.label : i.label.label));
+}
+
+async function completionsAt(doc: vscode.TextDocument, position: vscode.Position): Promise<vscode.CompletionList> {
+  const list = await vscode.commands.executeCommand<vscode.CompletionList>(
+    'vscode.executeCompletionItemProvider',
+    doc.uri,
+    position
+  );
+  assert.ok(list, 'executeCompletionItemProvider returned no completion list');
+  return list;
+}
+
+// Regression for GitLab's `!reference [.job, key]` tag. It belongs to no YAML schema, so a stock parser threw on it
+// and took the entire file down — `include:` block included — leaving the parse null and suppressing every input
+// completion, even though the tag sits in an unrelated job further down the file. Drives VS Code's own completion
+// engine end-to-end to confirm the name slot still resolves with a `!reference` present.
+suite('Input completion in a file using a !reference tag', () => {
+  suiteSetup(ensureActive);
+
+  test('name slot under the include offers the include\'s not-yet-set inputs', async () => {
+    const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(FIXTURE));
+    const editor = await vscode.window.showTextDocument(doc);
+
+    // The include's inputs already set `job_name`; the remaining inputs are `environment` and `region`. Type a
+    // fresh name slot on a new line under `job_name:` at that key's indent, then ask for completions at the caret.
+    const jobNameLine = lineStartingWith(doc, 'job_name');
+    const keyIndent = doc.lineAt(jobNameLine).firstNonWhitespaceCharacterIndex;
+    const insertAt = new vscode.Position(jobNameLine, doc.lineAt(jobNameLine).text.length);
+    await editor.edit((b) => b.insert(insertAt, `\n${' '.repeat(keyIndent)}`));
+
+    const slotLine = jobNameLine + 1;
+    const position = new vscode.Position(slotLine, keyIndent);
+    const list = await completionsAt(doc, position);
+
+    const got = labels(list);
+    assert.ok(got.includes('environment'), `expected an 'environment' completion. Got: ${JSON.stringify(got)}`);
+    assert.ok(got.includes('region'), `expected a 'region' completion. Got: ${JSON.stringify(got)}`);
+    // The already-set input must not be re-offered.
+    assert.ok(!got.includes('job_name'), `'job_name' is already set and must not be offered. Got: ${JSON.stringify(got)}`);
+  });
+});

--- a/tests/fixtures/reference-tag-completion/.gitlab-ci.yml
+++ b/tests/fixtures/reference-tag-completion/.gitlab-ci.yml
@@ -1,0 +1,14 @@
+include:
+  - local: "reference-tag-completion/templates/deploy.yml"
+    inputs:
+      job_name: deploy
+
+.pnpm-setup:
+  script:
+    - corepack enable
+    - pnpm install --frozen-lockfile
+
+test:
+  script:
+    - !reference [.pnpm-setup, script]
+    - pnpm test

--- a/tests/fixtures/reference-tag-completion/templates/deploy.yml
+++ b/tests/fixtures/reference-tag-completion/templates/deploy.yml
@@ -1,0 +1,16 @@
+spec:
+  inputs:
+    environment:
+      description: Target environment
+      type: string
+      default: staging
+    region:
+      description: Target region
+      type: string
+    job_name:
+      description: The name of the CI job
+      type: string
+---
+$[[ inputs.job_name ]]:
+  script:
+    - echo "deploy $[[ inputs.job_name ]] to $[[ inputs.environment ]]/$[[ inputs.region ]]"

--- a/tests/unit/completionInputContext.test.ts
+++ b/tests/unit/completionInputContext.test.ts
@@ -383,6 +383,25 @@ include:
       existingInputNames: [],
     });
   });
+
+  // A `!reference` anywhere in the file used to fail the parse outright, so an empty inputs slot offered nothing.
+  test('resolves the inputs slot when a later job uses a !reference tag', () => {
+    // The slot line carries the indentation the user has typed into it, hence the explicit spaces.
+    const text = `include:
+  - component: ${FULL_PIPELINE_URL}
+    inputs:
+${'      '}
+test:
+    script:
+        - !reference [.pnpm-setup, script]`;
+    const ctx = findCompletionInputContextAtLine(text, 3, 6);
+    assert.deepStrictEqual(ctx, {
+      componentUrl: FULL_PIPELINE_URL,
+      includeKind: 'component',
+      slot: 'name',
+      existingInputNames: [],
+    });
+  });
 });
 
 suite('buildInputInsertValue', () => {

--- a/tests/unit/yamlParser.test.ts
+++ b/tests/unit/yamlParser.test.ts
@@ -41,6 +41,31 @@ include:
   test('returns [] on unparseable input', () => {
     assert.deepStrictEqual(parseYamlDocuments('key: "unterminated', true), []);
   });
+
+  // A stock schema throws on GitLab's `!reference`, taking the whole document — `include:` and all — down with it.
+  test('parses a document using GitLab\'s !reference tag', () => {
+    const text = `include:
+  - component: https://gitlab.com/c/x@1.0.0
+    inputs:
+      stage: build
+
+test:
+  script:
+    - !reference [.pnpm-setup, script]
+`;
+    const docs = parseYamlDocuments(text, true);
+    assert.strictEqual(docs.length, 1);
+    const doc = findDocumentWith(docs, 'include');
+    assert.ok(doc, 'the include-bearing document should survive the !reference tag');
+    assert.deepStrictEqual(doc.include, [
+      { component: 'https://gitlab.com/c/x@1.0.0', inputs: { stage: 'build' } },
+    ]);
+  });
+
+  test('constructs !reference as the path sequence it points at', () => {
+    const docs = parseYamlDocuments('test:\n  script:\n    - !reference [.setup, script]\n', true);
+    assert.deepStrictEqual(docs[0].test, { script: [['.setup', 'script']] });
+  });
 });
 
 suite('findDocumentWith', () => {


### PR DESCRIPTION
## Summary
- Fixes input completion doing nothing on any file containing GitLab's `!reference [.job, key]` tag. The tag belongs to no YAML schema, so `js-yaml` throws `unknown sequence tag !<!reference>` and the parse returns `null`/`[]` — taking down the **whole file**, `include:` block and all, even though the tag sits in an unrelated job further down. Deleting the `!reference` line was the only workaround.
- Adds `GITLAB_CI_SCHEMA` (the core schema extended with a `!reference` tag) and uses it on every `load`/`loadAll` call. The tag constructs to the path sequence it points at: resolving a reference properly needs the merged pipeline, which this extension never builds, so the value is enough for the surrounding document to parse and for a caller reading one to see the target rather than `undefined`.
- Drops the stale `@types/js-yaml@4.0.9` devDependency. It shadowed the typings `js-yaml@5` ships itself, hiding the v5 tag API (`defineSequenceTag`, `CORE_SCHEMA.withTags`) and exposing a v4 API (`yaml.Type`, `yaml.DEFAULT_SCHEMA`) that does not exist at runtime.
- Link related issue(s): Fixes #262

## Change Type
- [ ] feat
- [x] fix
- [ ] refactor
- [ ] docs
- [ ] test
- [ ] chore

## Context
### User-facing impact
- Completion, hover, and validation now work in pipelines that use `!reference`, which is the standard way to reuse a hidden job's `script` and therefore common in real files.

### GitLab scope
- [ ] gitlab.com
- [ ] self-managed GitLab
- [x] both (local YAML parsing only; no GitLab interaction)

### Affected areas
- [ ] Component Browser
- [x] Hover provider
- [x] Completion provider
- [x] Validation provider
- [ ] Cache and refresh behavior
- [ ] GitLab API calls/auth/token storage
- [ ] Docs only

## What changed by bucket

| Bucket | Files | Approach |
|---|---|---|
| GitLab-aware schema | [yamlParser.ts](../src/utils/yamlParser.ts) | New exported `GITLAB_CI_SCHEMA` = `yaml.CORE_SCHEMA.withTags(referenceTag)`, where `referenceTag` is a `defineSequenceTag('!reference', …)` collecting the tag's items into a plain array. It is load-only: `identify: () => false` (the idiom the js-yaml docs give for load-only tags) keeps the tag from claiming plain arrays on the dump side and re-emitting unrelated sequences as `!reference`. Both `parseYaml` and `parseYamlDocuments` pass `{ schema: GITLAB_CI_SCHEMA }`. |
| Local include parse | [localComponentResolver.ts](../src/providers/localComponentResolver.ts) | Its own `yaml.loadAll` call takes the same schema — a local include can use `!reference` just as readily as the consumer file. |
| Dependency correction | [package.json](../package.json), [package-lock.json](../package-lock.json) | Removes `@types/js-yaml@^4.0.9` so `js-yaml@5`'s own bundled typings apply. No other package depends on it. |
| Regression tests | [yamlParser.test.ts](../tests/unit/yamlParser.test.ts), [completionInputContext.test.ts](../tests/unit/completionInputContext.test.ts), [referenceTagCompletion.test.ts](../tests/extension-host/suite/referenceTagCompletion.test.ts), [tests/fixtures/reference-tag-completion/](../tests/fixtures/reference-tag-completion/) | **Unit:** an `include:` block survives a later `!reference`, and the tag constructs to its path sequence; plus a completion regression resolving an inputs slot with a `!reference` present. **Extension-host:** `reference-tag-completion` drives VS Code's own completion engine against a consumer file whose `test` job uses `!reference`. |

## Validation
### Local checks
- [x] `npm run compile` (`tsc --noEmit` clean across both tsconfigs)
- [x] `npm test` — 387 passing; `npm run lint` clean
- [x] Manual verification in VS Code Extension Host

## Breaking Changes
- [x] No breaking changes
- [ ] Breaking changes (describe below)

## Risk and Rollback
- Main risks: `parseYaml`/`parseYamlDocuments` move from the default schema to `CORE_SCHEMA` + the `!reference` tag. Core is the YAML 1.2 default and covers the scalar types GitLab CI files use; the practical change is that previously-fatal `!reference` tags now parse.
- Rollback strategy: revert the commit. The schema is confined to `yamlParser.ts` and one call site in `localComponentResolver.ts`; restoring `@types/js-yaml` requires reinstalling the devDependency.

## Release Notes Draft
- Fix: input completion, hover, and validation no longer break in pipelines using GitLab's `!reference` tag.

## Checklist
- [x] Branch is up to date with target branch
- [x] Commit messages follow conventional commits
- [ ] Added/updated docs for behavior or settings changes
- [x] Added/updated tests for new behavior
- [x] No secrets or tokens in code, logs, screenshots, or test fixtures
