### PR TITLE
fix(parser): add YAML merge key support to GITLAB_CI_SCHEMA (#268)

### DIFF
--- a/src/utils/yamlParser.ts
+++ b/src/utils/yamlParser.ts
@@ -20,8 +20,8 @@ const referenceTag = yaml.defineSequenceTag<unknown[]>('!reference', {
   identify: () => false,
 });
 
-/** The core schema plus GitLab's CI-only tags, so a `.gitlab-ci.yml` using them still parses structurally. */
-export const GITLAB_CI_SCHEMA = yaml.CORE_SCHEMA.withTags(referenceTag);
+/** The core schema plus GitLab's CI-only tags and YAML merge keys (`<<:`), so a `.gitlab-ci.yml` parses structurally. */
+export const GITLAB_CI_SCHEMA = yaml.CORE_SCHEMA.withTags(yaml.mergeTag, referenceTag);
 
 /** Type-guard: a parsed YAML value is a non-null object (i.e. a mapping). Use to narrow `unknown` results. */
 export function isYamlNode(value: unknown): value is YamlNode {

--- a/tests/unit/yamlParser.test.ts
+++ b/tests/unit/yamlParser.test.ts
@@ -66,6 +66,30 @@ test:
     const docs = parseYamlDocuments('test:\n  script:\n    - !reference [.setup, script]\n', true);
     assert.deepStrictEqual(docs[0].test, { script: [['.setup', 'script']] });
   });
+
+  test('merges YAML merge keys (<<:) and preserves y/no/on as string keys', () => {
+    const text = `
+a: &common
+  image: alpine
+  y: 10
+  no: false
+  on: true
+
+b:
+  <<: *common
+  stage: test
+`;
+    const docs = parseYamlDocuments(text, true);
+    assert.strictEqual(docs.length, 1);
+    assert.deepStrictEqual(docs[0].b, {
+      image: 'alpine',
+      y: 10,
+      no: false,
+      on: true,
+      stage: 'test',
+    });
+    assert.strictEqual(typeof Object.keys(docs[0].b as Record<string, unknown>).find(k => k === 'y'), 'string');
+  });
 });
 
 suite('findDocumentWith', () => {


### PR DESCRIPTION
## Summary
Resolves #268.

GitLab CI uses Psych (YAML 1.1) which merges `<<: *anchor` keys into mappings. In `gitlab-component-helper`, `GITLAB_CI_SCHEMA` extended `yaml.CORE_SCHEMA` with only `referenceTag`, causing merge keys to parse as literal `<<` properties instead of merging anchored fields.

## Changes
- Updated `GITLAB_CI_SCHEMA` in `src/utils/yamlParser.ts` to include `yaml.mergeTag` alongside `referenceTag`.
- Retained `CORE_SCHEMA` base to ensure boolean-like strings (`y`, `no`, `on`, `off`) remain plain strings rather than resolving to booleans.
- Added unit tests in `tests/unit/yamlParser.test.ts` verifying:
  - Merge key (`<<:`) properly merges properties from anchored mappings.
  - Boolean-like keys (`y`, `no`, `on`) are preserved as string keys in the resulting mapping.

## Validation
- `npm test` passed cleanly (388/388 tests passing).