### PR TITLE
fix(parser): merge YAML merge keys (`<<:`) as GitLab does

### DIFF
--- a/src/utils/yamlParser.ts
+++ b/src/utils/yamlParser.ts
@@ -20,8 +20,13 @@ const referenceTag = yaml.defineSequenceTag<unknown[]>('!reference', {
   identify: () => false,
 });
 
-/** The core schema plus GitLab's CI-only tags, so a `.gitlab-ci.yml` using them still parses structurally. */
-export const GITLAB_CI_SCHEMA = yaml.CORE_SCHEMA.withTags(referenceTag);
+/**
+ * The core schema plus GitLab's CI-only tags, so a `.gitlab-ci.yml` using them still parses structurally.
+ *
+ * `mergeTag` gives `<<: *anchor` its YAML 1.1 meaning — merge the anchored mapping in — which is how GitLab's own
+ * parser (Ruby's Psych) reads it, and how anchors are shared between jobs in practice.
+ */
+export const GITLAB_CI_SCHEMA = yaml.CORE_SCHEMA.withTags(yaml.mergeTag, referenceTag);
 
 /** Type-guard: a parsed YAML value is a non-null object (i.e. a mapping). Use to narrow `unknown` results. */
 export function isYamlNode(value: unknown): value is YamlNode {

--- a/tests/extension-host/suite/mergeKey.test.ts
+++ b/tests/extension-host/suite/mergeKey.test.ts
@@ -1,0 +1,75 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+const EXTENSION_ID = 'eFAILution.gitlab-component-helper';
+
+// __dirname is <repo>/out-test/suite at runtime; fixtures live under tests/fixtures.
+const FIXTURE_DIR = path.resolve(__dirname, '..', '..', 'tests', 'fixtures', 'merge-key');
+const FIXTURE = path.join(FIXTURE_DIR, '.gitlab-ci.yml');
+
+async function ensureActive(): Promise<void> {
+  const ext = vscode.extensions.getExtension(EXTENSION_ID);
+  assert.ok(ext);
+  if (!ext.isActive) await ext.activate();
+}
+
+/** Wait until our own validation has run — the fixture's `bogus_input` guarantees one diagnostic to key off. */
+async function waitForOurDiagnostics(uri: vscode.Uri, timeoutMs = 5000): Promise<vscode.Diagnostic[]> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const ours = vscode.languages.getDiagnostics(uri).filter((d) => d.source === 'gitlab-component-helper');
+    if (ours.some((d) => d.code === 'unknown-input')) return ours;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  return vscode.languages.getDiagnostics(uri).filter((d) => d.source === 'gitlab-component-helper');
+}
+
+function labels(list: vscode.CompletionList | undefined): string[] {
+  return (list?.items ?? []).map((i) => (typeof i.label === 'string' ? i.label : i.label.label));
+}
+
+// Regression for the YAML merge key. GitLab parses with Psych, where `<<: *anchor` merges the anchored mapping in;
+// without `mergeTag` the parser leaves a literal `<<` key, so a `spec.inputs` entry inheriting its `default` through
+// the merge reads as having no default — reported missing — and `<<` itself surfaces as an input. Drives VS Code's
+// diagnostics and completion engine end-to-end, which is where the user actually sees the bug.
+suite('Merge-key inputs in a local include', () => {
+  suiteSetup(ensureActive);
+
+  test('inputs inheriting a default through `<<:` are not reported missing', async () => {
+    const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(FIXTURE));
+    await vscode.window.showTextDocument(doc);
+
+    const ours = await waitForOurDiagnostics(doc.uri);
+    const missing = ours.filter((d) => d.code === 'missing-required-input');
+    assert.deepStrictEqual(
+      missing.map((d) => d.message),
+      [],
+      `stage and region both carry a default through the merge key, so neither is required. Got: ${JSON.stringify(ours.map((d) => ({ code: d.code, msg: d.message })))}`
+    );
+  });
+
+  test('the merge key itself is not offered as an input', async () => {
+    const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(FIXTURE));
+    const editor = await vscode.window.showTextDocument(doc);
+
+    // Open a fresh name slot under `job_name:` at that key's indent, then ask for completions at the caret.
+    const lines = doc.getText().split('\n');
+    const jobNameLine = lines.findIndex((l) => l.trim().startsWith('job_name:'));
+    assert.ok(jobNameLine !== -1, 'fixture missing a job_name input line');
+    const keyIndent = doc.lineAt(jobNameLine).firstNonWhitespaceCharacterIndex;
+    const insertAt = new vscode.Position(jobNameLine, doc.lineAt(jobNameLine).text.length);
+    await editor.edit((b) => b.insert(insertAt, `\n${' '.repeat(keyIndent)}`));
+
+    const list = await vscode.commands.executeCommand<vscode.CompletionList>(
+      'vscode.executeCompletionItemProvider',
+      doc.uri,
+      new vscode.Position(jobNameLine + 1, keyIndent)
+    );
+    const got = labels(list);
+
+    assert.ok(!got.includes('<<'), `'<<' is a merge key, not an input. Got: ${JSON.stringify(got)}`);
+    assert.ok(got.includes('stage'), `expected the merged-in 'stage' input. Got: ${JSON.stringify(got)}`);
+    assert.ok(got.includes('region'), `expected the merged-in 'region' input. Got: ${JSON.stringify(got)}`);
+  });
+});

