### PR TITLE
fix(providers): match cached component templatePath regardless of ref (#276)

### DIFF
--- a/src/providers/documentLinkProvider.ts
+++ b/src/providers/documentLinkProvider.ts
@@ -88,8 +88,7 @@ export class ComponentDocumentLinkProvider implements vscode.DocumentLinkProvide
         (c) =>
           c.gitlabInstance === parsed.gitlabInstance &&
           c.sourcePath === parsed.path &&
-          c.name === parsed.name &&
-          (!parsed.version || c.version === parsed.version)
+          c.name === parsed.name
       );
 
       // Only produce a link when the cache has a resolved templatePath for the component. Uncached components are


### PR DESCRIPTION
## Summary
Resolves #276.

Allows document links for `component:` includes to resolve template paths from the component cache even when the include's pinned ref differs from the ref the component was discovered/cached under.

## Changes
- Removed the strict version matching filter (`(!parsed.version || c.version === parsed.version)`) when looking up cached components for `templatePath` resolution in `src/providers/documentLinkProvider.ts`.
- The resolved document link URL uses `parsed.version` from the include line directly (`templateFileUrlForResolved({ ..., version: parsed.version, templatePath: cached.templatePath })`), ensuring that repo layout (`templatePath`) is reused across refs without requiring an exact version match in cache discovery.

## Validation
- `npm test` passed (387 passing).
- `npm run compile` passed cleanly.