### PR TITLE
chore(parser): clarify referenceTag identify option purpose (#270)

### DIFF
--- a/src/utils/yamlParser.ts
+++ b/src/utils/yamlParser.ts
@@ -15,8 +15,8 @@ const referenceTag = yaml.defineSequenceTag<unknown[]>('!reference', {
   addItem: (carrier, item) => {
     carrier.push(item);
   },
-  // Load-only. `identify` selects the tag when *dumping*; returning false stops it claiming the plain arrays this
-  // constructs, which would re-emit unrelated sequences as `!reference`.
+  // Load-only sequence tag. `identify` is required by js-yaml's SequenceTagOptions; returning false ensures this
+  // tag is never selected when dumping JavaScript arrays.
   identify: () => false,
 });
 


### PR DESCRIPTION
## Summary
Resolves #270.

Clarifies the comment on `referenceTag`'s `identify: () => false` in `src/utils/yamlParser.ts`.

## Changes
- Updated the comment on `identify` to accurately reflect the TypeScript `SequenceTagOptions` type contract (where `identify: (data: any) => boolean` is required by `js-yaml`) rather than describing a misleading claim about js-yaml's dumper behavior.
- Retained `identify: () => false` to satisfy the TypeScript interface while keeping the tag strictly load-only.

## Validation
- `npm run check-types` (TypeScript check passes with zero errors).
- Unit tests pass (387 passing tests).
- `git diff --check` passes cleanly.