--- a/tests/fixtures/merge-key/.gitlab-ci.yml
+++ b/tests/fixtures/merge-key/.gitlab-ci.yml
@@ -1,0 +1,7 @@
+include:
+  - local: "merge-key/templates/deploy.yml"
+    inputs:
+      job_name: deploy-prod
+      # Deliberately unknown: gives the test a diagnostic to wait for, so asserting the *absence* of a
+      # missing-required-input for the merge-inherited inputs cannot pass before validation has run.
+      bogus_input: oops

--- a/tests/fixtures/merge-key/templates/deploy.yml
+++ b/tests/fixtures/merge-key/templates/deploy.yml
@@ -1,0 +1,23 @@
+.common-inputs: &common
+  stage:
+    description: The stage the job runs in
+    type: string
+    default: deploy
+  region:
+    description: Target region
+    type: string
+    default: eu-west-1
+
+spec:
+  inputs:
+    # `stage` and `region` arrive through the merge key. Both carry a default, so neither is required — a parser
+    # that leaves `<<` literal instead reports them missing and offers an input named `<<`.
+    <<: *common
+    job_name:
+      description: The name of the CI job
+      type: string
+---
+$[[ inputs.job_name ]]:
+  stage: $[[ inputs.stage ]]
+  script:
+    - echo "deploy to $[[ inputs.region ]]"

--- a/tests/unit/yamlParser.test.ts
+++ b/tests/unit/yamlParser.test.ts
@@ -9,7 +9,7 @@
  */
 
 import * as assert from 'node:assert/strict';
