### PR TITLE
fix(details): make Refresh Versions work in the browser-opened details panel

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,28 +10,13 @@ import { getComponentCacheManager, ComponentCacheManager } from './services/cach
 import { Logger } from './utils/logger';
 import { ValidationProvider } from './providers/validationProvider';
 import type { CachedComponent } from './types/cache';
+import { isVersionLookupShape } from './services/component/versionLookupShape';
 import type { GitLabYamlFragment } from './types/gitlab-catalog';
 import type { HoverContext } from './providers/hoverContentBuilder';
 
 /** Component payload passed to the `detachHover` command. Adds the hover-builder's location context. */
 type DetachableComponent = Component & { _hoverContext?: HoverContext };
 
-/**
- * Type-guard narrowing a `Component`-shaped value to one that also satisfies `CachedComponent`.
- *
- * @param component  A `Component` (typically `activeComponent` in the detach-hover panel) that may
- *                   or may not have been enriched with cache details.
- * @returns          `true` if all `CachedComponent` required fields are present and string-typed,
- *                   narrowing `component` to `Component & CachedComponent` in the truthy branch.
- *                   `false` if any field is missing.
- */
-function isCachedComponentShape(component: Component): component is Component & CachedComponent {
-  return typeof component.source === 'string'
-    && typeof component.sourcePath === 'string'
-    && typeof component.gitlabInstance === 'string'
-    && typeof component.version === 'string'
-    && typeof component.url === 'string';
-}
 import { getPerformanceMonitor } from './utils/performanceMonitor';
 import { isGitLabCIFile, invalidateFileGlobsCache } from './utils/gitlabCiFileMatcher';
 
