### PR TITLE
fix(parser): tolerate any local YAML tag, not just sequence !reference

### DIFF
--- a/src/utils/yamlParser.ts
+++ b/src/utils/yamlParser.ts
@@ -4,24 +4,50 @@ import * as yaml from 'js-yaml';
 export type YamlNode = Record<string, unknown>;
 
 /**
- * `!reference [.job, script]` — GitLab's own tag for splicing another job's key into this one. It belongs to no YAML
- * schema, so a stock parser throws on it and the *whole file* — `include:` block included — yields nothing, killing
- * completion/hover/validation for any pipeline that uses one. Resolving a reference needs the merged pipeline, which
- * this extension never builds, so the tag constructs to its path sequence: enough for the surrounding document to
- * parse, and a caller that reads one sees the target it points at rather than `undefined`.
+ * Shared options for the local-tag catch-alls below. A local tag (`!reference`, `!custom`, …) belongs to no schema,
+ * so a stock parse throws and the whole file — `include:` and all — yields nothing. Matching by prefix on `!`
+ * degrades any such tag to the value it wraps: this extension reads only `include:` and `spec.inputs`, never the
+ * tagged values. `identify` is dump-side only; false keeps these load-only.
  */
-const referenceTag = yaml.defineSequenceTag<unknown[]>('!reference', {
+const loadOnly = { matchByTagPrefix: true, identify: () => false } as const;
+
+/** One catch-all per node kind, since a tag is selected by the shape of the node it decorates. */
+const anyLocalScalarTag = yaml.defineScalarTag<string>('!', { ...loadOnly, resolve: (source) => source });
+
+const anyLocalSequenceTag = yaml.defineSequenceTag<unknown[]>('!', {
+  ...loadOnly,
   create: () => [],
   addItem: (carrier, item) => {
     carrier.push(item);
   },
-  // Load-only. `identify` selects the tag when *dumping*; returning false stops it claiming the plain arrays this
-  // constructs, which would re-emit unrelated sequences as `!reference`.
-  identify: () => false,
 });
 
-/** The core schema plus GitLab's CI-only tags, so a `.gitlab-ci.yml` using them still parses structurally. */
-export const GITLAB_CI_SCHEMA = yaml.CORE_SCHEMA.withTags(referenceTag);
+const anyLocalMappingTag = yaml.defineMappingTag<Map<unknown, unknown>, YamlNode>('!', {
+  ...loadOnly,
+  // Map carrier so non-string keys survive; finalized to a plain object, which is what every reader here expects.
+  create: () => new Map(),
+  addPair: (carrier, key, value) => {
+    carrier.set(key, value);
+    return ''; // Success; a non-empty string is an error message.
+  },
+  has: (carrier, key) => carrier.has(key),
+  keys: (result) => Object.keys(result),
+  get: (result, key) => result[String(key)],
+  finalize: (carrier) => {
+    const result: YamlNode = {};
+    for (const [key, value] of carrier) {
+      result[String(key)] = value;
+    }
+    return result;
+  },
+});
+
+/** The core schema plus tolerated local tags, so a `.gitlab-ci.yml` using them still parses structurally. */
+export const GITLAB_CI_SCHEMA = yaml.CORE_SCHEMA.withTags(
+  anyLocalScalarTag,
+  anyLocalSequenceTag,
+  anyLocalMappingTag
+);
 
 /** Type-guard: a parsed YAML value is a non-null object (i.e. a mapping). Use to narrow `unknown` results. */
 export function isYamlNode(value: unknown): value is YamlNode {

--- a/tests/fixtures/reference-tag-completion/templates/deploy.yml
+++ b/tests/fixtures/reference-tag-completion/templates/deploy.yml
@@ -11,6 +11,13 @@ spec:
       description: The name of the CI job
       type: string
 ---
+# The `!reference` here is load-bearing: it exercises the local include's own parse in localComponentResolver, which
+# reads this file's `spec:` block. Without it, that parse path is never given a tag to choke on.
+.deploy-setup:
+  script:
+    - echo "authenticating against $[[ inputs.region ]]"
+
 $[[ inputs.job_name ]]:
   script:
+    - !reference [.deploy-setup, script]
     - echo "deploy $[[ inputs.job_name ]] to $[[ inputs.environment ]]/$[[ inputs.region ]]"

--- a/tests/unit/yamlParser.test.ts
+++ b/tests/unit/yamlParser.test.ts
@@ -9,7 +9,7 @@
  */
 
 import * as assert from 'node:assert/strict';
-import { parseYamlDocuments, findDocumentWith } from '../../src/utils/yamlParser';
+import { parseYaml, parseYamlDocuments, findDocumentWith } from '../../src/utils/yamlParser';
 
 suite('parseYamlDocuments', () => {
   test('returns every mapping document of a multi-document stream', () => {
@@ -65,6 +65,65 @@ test:
   test('constructs !reference as the path sequence it points at', () => {
     const docs = parseYamlDocuments('test:\n  script:\n    - !reference [.setup, script]\n', true);
     assert.deepStrictEqual(docs[0].test, { script: [['.setup', 'script']] });
+  });
+
+  // Any local tag is fatal to a stock parse, not just a sequence-position `!reference`. Each of these forms took the
+  // whole document down while only the sequence form was handled, so the tags match by prefix on `!` instead.
+  test('tolerates a local tag in every node position', () => {
+    const cases: [string, string, unknown][] = [
+      ['scalar', 'key: !reference foo', { key: 'foo' }],
+      ['sequence', 'key: !reference [.setup, script]', { key: ['.setup', 'script'] }],
+      ['mapping', 'key: !reference\n  nested: value', { key: { nested: 'value' } }],
+    ];
+    for (const [position, text, expected] of cases) {
+      assert.deepStrictEqual(parseYamlDocuments(text, true)[0], expected, `${position} position`);
+    }
+  });
+
+  // The shape a user is mid-way through typing: `!reference` with no argument yet. Losing the parse here blanks
+  // completion at exactly the moment it is wanted.
+  test('tolerates a half-typed tag with no value yet', () => {
+    const text = `include:
+  - component: https://gitlab.com/c/x@1.0.0
+    inputs:
+      stage: build
+
+test:
+  script:
+    - !reference
+`;
+    const doc = findDocumentWith(parseYamlDocuments(text, true), 'include');
+    assert.ok(doc, 'the include must still resolve while a tag is half-typed');
+  });
+
+  test('tolerates an unknown tag that is not !reference', () => {
+    assert.deepStrictEqual(parseYamlDocuments('a: !custom [1, 2]', true)[0], { a: [1, 2] });
+  });
+
+  // The tolerated tags must not disturb ordinary YAML: core scalars keep their types rather than becoming strings.
+  test('leaves untagged YAML and its scalar types alone', () => {
+    const text = 'num: 1\nbool: true\nnul: null\nstr: plain\nlist:\n  - a\n';
+    assert.deepStrictEqual(parseYamlDocuments(text, true)[0], {
+      num: 1,
+      bool: true,
+      nul: null,
+      str: 'plain',
+      list: ['a'],
+    });
+  });
+});
+
+// `parseYaml` is the single-document path (the completion round-trip probe, the component browser's wrapped-include
+// parse). It takes the same schema, but the tests above all go through `parseYamlDocuments`.
+suite('parseYaml', () => {
+  test('tolerates a local tag in every node position', () => {
+    assert.deepStrictEqual(parseYaml('key: !reference foo', true), { key: 'foo' });
+    assert.deepStrictEqual(parseYaml('key: !reference [.setup, script]', true), { key: ['.setup', 'script'] });
+    assert.deepStrictEqual(parseYaml('key: !reference\n  nested: value', true), { key: { nested: 'value' } });
+  });
+
+  test('still returns null on genuinely malformed YAML', () => {
+    assert.strictEqual(parseYaml('key: "unterminated', true), null);
   });
 });
 


### PR DESCRIPTION
## Summary
- Takes the catch-all option: three prefix-matching (`matchByTagPrefix: true`) tags on `!`, one per node kind, replacing the bespoke `!reference` sequence tag. Any local tag now degrades to the plain value it wraps.
- Closes both test coverage gaps — the local-include `loadAll` and the `parseYaml` path.
- Link related issue(s): Fixes #269

## Change Type
- [ ] feat
- [x] fix
- [ ] refactor
- [ ] docs
- [ ] test
- [ ] chore

## Context
### User-facing impact
- Completion, hover and validation survive any custom tag in any position, including a half-typed `- !reference` mid-edit.

### GitLab scope
- [ ] gitlab.com
- [ ] self-managed GitLab
- [x] both (local YAML parsing only; no GitLab interaction)

### Affected areas
- [ ] Component Browser
- [x] Hover provider
- [x] Completion provider
- [x] Validation provider
- [ ] Cache and refresh behavior
- [ ] GitLab API calls/auth/token storage
- [ ] Docs only

## What changed by bucket

| Bucket | Files | Approach |
|---|---|---|
| Catch-all local tags | [yamlParser.ts](../src/utils/yamlParser.ts) | Scalar, sequence and mapping tags registered on `!` with `matchByTagPrefix: true` — one per kind, since a tag is selected by the shape of the node it decorates. The mapping tag builds into a `Map` carrier so non-string keys survive construction, then finalizes to a plain object, which is what every reader here (`isYamlNode`, `Object.keys`, property access) expects. |
| Local-include coverage | [tests/fixtures/reference-tag-completion/templates/deploy.yml](../tests/fixtures/reference-tag-completion/templates/deploy.yml) | The included template's body now carries its own `!reference`, so `resolveLocalIncludeOutcome`'s parse is actually given a tag to choke on. Reverting that call's schema argument now fails the extension-host test (22 passing / 1 failing); it previously stayed green. |
| Unit coverage | [yamlParser.test.ts](../tests/unit/yamlParser.test.ts) | Scalar/sequence/mapping positions, a half-typed `- !reference`, `!custom`, and a guard that untagged YAML keeps its core scalar types. New `parseYaml` suite covers the single-document path directly. Reverting the catch-all fails 3 of these. |

## Validation
### Local checks
- [x] `npm run check-types` — clean across both tsconfigs
- [x] `npm test` — 393 passing; `npm run lint` clean
- [x] Extension-host suite — 23 passing locally

### Manual test notes
- All five reported cases now parse, each covered by a unit test. Untagged YAML keeps its core scalar types (`1` a number, `true` a boolean, `null` null) — also tested, since a catch-all on `!` could plausibly disturb them.
- Both fixes were confirmed load-bearing by reverting each in turn and watching the new tests fail (counts in the table above) — the check that was missing from #263.

## Breaking Changes
- [x] No breaking changes
- [ ] Breaking changes (describe below)

## Risk and Rollback
- Main risks: the parse is now permissive about unknown tags rather than failing. A tag this extension does not understand yields the plain value it wraps, so a misspelled tag no longer surfaces as a dead file — but the extension never interpreted tagged values anyway, and GitLab itself is the authority on whether a pipeline is valid. Untagged YAML is unchanged, covered by an explicit test.
- Rollback strategy: revert the commit. The change is confined to the tag definitions in `yamlParser.ts`; no call sites change.

## Release Notes Draft
- Fix: any custom YAML tag (not just `!reference` in a list) no longer disables completion, hover and validation for the whole file.

## Checklist
- [x] Branch is up to date with target branch
- [ ] Commit messages follow conventional commits
- [ ] Added/updated docs for behavior or settings changes
- [x] Added/updated tests for new behavior
- [x] No secrets or tokens in code, logs, screenshots, or test fixtures