-import { parseYamlDocuments, findDocumentWith } from '../../src/utils/yamlParser';
+import { parseYamlDocuments, findDocumentWith, isYamlNode } from '../../src/utils/yamlParser';
 
 suite('parseYamlDocuments', () => {
   test('returns every mapping document of a multi-document stream', () => {
@@ -65,6 +65,51 @@ test:
   test('constructs !reference as the path sequence it points at', () => {
     const docs = parseYamlDocuments('test:\n  script:\n    - !reference [.setup, script]\n', true);
     assert.deepStrictEqual(docs[0].test, { script: [['.setup', 'script']] });
+  });
+
+  // GitLab parses with Psych, where `<<: *anchor` merges. Left unmerged, an input inheriting its `default` through
+  // an anchor reads as required, and a merged `spec.inputs` offers an input named `<<`.
+  test('merges `<<:` into the surrounding mapping', () => {
+    const text = `.defaults: &defaults
+  stage:
+    type: string
+    default: build
+spec:
+  inputs:
+    <<: *defaults
+    extra:
+      type: string
+`;
+    const docs = parseYamlDocuments(text, true);
+    assert.deepStrictEqual(findDocumentWith(docs, 'spec')?.spec, {
+      inputs: {
+        stage: { type: 'string', default: 'build' },
+        extra: { type: 'string' },
+      },
+    });
+  });
+
+  test('merges a sequence of anchors, earlier entries winning', () => {
+    const text = `.a: &a
+  x: 1
+  y: one
+.b: &b
+  y: two
+  z: 3
+job:
+  <<: [*a, *b]
+`;
+    const docs = parseYamlDocuments(text, true);
+    assert.deepStrictEqual(docs[0].job, { x: 1, y: 'one', z: 3 });
+  });
+
+  // YAML 1.1 scalar resolution would make these booleans; all are plausible job or input names.
+  test('keeps `y`, `n`, `yes`, `no`, `on`, `off` as string keys', () => {
+    const text = 'spec:\n  inputs:\n    y: 1\n    n: 2\n    yes: 3\n    no: 4\n    on: 5\n    off: 6\n';
+    const spec = findDocumentWith(parseYamlDocuments(text, true), 'spec')?.spec;
+    assert.ok(isYamlNode(spec));
+    assert.ok(isYamlNode(spec.inputs));
+    assert.deepStrictEqual(Object.keys(spec.inputs), ['y', 'n', 'yes', 'no', 'on', 'off']);
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds `yaml.mergeTag` to `GITLAB_CI_SCHEMA`, so `<<: *anchor` merges the anchored mapping in as GitLab's own parser (Ruby's Psych) does, rather than leaving a literal `<<` key.
- Covers the fix at both levels: unit tests on the parser, and an extension-host test on the user-visible symptom.
- Link related issue(s): Fixes #268

## Change Type
- [ ] feat
- [x] fix
- [ ] refactor
- [ ] docs
- [ ] test
- [ ] chore

## Context
### User-facing impact
- A `spec.inputs` entry that inherits its `default` through a merge key is no longer reported as a missing required input, and keeps its `type`, `description` and `options`.
- Completion no longer offers an input literally named `<<` when `spec.inputs` is itself a merge target.

### GitLab scope
- [ ] gitlab.com
- [ ] self-managed GitLab
- [x] both (local YAML parsing only; no GitLab interaction)

### Affected areas
- [ ] Component Browser
- [x] Hover provider
- [x] Completion provider
- [x] Validation provider
- [ ] Cache and refresh behavior
- [ ] GitLab API calls/auth/token storage
- [ ] Docs only

## What changed by bucket

| Bucket | Files | Approach |
|---|---|---|
| Merge-key support | [yamlParser.ts](../src/utils/yamlParser.ts) | One line: `CORE_SCHEMA.withTags(yaml.mergeTag, referenceTag)`. Deliberately **not** `YAML11_SCHEMA`, which would also merge but drags in YAML 1.1 scalar resolution — the keys `y`, `n`, `yes`, `no`, `on` and `off` resolve to booleans, and all are plausible job or input names in a `.gitlab-ci.yml`. |
| Unit coverage | [yamlParser.test.ts](../tests/unit/yamlParser.test.ts) | Merge into a `spec.inputs` mapping; a `<<: [*a, *b]` sequence merge with earlier entries winning; and a guard that `y`/`n`/`yes`/`no`/`on`/`off` survive as string keys — the regression test against someone later reaching for `YAML11_SCHEMA`. |
| Host coverage | [mergeKey.test.ts](../tests/extension-host/suite/mergeKey.test.ts), [fixtures/merge-key/](../tests/fixtures/merge-key/) | Drives VS Code's diagnostics and completion engines end-to-end, which is where the bug is actually visible. Follows the `referenceTagCompletion` pattern. The fixture's template pulls `stage` and `region` into `spec.inputs` via `<<: *common`, both carrying defaults; the consuming `.gitlab-ci.yml` sets neither. |

## Validation
### Local checks
- [x] `npm run check-types` — clean across both tsconfigs
- [x] `npm test` — 390 passing; `npm run lint` clean
- [x] Extension-host suite — 25 passing locally

### Manual test notes
- Reproduced the issue's table against `js-yaml@5.4.1` before changing anything: `CORE_SCHEMA` and js-yaml's default both yield `{"b":{"<<":{"x":1},"y":2}}`; `CORE_SCHEMA + mergeTag` yields the correct `{"b":{"x":1,"y":2}}`.
- Both new host tests were confirmed load-bearing by reverting the one-line fix and re-running: they fail with `Missing required input '<<' for local include 'deploy.yml'` and a completion list of `["<<"]` — exactly the two downstream impacts #268 predicts.
- The fixture carries a deliberate `bogus_input`. The main assertion is an *absence* (no `missing-required-input`), and the shared `waitForDiagnostics` helper returns as soon as any diagnostic appears, so an absence check could otherwise pass before validation had run. The unknown input guarantees a positive signal to wait on; the test uses a local `waitForOurDiagnostics` rather than changing the shared helper, which existing tests depend on.

## Breaking Changes
- [x] No breaking changes
- [ ] Breaking changes (describe below)

## Risk and Rollback
- Main risks: low. `mergeTag` only gives `<<` its standard meaning; documents without a merge key parse identically, and scalar resolution is untouched (explicitly tested). The one behavioural change is that a literal `<<` key can no longer be read back as data — nothing in this extension does that.
- Rollback strategy: revert the commit. The change is confined to the schema definition in `yamlParser.ts`; no call sites change.

## Release Notes Draft
- Fix: YAML merge keys (`<<: *anchor`) are now merged as GitLab does, so inputs inheriting a default through an anchor are no longer flagged as missing.

## Checklist
- [ ] Branch is up to date with target branch
- [ ] Commit messages follow conventional commits
- [ ] Added/updated docs for behavior or settings changes
- [x] Added/updated tests for new behavior
- [x] No secrets or tokens in code, logs, screenshots, or test fixtures