@@ -509,29 +494,33 @@ export function activate(context: vscode.ExtensionContext) {
               break;
             case 'fetchVersions':
               try {
-                if (!isCachedComponentShape(activeComponent)) {
-                  throw new Error('Component is missing required fields (source, sourcePath, gitlabInstance, version) for version lookup.');
+                if (!isVersionLookupShape(activeComponent)) {
+                  throw new Error(`Cannot look up versions for ${activeComponent.name}: missing source path or GitLab instance.`);
                 }
-                const versions = await cacheManager.fetchComponentVersions(activeComponent);
+                // Bind the narrowed value: `activeComponent` is reassignable, so TS widens it back across the await.
+                const lookupTarget = activeComponent;
+                const versions = await cacheManager.fetchComponentVersions(lookupTarget);
                 // For a monorepo source, map each full tag to its stripped {version} so the dropdown shows short
                 // labels while keeping the full tag as the option value (the inserted ref).
                 let versionLabels: Record<string, string> | undefined;
-                if (activeComponent.tagPattern) {
+                if (lookupTarget.tagPattern) {
                   versionLabels = {};
                   for (const v of versions) {
-                    versionLabels[v] = stripTagPrefix(v, activeComponent.name, activeComponent.tagPattern);
+                    versionLabels[v] = stripTagPrefix(v, lookupTarget.name, lookupTarget.tagPattern);
                   }
                 }
                 panel.webview.postMessage({
                   command: 'versionsLoaded',
                   versions: versions,
                   versionLabels,
-                  currentVersion: activeComponent.version
+                  currentVersion: lookupTarget.version
                 });
               } catch (error) {
+                const reason = error instanceof Error ? error.message : String(error);
+                logger.error(`[Extension] Error fetching versions for detached details panel: ${reason}`, 'Extension');
                 panel.webview.postMessage({
                   command: 'versionsError',
-                  error: error instanceof Error ? error.message : String(error)
+                  error: reason
                 });
               }
               break;

--- a/src/providers/componentBrowserProvider.ts
+++ b/src/providers/componentBrowserProvider.ts
@@ -3,7 +3,7 @@ import { getComponentService } from '../services/component';
 import { ComponentCacheManager } from '../services/cache/componentCacheManager';
 import { GitLabCatalogComponent, GitLabCatalogVariable } from '../types/gitlab-catalog';
 import type { ComponentParameter, Component } from './componentDetector';
-import type { CachedComponent } from '../types/cache';
+import { isVersionLookupShape } from '../services/component/versionLookupShape';
 import type { SourceGroup, ComponentGroup, ComponentVersion } from './componentBrowserTypes';
 import type { HoverContext } from './hoverContentBuilder';
 import { containsGitLabVariables } from '../utils/gitlabVariables';
@@ -24,19 +24,6 @@ import { compileTagTemplate, stripTagPrefix } from '../services/component/tagSco
  */
 type DetachableComponent = Component & { _hoverContext?: HoverContext };
 
-/**
- * Type-guard narrowing a `Component`-shaped value to one that also satisfies `CachedComponent`.
- * `Component` carries `source`/`sourcePath`/`gitlabInstance`/`version`/`url` as optional; cache
- * methods like `fetchComponentVersions` require them. The guard checks all five before the call so
- * we don't pass a half-populated `Component` into a function expecting the full cache shape.
- */
-function isCachedComponentShape(component: Component): component is Component & CachedComponent {
-  return typeof component.source === 'string'
-    && typeof component.sourcePath === 'string'
-    && typeof component.gitlabInstance === 'string'
-    && typeof component.version === 'string'
-    && typeof component.url === 'string';
-}
 
 /**
  * Pre-existing component shape parsed out of a `.gitlab-ci.yml` include line by
@@ -553,8 +540,8 @@ export class ComponentBrowserProvider {
         } else if (message.command === 'fetchVersions') {
           // Fetch available versions for the component
           try {
-            if (!isCachedComponentShape(component)) {
-              throw new Error('Component is missing required fields (source, sourcePath, gitlabInstance, version) for version lookup.');
+            if (!isVersionLookupShape(component)) {
+              throw new Error(`Cannot look up versions for ${component.name}: missing source path or GitLab instance.`);
             }
             const versions = await this.cacheManager.fetchComponentVersions(component);
             detailsPanel.webview.postMessage({
@@ -563,9 +550,11 @@ export class ComponentBrowserProvider {
               currentVersion: component.version
             });
           } catch (error) {
+            const reason = error instanceof Error ? error.message : String(error);
+            this.logger.error(`[ComponentBrowser] Error fetching versions: ${reason}`, 'ComponentBrowser');
             detailsPanel.webview.postMessage({
               command: 'versionsError',
-              error: error instanceof Error ? error.message : String(error)
+              error: reason
             });
           }
         } else if (message.command === 'versionChanged') {
@@ -1633,6 +1622,9 @@ export class ComponentBrowserProvider {
             font-size: 0.9em;
             color: var(--vscode-disabledForeground);
           }
+          .version-loading.version-error {
+            color: var(--vscode-errorForeground);
+          }
           .parameters {
             border: 1px solid var(--vscode-panel-border);
             border-radius: 5px;
@@ -1927,6 +1919,9 @@ export class ComponentBrowserProvider {
             const loading = document.getElementById('versionLoading');
             const select = document.getElementById('versionSelect');
 
+            // Clear any error left by a previous attempt before starting a new one.
+            loading.textContent = 'Loading version details...';
+            loading.classList.remove('version-error');
             loading.style.display = 'inline';
             select.disabled = true;
 
@@ -2103,11 +2098,16 @@ export class ComponentBrowserProvider {
               case 'versionsLoaded':
                 updateVersionDropdown(message.versions, message.currentVersion, message.versionLabels);
                 break;
-              case 'versionsError':
-                document.getElementById('versionLoading').style.display = 'none';
+              case 'versionsError': {
+                // Reuse the loading slot to report the failure: a refresh that silently does nothing reads as an
+                // inert button, so the user is told rather than left guessing.
+                const versionStatus = document.getElementById('versionLoading');
+                versionStatus.textContent = 'Could not load versions: ' + (message.error || 'unknown error');
+                versionStatus.classList.add('version-error');
+                versionStatus.style.display = 'inline';
                 document.getElementById('versionSelect').disabled = false;
-                // Could show error message here
                 break;
+              }
               case 'componentDetailsUpdated':
                 updateComponentDetails(message.component);
                 break;
@@ -2140,6 +2140,7 @@ export class ComponentBrowserProvider {
             });
 
             loading.style.display = 'none';
+            loading.classList.remove('version-error');
             select.disabled = false;
             currentVersions = versions;
             versionsLoaded = true;

--- a/src/services/cache/componentCacheManager.ts
+++ b/src/services/cache/componentCacheManager.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { getComponentService } from '../component';
 import { Logger } from '../../utils/logger';
 import { getPerformanceMonitor } from '../../utils/performanceMonitor';
-import { CachedComponent, PersistentCacheData } from '../../types/cache';
+import { CachedComponent, PersistentCacheData, VersionLookupComponent } from '../../types/cache';
 import { ComponentSource } from '../../types/api';
 import { reconcileComponentSource } from './sourceReconciliation';
 import { ProjectCache } from './projectCache';
@@ -424,9 +424,12 @@ export class ComponentCacheManager implements vscode.Disposable {
   }
 
   /**
-   * Fetch and cache all available versions for a specific component
+   * Fetch and cache all available versions for a specific component.
+   *
+   * Takes the narrow {@link VersionLookupComponent} rather than a full cache entry: the lookup is driven entirely by
+   * the project coordinates, so callers holding a partial component (the details panel) can use it too.
    */
-  public async fetchComponentVersions(component: CachedComponent): Promise<string[]> {
+  public async fetchComponentVersions(component: VersionLookupComponent): Promise<string[]> {
     try {
       const sortedVersions = await this.versionCache.fetchComponentVersions(component);
 

--- a/src/services/cache/versionCache.ts
+++ b/src/services/cache/versionCache.ts
@@ -1,7 +1,7 @@
 import { getComponentService } from '../component';
 import { compileTagTemplate, scopeTagsToComponent } from '../component/tagScoping';
 import { Logger } from '../../utils/logger';
-import { CachedComponent, VersionCacheSnapshot } from '../../types/cache';
+import { VersionCacheSnapshot, VersionLookupComponent } from '../../types/cache';
 
 /**
  * VersionCache - Handles version fetching and caching for components
@@ -30,7 +30,7 @@ export class VersionCache {
    * @param component Component to fetch versions for
    * @returns Array of sorted version strings (full prefixed tags for monorepo sources, plus `main`/`master`)
    */
-  async fetchComponentVersions(component: CachedComponent): Promise<string[]> {
+  async fetchComponentVersions(component: VersionLookupComponent): Promise<string[]> {
     try {
       const cacheKey = `${component.gitlabInstance}|${component.sourcePath}`;
       let projectTags: string[] | undefined = this.projectTagsCache.get(cacheKey);

--- a/src/services/component/versionLookupShape.ts
+++ b/src/services/component/versionLookupShape.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared type-guard for "can this component be used to look up versions?".
+ *
+ * `vscode`-free and pure so the unit suite can drive it directly. Both details-panel entry points check the same
+ * thing, so they share one definition rather than a copy each.
+ */
+
+import type { Component } from '../../providers/componentDetector';
+import type { VersionLookupComponent } from '../../types/cache';
+
+/**
+ * Narrow a `Component` to the fields a version lookup needs: the project coordinates to query and the ref to fall
+ * back on. `Component` carries all three as optional, so they are checked before calling the cache.
+ *
+ * Deliberately does **not** require `url` or `source`. The details panel's component is rebuilt in the webview from
+ * a `ComponentVersion`, which has no `url`, and nothing in the lookup path reads one — `fetchComponentVersions`
+ * queries by `gitlabInstance` + `sourcePath` and scopes by `tagPattern`. Demanding `url` here only rejects
+ * components the cache could have served.
+ *
+ * @param component The component to check.
+ * @returns         `true` when `sourcePath`, `gitlabInstance` and `version` are all present and string-typed.
+ */
+export function isVersionLookupShape(
+  component: Component
+): component is Component & VersionLookupComponent {
+  return typeof component.sourcePath === 'string'
+    && typeof component.gitlabInstance === 'string'
+    && typeof component.version === 'string';
+}

--- a/src/types/cache.ts
+++ b/src/types/cache.ts
@@ -111,6 +111,17 @@ export interface CachedComponent {
 }
 
 /**
+ * The subset of {@link CachedComponent} a version lookup actually needs: the project coordinates to query, the
+ * current ref to fall back on, and the monorepo template used to scope the returned tags.
+ *
+ * Version fetching is reachable from surfaces that hold less than a full cache entry — the details panel receives a
+ * `ComponentVersion` built in the webview, which carries no `url`. Naming the real requirement lets those callers
+ * through instead of failing a `CachedComponent` check on fields the lookup never reads.
+ */
+export type VersionLookupComponent = Pick<CachedComponent, 'name' | 'sourcePath' | 'gitlabInstance' | 'version'>
+  & Pick<CachedComponent, 'tagPattern'>;
+
+/**
  * Serialized form of the per-project version caches, persisted in global state.
  *
  * Holds both maps so they survive a session restart together: the raw tag list and the resolved default branch.

--- a/tests/unit/versionLookupShape.test.ts
+++ b/tests/unit/versionLookupShape.test.ts
@@ -20,6 +20,13 @@ const detailsPanelComponent: Component = {
   version: 'deploy-1.0.0',
 };
 
+/** The fixture minus one field, for the "what happens when this is missing" cases. */
+function without(field: keyof Component): Component {
+  const component = { ...detailsPanelComponent };
+  delete component[field];
+  return component;
+}
+
 suite('isVersionLookupShape', () => {
   test('accepts the details panel component, which has no url', () => {
     assert.strictEqual('url' in detailsPanelComponent, false, 'fixture should model the missing url');
@@ -27,8 +34,7 @@ suite('isVersionLookupShape', () => {
   });
 
   test('accepts a component with no source, which the lookup never reads', () => {
-    const { source: _source, ...withoutSource } = detailsPanelComponent;
-    assert.strictEqual(isVersionLookupShape(withoutSource), true);
+    assert.strictEqual(isVersionLookupShape(without('source')), true);
   });
 
   test('still accepts a fully populated cache entry', () => {
@@ -37,17 +43,14 @@ suite('isVersionLookupShape', () => {
   });
 
   test('rejects a component with no sourcePath', () => {
-    const { sourcePath: _sourcePath, ...withoutSourcePath } = detailsPanelComponent;
-    assert.strictEqual(isVersionLookupShape(withoutSourcePath), false);
+    assert.strictEqual(isVersionLookupShape(without('sourcePath')), false);
   });
 
   test('rejects a component with no gitlabInstance', () => {
-    const { gitlabInstance: _gitlabInstance, ...withoutInstance } = detailsPanelComponent;
-    assert.strictEqual(isVersionLookupShape(withoutInstance), false);
+    assert.strictEqual(isVersionLookupShape(without('gitlabInstance')), false);
   });
 
   test('rejects a component with no version', () => {
-    const { version: _version, ...withoutVersion } = detailsPanelComponent;
-    assert.strictEqual(isVersionLookupShape(withoutVersion), false);
+    assert.strictEqual(isVersionLookupShape(without('version')), false);
   });
 });

--- a/tests/unit/versionLookupShape.test.ts
+++ b/tests/unit/versionLookupShape.test.ts
@@ -1,0 +1,53 @@
+// @mocha
+/**
+ * Tests src/services/component/versionLookupShape.ts — the guard deciding whether a component can be used for a
+ * version lookup. It previously required `url`, which the details panel's webview-rebuilt component never carries,
+ * so Refresh Versions failed there for every component.
+ */
+
+import * as assert from 'node:assert/strict';
+import { isVersionLookupShape } from '../../src/services/component/versionLookupShape';
+import type { Component } from '../../src/providers/componentDetector';
+
+/** The shape the details panel receives: a `ComponentVersion` plus name/version, with no `url`. */
+const detailsPanelComponent: Component = {
+  name: 'deploy',
+  description: 'Deploy the thing',
+  parameters: [],
+  source: 'Test Source',
+  sourcePath: 'group/monorepo',
+  gitlabInstance: 'gitlab.com',
+  version: 'deploy-1.0.0',
+};
+
+suite('isVersionLookupShape', () => {
+  test('accepts the details panel component, which has no url', () => {
+    assert.strictEqual('url' in detailsPanelComponent, false, 'fixture should model the missing url');
+    assert.strictEqual(isVersionLookupShape(detailsPanelComponent), true);
+  });
+
+  test('accepts a component with no source, which the lookup never reads', () => {
+    const { source: _source, ...withoutSource } = detailsPanelComponent;
+    assert.strictEqual(isVersionLookupShape(withoutSource), true);
+  });
+
+  test('still accepts a fully populated cache entry', () => {
+    const cached = { ...detailsPanelComponent, url: 'https://gitlab.com/group/monorepo/deploy@deploy-1.0.0' };
+    assert.strictEqual(isVersionLookupShape(cached), true);
+  });
+
+  test('rejects a component with no sourcePath', () => {
+    const { sourcePath: _sourcePath, ...withoutSourcePath } = detailsPanelComponent;
+    assert.strictEqual(isVersionLookupShape(withoutSourcePath), false);
+  });
+
+  test('rejects a component with no gitlabInstance', () => {
+    const { gitlabInstance: _gitlabInstance, ...withoutInstance } = detailsPanelComponent;
+    assert.strictEqual(isVersionLookupShape(withoutInstance), false);
+  });
+
+  test('rejects a component with no version', () => {
+    const { version: _version, ...withoutVersion } = detailsPanelComponent;
+    assert.strictEqual(isVersionLookupShape(withoutVersion), false);
+  });
+});


### PR DESCRIPTION
## Summary
- **Refresh Versions** in the component details panel opened from the Component Browser did nothing at all — no dropdown change, no error in the UI, and no entry in the output channel. It failed on a type-guard that required a field the lookup never reads.
- The guard demanded `url`. The details panel's component is rebuilt in the webview from a `ComponentVersion`, which has no `url` field, so the guard rejected every component on that path before any network call.
- Replaces it with a guard describing what a version lookup actually needs, and makes the failure visible: the panel now reports the error, and the handler logs it.
- Link related issue(s): Fixes #279

## Change Type
- [ ] feat
- [x] fix
- [ ] refactor
- [ ] docs
- [ ] test
- [ ] chore

## Context
### User-facing impact
- **Refresh Versions works** in the details panel opened from the Component Browser. Previously it was inert for every component on that path.
- **A failed version refresh is now visible.** The panel shows `Could not load versions: …` next to the dropdown in the theme's error colour, and the reason is written to the output channel. Previously both were silent.
- The detached (hover) panel was already working, since a hover-detected component carries the full cache shape including `url`. Its error reporting improves the same way.

### Why the guard was wrong, not just strict
Nothing in the version-fetch path reads `url` or `source`:

- `ComponentCacheManager.fetchComponentVersions` matches the cache on `name` + `sourcePath` + `gitlabInstance`.
- `VersionCache.fetchComponentVersions` calls `fetchProjectTags(gitlabInstance, sourcePath)` and `fetchProjectDefaultBranch(gitlabInstance, sourcePath)`, then scopes the result with `tagPattern`.

So the guard described a shape the callee does not need, which is what made it reject components the cache could have served. The fix narrows the requirement to the fields actually used rather than loosening a check that was doing real work.

### GitLab scope
- [ ] gitlab.com
- [ ] self-managed GitLab
- [x] both (no change to what is requested from GitLab; only which components are allowed to request it)

### Affected areas
- [x] Component Browser (details panel)
- [x] Hover provider (detached details panel — error reporting only)
- [ ] Completion provider
- [ ] Validation provider
- [x] Cache and refresh behavior (version lookup entry conditions)
- [ ] GitLab API calls/auth/token storage
- [ ] Docs only

## What changed by bucket

| Bucket | Files | Approach |
|---|---|---|
| The requirement, named | `src/types/cache.ts` | New `VersionLookupComponent` — `Pick<CachedComponent, 'name' \| 'sourcePath' \| 'gitlabInstance' \| 'version' \| 'tagPattern'>`. Names the subset a lookup needs instead of leaving callers to infer it from a full cache entry. |
| Signatures | `src/services/cache/componentCacheManager.ts`, `src/services/cache/versionCache.ts` | Both `fetchComponentVersions` take `VersionLookupComponent` rather than `CachedComponent`. No body changes — they already only read those fields. |
| The guard | `src/services/component/versionLookupShape.ts` | New `isVersionLookupShape`, checking `sourcePath` + `gitlabInstance` + `version`. Replaces `isCachedComponentShape`, which was **duplicated** in `src/providers/componentBrowserProvider.ts` and `src/extension.ts` and required `url` + `source` on top. Extracted to one `vscode`-free module so both callers share it and it is unit-testable. |
| Call sites | `src/providers/componentBrowserProvider.ts`, `src/extension.ts` | Both use the shared guard. The thrown message changes from a list of the four fields that *were* present to one naming what is actually missing. |
| Visible failure | `src/providers/componentBrowserProvider.ts` | The webview's `versionsError` branch — previously three lines ending in `// Could show error message here` — now shows the reason in the existing status slot, in `--vscode-errorForeground`. Cleared when a refresh starts and when one succeeds, so a stale error cannot persist. |
| Logged failure | `src/providers/componentBrowserProvider.ts`, `src/extension.ts` | Both `fetchVersions` catch blocks now log before posting `versionsError`. Neither logged anything before, so the failure left no trace at any log level. |
| Unit coverage | `tests/unit/versionLookupShape.test.ts` | Six cases. The load-bearing one asserts a component with **no `url`** is accepted — that is the exact shape the details panel receives, and the assertion fails against the old guard. |

## Validation
### Local checks
- [x] `npm run compile`
- [x] `npm test` — 402 passing (+6 new); `npm run lint` clean
- [x] Extension-host suite — 25 passing locally
- [x] Manual verification in VS Code Extension Host

### Manual test notes
- To verify the fix:
  - **GitLab CI: Browse Components** → **Details** on any component → **Refresh Versions** → the dropdown repopulates. *(Does nothing on `beta`.)*
  - Best seen on a tag-per-component monorepo source (one with a `tagPattern`), where the dropdown is the main way to move between versions.
- To verify the error path, point a source at an unreachable instance or revoke its token, then click **Refresh Versions**: the panel should show `Could not load versions: …` and the output channel should carry a matching `[ComponentBrowser] Error fetching versions:` line. *(Both silent on `beta`.)*
- Confirm the error clears: trigger a failure, then fix the cause and refresh again — the message should be replaced by the loading text, not left behind.

## Breaking Changes
- [x] No breaking changes
- [ ] Breaking changes (describe below)

## Risk and Rollback
- Main risks: **low**. The change widens what is accepted into an existing read-only lookup; it adds no new call, request or write. A component that passed the old guard still passes the new one — `isCachedComponentShape` required a strict superset of these fields — so no path that worked before can start failing.
- The one behavioural consequence is intended: components that were previously rejected now reach `fetchComponentVersions`. That call already handles its own failure, returning `[component.version]` as a fallback and logging on error.
- Rollback strategy: revert the commit. No persisted state, settings, cache shape or webview protocol changes; `versionsLoaded`/`versionsError` keep their existing field names.

## Release Notes Draft
- Fix: **Refresh Versions** now works in the component details panel opened from the Component Browser; it previously did nothing.
- Fix: a failed version refresh now reports the reason in the panel and the output channel instead of failing silently.

## Checklist
- [ ] Branch is up to date with target branch
- [ ] Commit messages follow conventional commits
- [x] Added/updated docs for behavior or settings changes (this PR description; no user-facing settings changed)
- [x] Added/updated tests for new behavior
- [x] No secrets or tokens in code, logs, screenshots, or test fixtures
